### PR TITLE
Move shared form components into src/design-system

### DIFF
--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -17,8 +17,8 @@ interface Props {
   onChange?: (e: React.ChangeEvent) => void;
 }
 
-const Button: React.FC<Props> = (props) => {
+const InputButton: React.FC<Props> = (props) => {
   return <StyledButton>{props.label}</StyledButton>;
 };
 
-export default Button;
+export default InputButton;

--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { Label } from "./form-styles";
+import TextLabel from "./TextLabel";
 
 interface Props {
   value?: string;
@@ -35,10 +35,10 @@ const SelectInput = styled.select`
   color: #00413e;
 `;
 
-const Select: React.FC<Props> = (props) => {
+const InputSelect: React.FC<Props> = (props) => {
   return (
     <SelectContainer>
-      <Label>{props.label}</Label>
+      <TextLabel>{props.label}</TextLabel>
       <SelectInput
         disabled={props.disabled}
         onChange={props.onChange}
@@ -51,4 +51,4 @@ const Select: React.FC<Props> = (props) => {
   );
 };
 
-export default Select;
+export default InputSelect;

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { Label } from "./form-styles";
+import TextLabel from "./TextLabel";
 
 const Input = styled.input`
   padding: 16px;
@@ -31,10 +31,10 @@ interface Props {
   type?: string;
 }
 
-const TextInput: React.FC<Props> = (props) => {
+const InputText: React.FC<Props> = (props) => {
   return (
     <TextInputContainer>
-      <Label>{props.label}</Label>
+      <TextLabel>{props.label}</TextLabel>
       <Input
         type={props.type || "text"}
         defaultValue={props.defaultValue}
@@ -47,4 +47,4 @@ const TextInput: React.FC<Props> = (props) => {
   );
 };
 
-export default TextInput;
+export default InputText;

--- a/src/design-system/InputTextArea.tsx
+++ b/src/design-system/InputTextArea.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { Label } from "./form-styles";
+import TextLabel from "./TextLabel";
 
 interface Props {
   label?: string;
@@ -28,10 +28,10 @@ const TextAreaContainer = styled.div`
   flex-direction: column;
 `;
 
-const TextArea: React.FC<Props> = (props) => {
+const InputTextArea: React.FC<Props> = (props) => {
   return (
     <TextAreaContainer>
-      <Label>{props.label}</Label>
+      <TextLabel>{props.label}</TextLabel>
       <TextAreaInput
         onChange={props.onChange}
         value={props.value}
@@ -42,4 +42,4 @@ const TextArea: React.FC<Props> = (props) => {
   );
 };
 
-export default TextArea;
+export default InputTextArea;

--- a/src/design-system/TextLabel.tsx
+++ b/src/design-system/TextLabel.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const Label = styled.span`
+const TextLabel = styled.span`
   text-transform: uppercase;
   font-size: 12px;
   font-weight: 100;
@@ -8,3 +8,5 @@ export const Label = styled.span`
   letter-spacing: 2px;
   color: #00413e;
 `;
+
+export default TextLabel;

--- a/src/page-form/components/Form.tsx
+++ b/src/page-form/components/Form.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import zcta from "us-zcta-counties";
 
-import Button from "./Button";
-import Select from "./Select";
-import TextArea from "./TextArea";
-import TextInput from "./TextInput";
+import InputButton from "../../design-system/InputButton";
+import InputSelect from "../../design-system/InputSelect";
+import InputText from "../../design-system/InputText";
+import InputTextArea from "../../design-system/InputTextArea";
 
 interface FormValues {
   email?: string;
@@ -30,32 +30,32 @@ const Form: React.FC = () => {
 
   return (
     <div>
-      <TextInput
+      <InputText
         label="email"
         placeholder="Your email here..."
         onChange={(e) => handleFormChange("email", e.target.value)}
         value={formValues.email}
       />
-      <TextInput
+      <InputText
         label="feedback"
         placeholder="Your feedback here..."
         onChange={(e) => handleFormChange("feedback", e.target.value)}
         value={formValues.feedback}
       />
-      <TextInput
+      <InputText
         label="when did this occur"
         placeholder="Date..."
         onChange={(e) => handleFormChange("date", e.target.value)}
         value={formValues.date}
       />
-      <TextInput
+      <InputText
         label="action taken"
         placeholder="What was done?"
         onChange={(e) => handleFormChange("action", e.target.value)}
         value={formValues.action}
       />
       <div style={{ display: "flex", width: "100%" }}>
-        <Select
+        <InputSelect
           label="state"
           value={formValues.state}
           onChange={(e) => handleFormChange("state", e.target.value)}
@@ -65,8 +65,8 @@ const Form: React.FC = () => {
               {state}
             </option>
           ))}
-        </Select>
-        <Select
+        </InputSelect>
+        <InputSelect
           label="county"
           value={formValues.county}
           onChange={(e) => handleFormChange("county", e.target.value)}
@@ -81,22 +81,22 @@ const Form: React.FC = () => {
           ) : (
             <option>Please select a state first.</option>
           )}
-        </Select>
+        </InputSelect>
       </div>
-      <TextInput
+      <InputText
         value={formValues.source}
         label="source"
         defaultValue="https://"
         placeholder="What was done?"
         onChange={(e) => handleFormChange("source", e.target.value)}
       />
-      <TextArea
+      <InputTextArea
         label="additional information"
         value={formValues.additionalInfo}
         placeholder=""
         onChange={(e) => handleFormChange("additionalInfo", e.target.value)}
       />
-      <Button label="Send" />
+      <InputButton label="Send" />
     </div>
   );
 };


### PR DESCRIPTION
## Description of the change

Mostly doing this to mark the components that I think will be shared between the two forms. Named the components starting with `Input` so that when `src/design-system` is sorted alphabetically, similar components appear next to each other!

File moves and import changes were done automatically by VSCode, so there shouldn't be any typos.

I understand that this could conflict with #24. Let me know if you want me to wait until #24 merges before merging this.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant

