### PR TITLE
Persist model inputs in URL

### DIFF
--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -32,7 +32,9 @@ export enum RateOfSpread {
 }
 // any field that we can update via reducer should be here,
 // and should probably be optional
-interface ModelInputsUpdate {
+
+// fields that we want to store in URL or other persistent store
+interface ModelInputsPersistent {
   age0Cases?: number;
   age0Population?: number;
   age20Cases?: number;
@@ -49,12 +51,16 @@ interface ModelInputsUpdate {
   age85Population?: number;
   ageUnknownCases?: number;
   ageUnknownPopulation?: number;
-  confirmedCases?: number;
   facilityDormitoryPct?: number;
   facilityOccupancyPct?: number;
   rateOfSpreadFactor?: RateOfSpread;
   staffCases?: number;
   staffPopulation?: number;
+}
+
+interface ModelInputsUpdate extends ModelInputsPersistent {
+  // these don't persist because they are auto-populated from external data
+  confirmedCases?: number;
   totalIncarcerated?: number;
   usePopulationSubsets?: boolean;
 }
@@ -66,13 +72,18 @@ interface EpidemicModelInputs extends ModelInputsUpdate {
   facilityOccupancyPct: number;
 }
 
-interface MetadataUpdate {
-  countyLevelData?: CountyLevelData;
-  countyLevelDataLoading?: boolean;
-  countyLevelDataFailed?: boolean;
+interface MetadataPersistent {
+  // fields that we want to store in URL or other persistent store
   countyName?: string;
   facilityName?: string;
   stateCode?: string;
+}
+
+interface MetadataUpdate extends MetadataPersistent {
+  countyLevelData?: CountyLevelData;
+  countyLevelDataLoading?: boolean;
+  countyLevelDataFailed?: boolean;
+  // this is not user input so don't store it
   hospitalBeds?: number;
 }
 // some fields are required to display a sensible UI, define them here
@@ -80,6 +91,37 @@ interface Metadata extends MetadataUpdate {
   stateCode: string;
   hospitalBeds: number;
 }
+
+type EpidemicModelPersistent = ModelInputsPersistent & MetadataPersistent;
+// we have to type all them out here again
+// but at least we can validate that none are illegal
+// TODO: is there a smarter way to get these values?
+export const urlParamKeys: Array<keyof EpidemicModelPersistent> = [
+  "countyName",
+  "facilityName",
+  "stateCode",
+  "age0Cases",
+  "age0Population",
+  "age20Cases",
+  "age20Population",
+  "age45Cases",
+  "age45Population",
+  "age55Cases",
+  "age55Population",
+  "age65Cases",
+  "age65Population",
+  "age75Cases",
+  "age75Population",
+  "age85Cases",
+  "age85Population",
+  "ageUnknownCases",
+  "ageUnknownPopulation",
+  "facilityDormitoryPct",
+  "facilityOccupancyPct",
+  "rateOfSpreadFactor",
+  "staffCases",
+  "staffPopulation",
+];
 
 export type EpidemicModelUpdate = ModelInputsUpdate & MetadataUpdate;
 
@@ -150,7 +192,6 @@ function epidemicModelReducer(
       // it's not very granular but it doesn't need to be at the moment
       return Object.assign({}, state, action.payload);
     case "reset":
-      console.log(action.payload);
       return getResetState(action.payload);
   }
 }

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -213,7 +213,7 @@ function sanitizeQueryParams(rawQueryParams: QueryParams) {
   return mapValues(pick(rawQueryParams, urlParamKeys), (value) => {
     // most of these are numbers but some are strings
     const n = numeral(value).value();
-    return n != null ? n : "" + value;
+    return n != null ? n : value?.toString();
   });
 }
 

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -53,10 +53,9 @@ function useModel() {
   const dispatch = useEpidemicModelDispatch();
   const model = useEpidemicModelState();
 
-  const { values, replaceValues } = useQueryParams({});
+  const { values, replaceValues, pushValues } = useQueryParams({});
 
   function updateModel(update: EpidemicModelUpdate) {
-    // on updates, replace the URL state
     const urlParams = Object.assign({}, values, pick(update, urlParamKeys));
     replaceValues(urlParams);
 
@@ -64,6 +63,10 @@ function useModel() {
   }
 
   function resetModel(stateCode?: string, countyName?: string) {
+    // TODO: this use of pick() is a degraded type check to make sure
+    // we don't pass any illegal keys to the URL state
+    pushValues(pick({ stateCode, countyName }, urlParamKeys));
+
     dispatch({
       type: "reset",
       payload: Object.assign(

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -1,4 +1,3 @@
-import { pick } from "lodash";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -6,11 +5,9 @@ import Colors from "../design-system/Colors";
 import InputSelect from "../design-system/InputSelect";
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import TextLabel from "../design-system/TextLabel";
-import useQueryParams from "../hooks/useQueryParams";
 import ChartArea from "./ChartArea";
 import {
   EpidemicModelUpdate,
-  urlParamKeys,
   useEpidemicModelDispatch,
   useEpidemicModelState,
 } from "./EpidemicModelContext";
@@ -53,34 +50,11 @@ function useModel() {
   const dispatch = useEpidemicModelDispatch();
   const model = useEpidemicModelState();
 
-  const { values, replaceValues, pushValues } = useQueryParams({});
-
   function updateModel(update: EpidemicModelUpdate) {
-    const urlParams = Object.assign({}, values, pick(update, urlParamKeys));
-    replaceValues(urlParams);
-
     dispatch({ type: "update", payload: update });
   }
 
-  function resetModel(stateCode?: string, countyName?: string) {
-    // TODO: this use of pick() is a degraded type check to make sure
-    // we don't pass any illegal keys to the URL state
-    pushValues(pick({ stateCode, countyName }, urlParamKeys));
-
-    dispatch({
-      type: "reset",
-      payload: Object.assign(
-        { dataSource: model.countyLevelData },
-        { stateCode, countyName },
-      ),
-    });
-  }
-
-  return [model, updateModel, resetModel] as [
-    typeof model,
-    typeof updateModel,
-    typeof resetModel,
-  ];
+  return [model, updateModel] as [typeof model, typeof updateModel];
 }
 
 /* Locale Information */
@@ -91,7 +65,7 @@ const LocaleInformationDiv = styled.div`
 `;
 
 const LocaleInformation: React.FC = () => {
-  const [model, updateModel, resetModel] = useModel();
+  const [model, updateModel] = useModel();
 
   const [stateList, updateStateList] = useState([{ value: "US Total" }]);
   const [countyList, updateCountyList] = useState([{ value: "Total" }]);
@@ -126,7 +100,7 @@ const LocaleInformation: React.FC = () => {
         label="State"
         value={model.stateCode}
         onChange={(event) => {
-          resetModel(event.target.value);
+          updateModel({ stateCode: event.target.value });
         }}
       >
         {stateList.map(({ value }) => (
@@ -139,7 +113,10 @@ const LocaleInformation: React.FC = () => {
         label="County"
         value={model.countyName}
         onChange={(event) => {
-          resetModel(model.stateCode, event.target.value);
+          updateModel({
+            stateCode: model.stateCode,
+            countyName: event.target.value,
+          });
         }}
       >
         {countyList.map(({ value }) => (

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -1,3 +1,4 @@
+import { pick } from "lodash";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 
@@ -5,9 +6,11 @@ import Colors from "../design-system/Colors";
 import InputSelect from "../design-system/InputSelect";
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import TextLabel from "../design-system/TextLabel";
+import useQueryParams from "../hooks/useQueryParams";
 import ChartArea from "./ChartArea";
 import {
   EpidemicModelUpdate,
+  urlParamKeys,
   useEpidemicModelDispatch,
   useEpidemicModelState,
 } from "./EpidemicModelContext";
@@ -50,7 +53,13 @@ function useModel() {
   const dispatch = useEpidemicModelDispatch();
   const model = useEpidemicModelState();
 
+  const { values, replaceValues } = useQueryParams({});
+
   function updateModel(update: EpidemicModelUpdate) {
+    // on updates, replace the URL state
+    const urlParams = Object.assign({}, values, pick(update, urlParamKeys));
+    replaceValues(urlParams);
+
     dispatch({ type: "update", payload: update });
   }
 


### PR DESCRIPTION
## Description of the change

This uses @notfelineit 's new hook to persist form context data to the URL for sharing, bookmarking, etc. It wound up being way more of a beast than I expected but here is where it's at right now:

- updates to the location and facility inputs trigger a history state replacement (meaning no back/forward navigation)
- upon the initial page load, any existing URL parameters are incorporated into the existing state

I initially hoped to preserve back/forward navigation, but I got too deep in the weeds and ultimately abandoned that for now. I think it's still possible but maybe can follow later (unless someone has a quick solution that has evaded my pudding brain today).

There were some challenges that I worked around for now: having the `useQueryState` maintain the same reference across renders would make things cleaner, as would more properly reconciling the query type definitions with the model. You will see that I cheated on both of these; it works as far as I can tell but definitely there are some possible edge case bugs. 

Also, there seem to be lots of annoying whitespace changes in this diff! Fair warning that you might want to turn those off while reviewing.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
