### PR TITLE
Add global styles + base for form page

### DIFF
--- a/src/entry-point/App.tsx
+++ b/src/entry-point/App.tsx
@@ -1,15 +1,21 @@
 import { hot } from "react-hot-loader";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 
+import FormPage from "../page-form/FormPage";
 import HomePage from "../page-home/HomePage";
 import TestPage from "../page-test/TestPage";
+import { GlobalStyles } from "../styles";
 
 const App: React.FC<{}> = () => {
   return (
     <BrowserRouter>
+      <GlobalStyles />
       <Switch>
         <Route path="/test">
           <TestPage />
+        </Route>
+        <Route path="/contribute">
+          <FormPage />
         </Route>
         <Route path="/">
           <HomePage />

--- a/src/page-form/FormPage.tsx
+++ b/src/page-form/FormPage.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const FormContainer = styled.div`
+  padding: 24px;
+`;
+
+const Form: React.FC<{}> = () => {
+  return (
+    <div>
+      Hello
+      <h1>Title</h1>
+    </div>
+  );
+};
+
+export default Form;

--- a/src/page-test/TestPage.tsx
+++ b/src/page-test/TestPage.tsx
@@ -46,6 +46,17 @@ const TestPage: React.FC<{}> = () => {
       <p>
         Go to <Link to="/">Home Page</Link>.
       </p>
+      <div>
+        <h1> h1 </h1>
+        <p> paragraph </p>
+        <body> body </body>
+        <div className="description"> description </div>
+        <div className="nav-link">nav-link</div>
+        <div className="metric">metric</div>
+        <div className="tooltip">tooltip</div>
+        <div className="ic-facts">ic-facts</div>
+        <div className="ic-share">ic-share</div>
+      </div>
     </div>
   );
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -89,7 +89,7 @@ export const GlobalStyles = createGlobalStyle`
     height: 24px;
   }
 
-  .ic_share {
+  .ic-share {
     width: 14px;
     height: 14x;
   }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,0 +1,101 @@
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalStyles = createGlobalStyle`
+  @import url('https://fonts.googleapis.com/css?family=Poppins&display=swap');
+  @import url('https://fonts.googleapis.com/css?family=Libre+Baskerville&display=swap');
+  @import url('https://fonts.googleapis.com/css?family=Rubik&display=swap');
+
+  body {
+    font-family: 'Poppins', sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 16px;
+    letter-spacing: -0.05em;
+    color: #00413E;
+  }
+
+  h1 {
+    font-family: 'Libre Baskerville', serif;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 64px;
+    line-height: 64px;
+    text-align: center;
+    letter-spacing: -0.03em;
+    color: #006C67;
+  }
+
+  p {
+    font-family: 'Poppins', sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 16px;
+    letter-spacing: -0.05em;
+    color: #00413E;
+  }
+
+  .nav-link {
+    font-family: 'Poppins', sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 16px;
+    text-align: right;
+    letter-spacing: -0.05em;
+    color: #006C67;
+  }
+
+  .tooltip {
+    font-family: 'Rubik', sans-serif;
+    font-family: Rubik;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 12px;
+    line-height: 16px;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    color: #FFFFFF;
+    opacity: 0.8;
+    background: #005450;
+    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    padding: 8px;
+  }
+
+  .metric {
+    font-family: 'Poppins', sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 24px;
+    color: #DE5558;
+  }
+
+  .description {
+    font-family: 'Rubik', sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 12px;
+    line-height: 16px;
+    color: #00413E;
+    opacity: 0.8;
+  }
+
+  .ic-facts {
+    width: 24px;
+    height: 24px;
+  }
+
+  .ic_share {
+    width: 14px;
+    height: 14x;
+  }
+
+  .logo {
+    width: 137px;
+    height: 10px;
+  }
+`

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -98,4 +98,4 @@ export const GlobalStyles = createGlobalStyle`
     width: 137px;
     height: 10px;
   }
-`
+`;


### PR DESCRIPTION
# Add Global Styles & Form
This PR:
- adds global styles based on [Juan's css file ](https://recidiviz.slack.com/archives/G010VACT8F2/p1585333687046500) 
- adds a base for the [form page 
](https://www.figma.com/proto/v43UQeEd1Xkb3w2NgxcWql/%F0%9F%9A%80-Recidiviz?node-id=288%3A4&viewport=183%2C343%2C0.09931680560112&scaling=scale-down-width)
- adds style examples to the `/test` page for each css style

## Styles
The styles are the following:
<img width="1438" alt="Screen Shot 2020-03-27 at 9 48 22 PM" src="https://user-images.githubusercontent.com/31225471/77815111-bdbcb680-7074-11ea-9751-365146a8bada.png">

We can update them as we build out the real pages! 😄 