### PR TITLE
Defaulting Age Group Population and Infected Numbers to Zero

### DIFF
--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -41,28 +41,28 @@ export function calculateCurves(inputs: EpidemicModelInputs): CurveData {
   const ageGroupPopulations = Array(ageGroupIndex.__length).fill(0);
   const ageGroupInitiallyInfected = Array(ageGroupIndex.__length).fill(0);
   if (usePopulationSubsets) {
-    ageGroupPopulations[ageGroupIndex.age0] = age0Population;
-    ageGroupPopulations[ageGroupIndex.age20] = age20Population;
-    ageGroupPopulations[ageGroupIndex.age45] = age45Population;
-    ageGroupPopulations[ageGroupIndex.age55] = age55Population;
-    ageGroupPopulations[ageGroupIndex.age65] = age65Population;
-    ageGroupPopulations[ageGroupIndex.age75] = age75Population;
-    ageGroupPopulations[ageGroupIndex.age85] = age85Population;
-    ageGroupPopulations[ageGroupIndex.ageUnknown] = ageUnknownPopulation;
-    ageGroupPopulations[ageGroupIndex.staff] = staffPopulation;
+    ageGroupPopulations[ageGroupIndex.age0] = age0Population || 0;
+    ageGroupPopulations[ageGroupIndex.age20] = age20Population || 0;
+    ageGroupPopulations[ageGroupIndex.age45] = age45Population || 0;
+    ageGroupPopulations[ageGroupIndex.age55] = age55Population || 0;
+    ageGroupPopulations[ageGroupIndex.age65] = age65Population || 0;
+    ageGroupPopulations[ageGroupIndex.age75] = age75Population || 0;
+    ageGroupPopulations[ageGroupIndex.age85] = age85Population || 0;
+    ageGroupPopulations[ageGroupIndex.ageUnknown] = ageUnknownPopulation || 0;
+    ageGroupPopulations[ageGroupIndex.staff] = staffPopulation || 0;
 
-    ageGroupInitiallyInfected[ageGroupIndex.age0] = age0Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age20] = age20Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age45] = age45Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age55] = age55Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age65] = age65Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age75] = age75Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.age85] = age85Cases;
-    ageGroupInitiallyInfected[ageGroupIndex.ageUnknown] = ageUnknownCases;
-    ageGroupInitiallyInfected[ageGroupIndex.staff] = staffCases;
+    ageGroupInitiallyInfected[ageGroupIndex.age0] = age0Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age20] = age20Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age45] = age45Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age55] = age55Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age65] = age65Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age75] = age75Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.age85] = age85Cases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.ageUnknown] = ageUnknownCases || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.staff] = staffCases || 0;
   } else {
-    ageGroupPopulations[ageGroupIndex.ageUnknown] = totalIncarcerated;
-    ageGroupInitiallyInfected[ageGroupIndex.ageUnknown] = confirmedCases;
+    ageGroupPopulations[ageGroupIndex.ageUnknown] = totalIncarcerated || 0;
+    ageGroupInitiallyInfected[ageGroupIndex.ageUnknown] = confirmedCases || 0;
   }
 
   return getCurveProjections({


### PR DESCRIPTION
- Fixes a bug in the code where we are trying to use undefined and NaN values to populate the SEIR model and generate the graphs.  Obviously that won't work.  To fix this bug, we default all age population inputs to zero if they would otherwise be undefined.  This allows us to proceed with the calculations.

## Description of the change

Fixes a bug in the code where we are trying to use undefined and NaN values to populate the SEIR model and generate the graphs.  Obviously that won't work.  To fix this bug, we default all age population inputs to zero if they would otherwise be undefined.  This allows us to proceed with the calculations.

**Before**

<img width="1285" alt="Screen Shot 2020-04-08 at 6 06 51 PM" src="https://user-images.githubusercontent.com/25503/78846797-f5175580-79da-11ea-851c-3f0416d44e8c.png">

**After**

<img width="1275" alt="Screen Shot 2020-04-08 at 8 51 17 PM" src="https://user-images.githubusercontent.com/25503/78846809-fea0bd80-79da-11ea-98ec-a70f9fb55e22.png">

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
