### PR TITLE
Fix bug in output table

### DIFF
--- a/src/impact-dashboard/ImpactProjectionTable.tsx
+++ b/src/impact-dashboard/ImpactProjectionTable.tsx
@@ -25,7 +25,6 @@ const Table = styled.table`
   letter-spacing: 0;
   text-align: center;
   width: 100%;
-  max-width: 600px;
 
   th,
   td {

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -68,11 +68,13 @@ type PeakData = {
 function getPeakHospitalized(data: ndarray, hospitalBeds: number): PeakData {
   const hospitalized = getAllValues(getColView(data, seirIndex.hospitalized));
   const peakHospitalized = Math.max(...hospitalized);
+  const daysUntil50Pct = hospitalized.findIndex(
+    (val) => val / hospitalBeds > 0.5,
+  );
   return {
     peakDay: hospitalized.indexOf(peakHospitalized) + 1,
     peakPct: peakHospitalized / hospitalBeds,
-    daysUntil50Pct:
-      hospitalized.find((val) => val / hospitalBeds > 0.5) || null,
+    daysUntil50Pct: daysUntil50Pct > -1 ? daysUntil50Pct + 1 : null,
   };
 }
 


### PR DESCRIPTION
## Description of the change

We were printing the hospitalized population on the day it crossed the 50% threshold, rather than how many days. We were also failing to include people who were previously hospitalized in the "overall" hospitalized counts. This fixes that! 

(also fixes table display to limit unnecessary width restriction; the page never gets wide enough to make that really necessary)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
