### PR TITLE
Updating InputSelect Padding to Fix Sizing Issue with Text-based Inputs

### DIFF
--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -26,7 +26,7 @@ const SelectInput = styled.select`
   -moz-appearance: none;
   width: 100%;
   border: none;
-  padding: 16px;
+  padding: 18px;
   background: #e0e4e4;
   outline: 0 solid transparent;
   margin-top: 8px;


### PR DESCRIPTION
## Description of the change

Fixing a small padding issue so that the Select Inputs match the visual height of the text-based inputs.

<img width="1301" alt="Screen Shot 2020-04-08 at 5 56 26 PM" src="https://user-images.githubusercontent.com/25503/78837721-a493fe00-79c2-11ea-9ad2-6841cd0630f5.png">

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
