### PR TITLE
Fix web manifest, part 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       compile it to JS. Using the workaround recommended here:
       https://github.com/parcel-bundler/parcel/issues/235#issuecomment-397226657
      -->
-    <link rel="manifest" href="/public/manifest.webmanifest" />
+    <link rel="manifest" href="/manifest.webmanifest" />
 
     <title>TITLE PLACEHOLDER</title>
     <link

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -3,12 +3,12 @@
   "name": "COVID-19 Dashboard",
   "icons": [
     {
-      "src": "android-chrome-192x192.png",
+      "src": "public/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "android-chrome-512x512.png",
+      "src": "public/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Description of the change

Previous PR: #57 

When compiled statically:
- The HTML references `/public/manifest.json`, which exists
- `/public/manifest.json` references `android-chrome-192x192.png`
- `/public/android-chrome-192x192.png` doesn't exist. It exists at `/android-chrome-192x192.png`

![image](https://user-images.githubusercontent.com/1570168/78954802-10916780-7a92-11ea-85f7-5c74292fb9ff.png)


This PR fixes those references -- hopefully I got it right this time!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
