### PR TITLE
More housekeeping

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,10 @@
   "scripts": {
     "build": "parcel build index.html && echo && parcel build --target node src/entry-point-static/build.tsx && echo && node dist/build.js && rm -f dist/build.js dist/build.js.map",
     "clean": "rm -rf dist && rm -rf .cache",
-    "dev": "bin/parcel serve index.html",
-    "build": "parcel build index.html && echo && parcel build --target node src/entry-point-static/build.tsx && echo && node dist/build.js && rm -f dist/build.js dist/build.js.map"
+    "dev": "parcel serve index.html",
+    "postinstall": "touch node_modules/.bin/.keep"
   },
   "dependencies": {
-    "us-zcta-counties": "^0.0.2"
-  },
-  "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/d3": "5.7.2",
     "@types/node": "12.12.31",
@@ -43,7 +40,8 @@
     "resize-observer-polyfill": "^1.5.1",
     "semiotic": "1.20.5",
     "styled-components": "5.0.1",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "us-zcta-counties": "0.0.2"
   },
   "alias": {
     "react-dom": "@hot-loader/react-dom"

--- a/package.json
+++ b/package.json
@@ -54,13 +54,16 @@
     }
   },
   "lint-staged": {
-    "!(*.d.)ts": [
+    "!(*.d).ts": [
       "false -- Please use .tsx instead of .ts!"
+    ],
+    "*.js": [
+      "false -- Please use .tsx with `// @ts-nocheck` instead of .js!"
     ],
     "*.{html,json,md}": [
       "prettier --write"
     ],
-    "*.{d.ts,js,tsx}": [
+    "*.{d.ts,tsx}": [
       "bash -c tsc",
       "eslint --cache --fix",
       "prettier --write"

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { curveCatmullRom, format } from "d3";
 import ResponsiveXYFrame from "semiotic/lib/ResponsiveXYFrame";
 import styled from "styled-components";

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 // this function comes from Justine, adapted from python model
 function simulateOneDay({
   x,

--- a/src/page-overview/assets/data-forms.tsx
+++ b/src/page-overview/assets/data-forms.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { estimatePeakHospitalUse } from "../../infection-model";
 import { populationAndHospitalData } from "./dataSource";
 

--- a/src/page-overview/assets/dataSource.tsx
+++ b/src/page-overview/assets/dataSource.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 // these values were updated from the Recidiviz COVID model spreadsheet March 30, 2020
 export const populationAndHospitalData = {
   AK: {

--- a/src/page-overview/assets/init.tsx
+++ b/src/page-overview/assets/init.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import ResizeObserver from "resize-observer-polyfill";
 
 import {

--- a/src/page-overview/assets/sliders.tsx
+++ b/src/page-overview/assets/sliders.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { appState, updateAppState } from "./data-forms";
 
 function degreesToRadians(degrees) {

--- a/src/page-overview/assets/tooltip.tsx
+++ b/src/page-overview/assets/tooltip.tsx
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import { getStateName } from "./data-forms";
 
 export function initTooltips() {


### PR DESCRIPTION
## Description of the change

- I looked for the best way for us to start moving to TypeScript when possible. I found that using `.tsx` files with `// ts-nocheck` is just as good as using `.js` (`tsc` skips checks for both), but with the added benefit of being able to use TypeScript features (like `interface`) in the file if we want to.
- Based on this, I'm moving our existing `.js` files to `tsx` and preventing new .js` files from being commited -- there will be an error message `Please use .tsx with `// @ts-nocheck` instead of .js!`
- We don't have a production server. So to keep things simple, we can move all Node dependencies from `dev Dependencies` into `dependencies` since that's where everyone's been adding new things anyway.
- **#19 Fix Now preview deployments** came with a small issue: The `node_modules/.bin/.keep` file was deleted after each `yarn add`. This PR adds a postinstall script to add it back each time.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant

