### PR TITLE
Clean up model data fetching from spreadsheet

### DIFF
--- a/src/@types/numeral.d.ts
+++ b/src/@types/numeral.d.ts
@@ -1,0 +1,11 @@
+interface Numeral {
+  // numeral returns null here if it can't parse the input string,
+  // but @types doesn't reflect that
+  value(): number | null;
+}
+
+declare const numeral: Numeral;
+
+declare module "numeral" {
+  export = numeral;
+}

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -131,6 +131,8 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
             const totalIncarceratedPopulation = numeral(
               row["Total Incarcerated Population"],
             ).value();
+            const estimatedTotalCases =
+              (numeral(row.cases).value() || 0) * (1 / caseReportingRate);
             return {
               county: row.County || "",
               state: row.State || "",
@@ -139,7 +141,7 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
               estimatedIncarceratedCases:
                 (totalIncarceratedPopulation /
                   numeral(row["Total Population"]).value()) *
-                (1 / caseReportingRate),
+                estimatedTotalCases,
             };
           },
         )

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -78,8 +78,7 @@ function getPeakHospitalized(data: ndarray, hospitalBeds: number): PeakData {
 
 const ImpactProjectionTableContainer: React.FC = () => {
   const modelData = useEpidemicModelState();
-  // TODO: real number for this
-  const hospitalBeds = 12345;
+  const { hospitalBeds } = modelData;
   // TODO: could this be stored on the context instead for reuse?
   const { incarcerated, staff } = calculateCurves(modelData);
   const incarceratedData: TableRow[] = [
@@ -104,8 +103,6 @@ const ImpactProjectionTableContainer: React.FC = () => {
     buildTableRowFromCurves(incarcerated, "Deceased", getFatalitiesForDay),
   );
   const staffData: TableRow[] = [
-    // TODO: should this be "infected" not including exposed instead?
-    // Alternatively should it be called "Cases"?
     buildTableRowFromCurves(staff, "Infected", countCasesForDay),
     Object.assign(
       buildTableRowFromCurves(staff, "Unable to work", countUnableToWorkForDay),


### PR DESCRIPTION
## Description of the change

This adds a more explicit interface for only the columns we actually need from the model spreadsheet. It also adds an estimate of initial cases (using the same methodology as the Excel model) to seed the model with.

After the initial update, it now selects all the necessary generic inputs to plot the entire US in the chart and table, so that chart should now load properly and display something meaningful after the page loads. @szhu you are probably already aware that we are going to have to do something similar every time a new state or county is selected from the input forms (this is still a loose end in the data flow from my perspective but may already be part of what you're doing? let me know if this is something I can help with in the morning).

(also realized that I forgot to replace a dummy value in the table data with the real data from the context; that's fixed here too)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
