### PR TITLE
Fix Loading + stop statically rendering HTML

### DIFF
--- a/src/design-system/Loading.tsx
+++ b/src/design-system/Loading.tsx
@@ -1,25 +1,22 @@
-import { css } from "@emotion/core";
+import React from "react";
 import BounceLoader from "react-spinners/BounceLoader";
+import styled from "styled-components";
 
-import { GlobalStyles } from "../styles";
+import Colors from "./Colors";
 
-const override = css`
-  display: block;
-  margin: 0 auto;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  -ms-transform: translateX(-50%) translateY(-50%);
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
+const LoadingContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
 `;
 
 const Loading: React.FC = () => {
   return (
-    <>
-      <GlobalStyles />
-      <BounceLoader css={override} size={60} color={"#005450"} />
-    </>
+    <LoadingContainer>
+      <BounceLoader size={60} color={Colors.forest} />
+    </LoadingContainer>
   );
 };
 

--- a/src/entry-point-static/generatePageContent.tsx
+++ b/src/entry-point-static/generatePageContent.tsx
@@ -10,7 +10,7 @@ export default function generatePageContent(
   { title, path }: PageInfo,
 ) {
   let styleSheet = new ServerStyleSheet();
-  let contentHtml = ReactDOMServer.renderToString(
+  ReactDOMServer.renderToString(
     styleSheet.collectStyles(
       <StaticRouter location={path}>
         <App />
@@ -22,7 +22,7 @@ export default function generatePageContent(
   [
     ["TITLE PLACEHOLDER", title],
     ["<style></style>", stylesHtml],
-    ["CONTENT PLACEHOLDER", contentHtml],
+    ["CONTENT PLACEHOLDER", ""],
   ].map(([toFind, toReplace]) => {
     if (template.indexOf(toFind) === -1) {
       console.error(


### PR DESCRIPTION
## Description of the change

Fixes the brief mispositioning of the loading spinner when loading the static build.

| Before    | After    |
| ----------| -------- |
| ![before] | ![after] |

[before]: https://user-images.githubusercontent.com/1570168/78952915-f6ed2180-7a8b-11ea-9887-60067dc3cde9.gif
[after]: https://user-images.githubusercontent.com/1570168/78952923-fbb1d580-7a8b-11ea-86da-831eebeed385.gif

This was loaded with devtools set to the "Fast 3G" setting so that the loading state could be captured more easily.

Note: With the animations slowed down, it might seem like the Before experience feels better. It doesn't -- at normal speed, you just see a lot of flashes of content which is very jarring!

---

The change in this PR is fairly simple, but a significant amount of experimentation went into producing the best result. Here are some findings:
- I investigated why the loading spinner is briefly misplaced by examining it at that moment using this method: Open the Sources panel of devtools. Load the page and click the pause button as soon as you see the misplaced spinner.
- The Loading component was immediately inside a `<div className="font-body text-green min-h-screen tracking-normal w-full">`, so I realized that is probably one of the interior Loading components, not the one in `App.tsx`. Actually, we know the Loading component belongs to the chart, because everything else exists in the static render already. This realization didn't help me get anywhere, though.
- I noticed that the DOM hierarchy surrounding the loading spinner is completely out of line what is defined in our code. I wrapped Loading as follows: `<div className="some-class-name">Some text<Loading/></div>`, but the output looked closer to `Some text<Loading/>` without the wrapping div.
- I looked at the output of the static render and the output had the correct hierarchy.
- My best theory at the moment is that the issue is probably that what is statically rendered is not the same as the initial client render:
  - The initial static render contains the Loading component.
  - The first client render doesn't contain the Loading component.
  - When client React starts, tries it best to reconcile these two by removing any divs that it sees but keeping the foreign content `Some text<Loading/>`.
  - Why does it do this rather than removing everything? A common issue React has to deal with is when browser extensions inject content into the page, so I assume this is a reasonable response to that.
- Why is there a rendering mismatch? I have these theories:
  - The build script doing something wrong with static rendering.
  - The Loading component is buggy.
  - Static rendering/reconciliation with client rendering in React is buggy.
  - The reconciliation is just not supposed to account for the fact that the client render might be different than the static render.

Based on the above investigation, I examined the following solutions for for a fix:
- Use something other than the `react-spinners` package. I looked around but nothing looks as pretty as the current Loading component!
- Force the Loading spinner to not show up for a fraction of a second. This might be an ok solution, but I spent too long trying to write elegant code for this.
- Don't statically render. I realized that both pages show a Loading spinner initially anyway, which means there's really no point to statically rendering anything but the CSS (which means we immediately get the correct background color). In fact, it's even better, because we don't see the statically rendered form before client React starts and the loading spinner covers it up. **This is the solution I went with, which is what this PR does.**
- Make the client render is in the same state as the static render. This is probably the correct long-term solution if we want to show significant initial content, which is not the case right now.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
