### PR TITLE
Add fatalities curve and output table

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-styled-components": "1.10.7",
     "camelcase-keys": "6.2.2",
     "chalk": "3.0.0",
+    "core-js": "3.6.4",
     "d3": "5.15.0",
     "d3-array": "2.4.0",
     "date-fns": "2.11.1",

--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -1,4 +1,5 @@
 const Colors = {
+  black: "#000",
   green: "#006C67",
   forest: "#005450",
   lightBlue: "#33B6FF",

--- a/src/entry-point-client/index.tsx
+++ b/src/entry-point-client/index.tsx
@@ -1,3 +1,4 @@
+import "core-js/stable";
 import "regenerator-runtime/runtime";
 
 import React from "react";

--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -7,6 +7,7 @@ import CurveChartLegend from "./CurveChartLegend";
 export type MarkColors = {
   exposed: string;
   infectious: string;
+  fatalities: string;
   hospitalized: string;
   hospitalBeds: string;
 };
@@ -27,9 +28,10 @@ const LegendContainer = styled.div`
 const ChartArea: React.FC = () => {
   const markColors = {
     exposed: Colors.green,
-    infectious: Colors.red,
+    fatalities: Colors.black,
     hospitalized: Colors.lightBlue,
     hospitalBeds: Colors.red,
+    infectious: Colors.red,
   };
   return (
     <Container>

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -7,6 +7,8 @@ import Colors from "../design-system/Colors";
 import { MarkColors } from "./ChartArea";
 
 const ChartContainer = styled.div`
+  height: 380px;
+
   .frame {
     font-family: "Poppins", sans-serif;
     font-size: 11px;
@@ -142,6 +144,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     lineType: { type: "area", interpolator: curveCatmullRom },
     xAccessor: "days",
     yAccessor: "count",
+    responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
     yExtent: { extent: [0], includeAnnotations: true },

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -1,4 +1,8 @@
-import { calculateCurves } from "../infection-model";
+import { zip } from "d3-array";
+
+import { calculateCurves, CurveData } from "../infection-model";
+import { getAllValues, getColView } from "../infection-model/matrixUtils";
+import { seirIndex } from "../infection-model/seir";
 import { MarkColors } from "./ChartArea";
 import CurveChart from "./CurveChart";
 import { useEpidemicModelState } from "./EpidemicModelContext";
@@ -7,20 +11,37 @@ interface Props {
   markColors: MarkColors;
 }
 
+// for these curves we combine incarcerated and staff
+function combinePopulations(data: CurveData, columnIndex: number) {
+  return zip(
+    getAllValues(getColView(data.incarcerated, columnIndex)),
+    getAllValues(getColView(data.staff, columnIndex)),
+  ).map(([incarcerated, staff]) => incarcerated + staff);
+}
+
 const CurveChartContainer: React.FC<Props> = ({ markColors }) => {
   const modelData = useEpidemicModelState();
+  // TODO: could this be stored on the context instead for reuse?
+  const projectionData = calculateCurves(modelData);
+  // merge and filter the curve data to only what we need for the chart
+  const curveData = {
+    exposed: combinePopulations(projectionData, seirIndex.exposed),
+    fatalities: combinePopulations(projectionData, seirIndex.fatalities),
+    hospitalized: combinePopulations(projectionData, seirIndex.hospitalized),
+    infectious: combinePopulations(projectionData, seirIndex.infectious),
+  };
 
   return modelData.countyLevelDataLoading ? (
     <div>Loading...</div>
   ) : (
     <CurveChart
-      curveData={calculateCurves(modelData)}
       hospitalBeds={
         modelData.countyLevelData
           ?.get(modelData.stateCode)
           // we don't show this until data is loaded so nothing should be undefined
           ?.get(modelData.countyName as string)?.hospitalBeds as number
       }
+      curveData={curveData}
       markColors={markColors}
     />
   );

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -35,13 +35,8 @@ const CurveChartContainer: React.FC<Props> = ({ markColors }) => {
     <div>Loading...</div>
   ) : (
     <CurveChart
-      hospitalBeds={
-        modelData.countyLevelData
-          ?.get(modelData.stateCode)
-          // we don't show this until data is loaded so nothing should be undefined
-          ?.get(modelData.countyName as string)?.hospitalBeds as number
-      }
       curveData={curveData}
+      hospitalBeds={modelData.hospitalBeds}
       markColors={markColors}
     />
   );

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -1,5 +1,6 @@
 import { zip } from "d3-array";
 
+import Loading from "../design-system/Loading";
 import { calculateCurves, CurveData } from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
 import { seirIndex } from "../infection-model/seir";
@@ -32,7 +33,7 @@ const CurveChartContainer: React.FC<Props> = ({ markColors }) => {
   };
 
   return modelData.countyLevelDataLoading ? (
-    <div>Loading...</div>
+    <Loading />
   ) : (
     <CurveChart
       curveData={curveData}

--- a/src/impact-dashboard/CurveChartLegend.tsx
+++ b/src/impact-dashboard/CurveChartLegend.tsx
@@ -27,6 +27,7 @@ const CurveChartLegend: React.FC<Props> = ({ markColors }) => {
       <LegendItem color={markColors.exposed}>exposed</LegendItem>
       <LegendItem color={markColors.infectious}>infectious</LegendItem>
       <LegendItem color={markColors.hospitalized}>hospitalized</LegendItem>
+      <LegendItem color={markColors.fatalities}>fatalities</LegendItem>
     </LegendWrapper>
   );
 };

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -59,10 +59,12 @@ interface MetadataUpdate {
   countyName?: string;
   facilityName?: string;
   stateCode?: string;
+  hospitalBeds?: number;
 }
 // some fields are required to display a sensible UI, define them here
 interface Metadata extends MetadataUpdate {
   stateCode: string;
+  hospitalBeds: number;
 }
 
 type EpidemicModelUpdate = ModelInputsUpdate & MetadataUpdate;
@@ -102,6 +104,7 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
     usePopulationSubsets: false,
     facilityOccupancyPct: 1,
     facilityDormitoryPct: 0.15,
+    hospitalBeds: 0,
   });
 
   // fetch from external datasource
@@ -152,6 +155,8 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
             countyName: "Total",
             totalIncarcerated: nestedStateCounty.get("US Total")?.get("Total")
               ?.totalIncarceratedPopulation,
+            hospitalBeds: nestedStateCounty.get("US Total")?.get("Total")
+              ?.hospitalBeds,
             countyLevelDataLoading: false,
           },
         });

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 import ChartArea from "./ChartArea";
 import { useEpidemicModelState } from "./EpidemicModelContext";
+import ImpactProjectionTable from "./ImpactProjectionTableContainer";
 
 const Container = styled.div`
   display: flex;
@@ -35,6 +36,7 @@ const ImpactDashboard: React.FC = () => {
           <FormContainer>forms</FormContainer>
           <ChartsContainer>
             <ChartArea />
+            <ImpactProjectionTable />
           </ChartsContainer>
         </>
       )}

--- a/src/impact-dashboard/ImpactProjectionTable.tsx
+++ b/src/impact-dashboard/ImpactProjectionTable.tsx
@@ -77,13 +77,13 @@ const LabelCell = styled.td<{ italic?: boolean }>`
   font-style: ${(props) => (props.italic ? "italic" : "inherit")};
 `;
 
-numeral.nullFormat("N/A");
+const naString = "N/A";
 function formatThousands(value: number | null): string {
-  return numeral(value).format("0,0");
+  return value === null ? naString : numeral(value).format("0,0");
 }
 
 function formatPct(value: number | null): string {
-  return numeral(value).format("0.0%");
+  return value === null ? naString : numeral(value).format("0,0.0%");
 }
 
 function makeTableRow(row: TableRow, formatter = formatThousands) {

--- a/src/impact-dashboard/ImpactProjectionTable.tsx
+++ b/src/impact-dashboard/ImpactProjectionTable.tsx
@@ -1,0 +1,162 @@
+import numeral from "numeral";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+
+export interface TableRow {
+  label: string;
+  week1: number | null;
+  week2: number | null;
+  week3: number | null;
+  overall: number | null; // n/a for some rows
+}
+
+interface Props {
+  incarceratedData: TableRow[];
+  peakData: TableRow[];
+  staffData: TableRow[];
+}
+
+const Table = styled.table`
+  color: ${Colors.black};
+  font-family: "Rubik", sans-serif;
+  font-size: 12px;
+  font-weight: normal;
+  letter-spacing: 0;
+  text-align: center;
+  width: 100%;
+  max-width: 600px;
+
+  th,
+  td {
+    padding-bottom: 5px;
+  }
+`;
+
+const TableHeading = styled.thead`
+  border-bottom: 1px solid ${Colors.forest};
+`;
+
+const HeadingCell = styled.th<{ left?: boolean }>`
+  color: ${Colors.forest};
+  font-family: "Poppins", sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.05em;
+  text-align: ${(props) => (props.left ? "left" : "center")};
+
+  &.marked {
+    position: relative;
+    &::after {
+      content: "";
+      position: absolute;
+      left: calc(50% - 0.5px);
+      bottom: -4px;
+      width: 0;
+      height: 9px;
+      border-color: ${Colors.forest};
+      border-left: 1px solid;
+      overflow: visible;
+    }
+  }
+`;
+
+const TableSection = styled.tbody`
+  &::before {
+    content: "";
+    display: table-row;
+    height: 16px;
+  }
+`;
+
+const LabelCell = styled.td<{ italic?: boolean }>`
+  color: ${Colors.forest};
+  font-weight: normal;
+  text-align: left;
+  opacity: 0.8;
+  font-style: ${(props) => (props.italic ? "italic" : "inherit")};
+`;
+
+numeral.nullFormat("N/A");
+function formatThousands(value: number | null): string {
+  return numeral(value).format("0,0");
+}
+
+function formatPct(value: number | null): string {
+  return numeral(value).format("0.0%");
+}
+
+function makeTableRow(row: TableRow, formatter = formatThousands) {
+  const { label, week1, week2, week3, overall } = row;
+  return (
+    <tr key={label}>
+      <LabelCell>{label}</LabelCell>
+      <td>{formatter(week1)}</td>
+      <td>{formatter(week2)}</td>
+      <td>{formatter(week3)}</td>
+      <td>{formatter(overall)}</td>
+    </tr>
+  );
+}
+
+function makeOverallOnlyRow(row: TableRow, formatter = formatThousands) {
+  const { label, overall } = row;
+  return (
+    <tr key={label}>
+      <LabelCell colSpan={4}>{label}</LabelCell>
+      <td>{formatter(overall)}</td>
+    </tr>
+  );
+}
+
+const ImpactProjectionTable: React.FC<Props> = ({
+  incarceratedData,
+  peakData,
+  staffData,
+}) => {
+  return (
+    <Table>
+      <TableHeading>
+        <tr>
+          <LabelCell italic>Impact projections</LabelCell>
+          <HeadingCell className="marked">in 1 wk</HeadingCell>
+          <HeadingCell className="marked">in 2 wk</HeadingCell>
+          <HeadingCell className="marked">in 3 wk</HeadingCell>
+          <HeadingCell>Overall</HeadingCell>
+        </tr>
+      </TableHeading>
+      <TableSection>
+        <tr>
+          <HeadingCell left scope="rowgroup">
+            Incarcerated population (totals)
+          </HeadingCell>
+        </tr>
+        {incarceratedData.map((row, i) => {
+          const formatter = i === 2 ? formatPct : undefined;
+          return makeTableRow(row, formatter);
+        })}
+      </TableSection>
+      <TableSection>
+        <tr>
+          <HeadingCell left scope="rowgroup">
+            In-facility staff (totals)
+          </HeadingCell>
+        </tr>
+        {staffData.map((row) => makeTableRow(row))}
+      </TableSection>
+      <TableSection>
+        <tr>
+          <HeadingCell left scope="rowgroup">
+            Maximum utilization
+          </HeadingCell>
+        </tr>
+        {peakData.map((row, i) => {
+          const formatter = i === 0 ? formatPct : undefined;
+          return makeOverallOnlyRow(row, formatter);
+        })}
+      </TableSection>
+    </Table>
+  );
+};
+
+export default ImpactProjectionTable;

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -1,0 +1,144 @@
+import { sum } from "d3-array";
+import ndarray from "ndarray";
+
+import Loading from "../design-system/Loading";
+import { calculateCurves } from "../infection-model";
+import {
+  getAllValues,
+  getColView,
+  getRowView,
+} from "../infection-model/matrixUtils";
+import { seirIndex } from "../infection-model/seir";
+import { useEpidemicModelState } from "./EpidemicModelContext";
+import ImpactProjectionTable, { TableRow } from "./ImpactProjectionTable";
+
+function buildTableRowFromCurves(
+  data: ndarray,
+  label: string,
+  calculator: Function,
+): TableRow {
+  const [week1, week2, week3, overall] = [
+    6,
+    13,
+    20,
+    data.shape[0] - 1,
+  ].map((day) => calculator(data, day));
+
+  return {
+    label,
+    week1,
+    week2,
+    week3,
+    overall,
+  };
+}
+
+// row = day and col = SEIR bucket
+function countCasesForDay(data: ndarray, day: number): number {
+  const row = getAllValues(getRowView(data, day));
+  const notCases = [seirIndex.susceptible, seirIndex.exposed];
+  return Math.round(sum(row.filter((d, i) => !notCases.includes(i))));
+}
+
+function getHospitalizedForDay(data: ndarray, day: number): number {
+  return Math.round(data.get(day, seirIndex.hospitalized));
+}
+
+function getFatalitiesForDay(data: ndarray, day: number): number {
+  return Math.round(data.get(day, seirIndex.fatalities));
+}
+
+function countUnableToWorkForDay(data: ndarray, day: number): number {
+  const unableToWork = [
+    seirIndex.mild,
+    seirIndex.severe,
+    seirIndex.hospitalized,
+    seirIndex.fatalities,
+  ];
+  const row = getAllValues(getRowView(data, day));
+  return Math.round(sum(row.filter((d, i) => unableToWork.includes(i))));
+}
+
+type PeakData = {
+  peakPct: number;
+  peakDay: number;
+  daysUntil50Pct: number | null;
+};
+
+function getPeakHospitalized(data: ndarray, hospitalBeds: number): PeakData {
+  const hospitalized = getAllValues(getColView(data, seirIndex.hospitalized));
+  const peakHospitalized = Math.max(...hospitalized);
+  return {
+    peakDay: hospitalized.indexOf(peakHospitalized) + 1,
+    peakPct: peakHospitalized / hospitalBeds,
+    daysUntil50Pct:
+      hospitalized.find((val) => val / hospitalBeds > 0.5) || null,
+  };
+}
+
+const ImpactProjectionTableContainer: React.FC = () => {
+  const modelData = useEpidemicModelState();
+  // TODO: real number for this
+  const hospitalBeds = 12345;
+  // TODO: could this be stored on the context instead for reuse?
+  const { incarcerated, staff } = calculateCurves(modelData);
+  const incarceratedData: TableRow[] = [
+    buildTableRowFromCurves(incarcerated, "Cases", countCasesForDay),
+  ];
+  const incarceratedHospitalized = buildTableRowFromCurves(
+    incarcerated,
+    "In hospital",
+    getHospitalizedForDay,
+  );
+  incarceratedData.push(incarceratedHospitalized);
+  incarceratedData.push({
+    label: "% of public hospital beds used for incarc. pop.",
+    // none of these numbers are null unless explicitly set,
+    // which we haven't done
+    week1: (incarceratedHospitalized.week1 as number) / hospitalBeds,
+    week2: (incarceratedHospitalized.week2 as number) / hospitalBeds,
+    week3: (incarceratedHospitalized.week3 as number) / hospitalBeds,
+    overall: null,
+  });
+  incarceratedData.push(
+    buildTableRowFromCurves(incarcerated, "Deceased", getFatalitiesForDay),
+  );
+  const staffData: TableRow[] = [
+    // TODO: should this be "infected" not including exposed instead?
+    // Alternatively should it be called "Cases"?
+    buildTableRowFromCurves(staff, "Infected", countCasesForDay),
+    Object.assign(
+      buildTableRowFromCurves(staff, "Unable to work", countUnableToWorkForDay),
+      { overall: null },
+    ),
+    buildTableRowFromCurves(staff, "In hospital", getHospitalizedForDay),
+    buildTableRowFromCurves(staff, "Deceased", getFatalitiesForDay),
+  ];
+  const peakStats = getPeakHospitalized(incarcerated, hospitalBeds);
+  const peakData: TableRow[] = [
+    // TODO: dynamically indicate if this is for state or county
+    { label: "Peak hospital bed utilization", value: peakStats.peakPct },
+    {
+      label: "Days until peak hospital bed utilization",
+      value: peakStats.peakDay,
+    },
+    {
+      label:
+        "Days until 50% hospital bed utilization in region is by incarcerated population",
+      value: peakStats.daysUntil50Pct,
+    },
+  ].map(({ label, value }) => ({
+    label,
+    week1: null,
+    week2: null,
+    week3: null,
+    overall: value,
+  }));
+  return modelData.countyLevelDataLoading ? (
+    <Loading />
+  ) : (
+    <ImpactProjectionTable {...{ incarceratedData, staffData, peakData }} />
+  );
+};
+
+export default ImpactProjectionTableContainer;

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -80,8 +80,9 @@ export function calculateCurves(inputs: EpidemicModelInputs) {
 
   return {
     exposed: combinePopulations(seirIndex.exposed),
-    infectious: combinePopulations(seirIndex.infectious),
+    fatalities: combinePopulations(seirIndex.fatalities),
     hospitalized: combinePopulations(seirIndex.hospitalized),
+    infectious: combinePopulations(seirIndex.infectious),
   };
 }
 

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -1,10 +1,14 @@
-import { zip } from "d3-array";
+import ndarray from "ndarray";
 
 import { EpidemicModelInputs } from "../impact-dashboard/EpidemicModelContext";
-import { getAllValues, getColView } from "./matrixUtils";
-import { ageGroupIndex, getCurveProjections, seirIndex } from "./seir";
+import { ageGroupIndex, getCurveProjections } from "./seir";
 
-export function calculateCurves(inputs: EpidemicModelInputs) {
+export type CurveData = {
+  incarcerated: ndarray;
+  staff: ndarray;
+};
+
+export function calculateCurves(inputs: EpidemicModelInputs): CurveData {
   const {
     age0Cases,
     age0Population,
@@ -61,7 +65,7 @@ export function calculateCurves(inputs: EpidemicModelInputs) {
     ageGroupInitiallyInfected[ageGroupIndex.ageUnknown] = confirmedCases;
   }
 
-  const curveData = getCurveProjections({
+  return getCurveProjections({
     ageGroupPopulations,
     ageGroupInitiallyInfected,
     facilityDormitoryPct,
@@ -69,21 +73,6 @@ export function calculateCurves(inputs: EpidemicModelInputs) {
     numDays,
     rateOfSpreadFactor,
   });
-
-  // for these curves we combine incarcerated and staff
-  function combinePopulations(columnIndex: number) {
-    return zip(
-      getAllValues(getColView(curveData.incarcerated, columnIndex)),
-      getAllValues(getColView(curveData.staff, columnIndex)),
-    ).map(([incarcerated, staff]) => incarcerated + staff);
-  }
-
-  return {
-    exposed: combinePopulations(seirIndex.exposed),
-    fatalities: combinePopulations(seirIndex.fatalities),
-    hospitalized: combinePopulations(seirIndex.hospitalized),
-    infectious: combinePopulations(seirIndex.infectious),
-  };
 }
 
 export function estimatePeakHospitalUse() {

--- a/src/page-test/TestPage.tsx
+++ b/src/page-test/TestPage.tsx
@@ -75,7 +75,7 @@ const TestPage: React.FC = () => {
       <div>
         <h1> h1 </h1>
         <p> paragraph </p>
-        <body> body </body>
+        <div> div </div>
         <div className="description"> description </div>
         <div className="nav-link">nav-link</div>
         <div className="metric">metric</div>


### PR DESCRIPTION
## Description of the change

This adds an additional curve to the chart for Fatalities and also adds a table below the chart that contains some of the same data and some additional metrics, broken out by incarcerated vs staff populations. 

![Screen Shot 2020-04-07 at 7 50 39 PM](https://user-images.githubusercontent.com/5385319/78740421-8e773680-790b-11ea-992f-28046f3580e6.png)

There is a bit of redundancy in the table code; I tried not to build every data structure and table segment completely by hand but I also didn't fuss over making the solution perfectly elegant. There's also a bit of inefficiency here in that we are calculating the same projections twice, which may or may not be desirable in the interest of keeping the components independent of one another. These are things we can revisit later if we decide it's worthwhile but I didn't think they were launch-blockers.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
