### PR TITLE
Fixes type issues in the loading spinner.

### DIFF
--- a/src/design-system/Loading.tsx
+++ b/src/design-system/Loading.tsx
@@ -1,24 +1,24 @@
+import { css } from "@emotion/core";
 import BounceLoader from "react-spinners/BounceLoader";
 
 import { GlobalStyles } from "../styles";
 
-const override = {
-  display: "block",
-  margin: "0 auto",
-  position: "fixed",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-};
+const override = css`
+  display: block;
+  margin: 0 auto;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translateX(-50%) translateY(-50%);
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+`;
 
 const Loading: React.FC = () => {
   return (
     <>
       <GlobalStyles />
-      <div>
-        {/* BounceLoader's type definition might be wrong. */}
-        <BounceLoader css={override as any} size={60} color={"#005450"} />
-      </div>
+      <BounceLoader css={override} size={60} color={"#005450"} />
     </>
   );
 };

--- a/src/page-verification-needed/VerificationNeeded.tsx
+++ b/src/page-verification-needed/VerificationNeeded.tsx
@@ -2,26 +2,26 @@ import styled from "styled-components";
 
 import SiteHeader from "../site-header/SiteHeader";
 
+const StyledButton = styled.button`
+  background: #00615c;
+  font-size: 16px;
+  border-radius: 12px;
+  color: white;
+  font-family: "Poppins", sans-serif;
+  height: 48px;
+  width: 200px;
+  outline: none;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
 const VerificationNeeded: React.FC = () => {
   const refreshAndNavigateAway = () => {
     window.location.href = "/";
   };
-
-  const StyledButton = styled.button`
-    background: #00615c;
-    font-size: 16px;
-    border-radius: 12px;
-    color: white;
-    font-family: "Poppins", sans-serif;
-    height: 48px;
-    width: 200px;
-    outline: none;
-  `;
-
-  const ButtonWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-  `;
 
   return (
     <div>


### PR DESCRIPTION
## Description of the change

This fixes a type issue that previously caused the `any` requirement. However, I originally sought to solve the issue that when running `yarn dev` the loading spinner is properly centered in the view port, but when running the files in `/dist` after `yarn build` the spinner is in the exact top-left corner. So while this change should definitely be merged, I'd also be interested in knowing if anyone has ideas about why that may be happening.

(As a test I changed the /verify page to just return `<Loading />` directly and it was centered correctly. So something about the way it is invoked in `App.tsx` after `yarn build` is causing the centering to not work.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
