### PR TITLE
Cleanup auth and routing React code + fix static rendering

### DIFF
--- a/src/auth/AuthWall.tsx
+++ b/src/auth/AuthWall.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { Redirect, useLocation } from "react-router-dom";
 
 import Loading from "../design-system/Loading";
 import { useAuth0 } from "./react-auth0-spa";
 
 const AuthWall: React.FC = (props) => {
   const location = useLocation();
-  const { loading, isAuthenticated, loginWithRedirect } = useAuth0() as any;
+  const {
+    loading,
+    isAuthenticated,
+    loginWithRedirect,
+    user,
+  } = useAuth0() as any;
 
   useEffect(() => {
     if (loading || isAuthenticated) {
@@ -23,6 +28,10 @@ const AuthWall: React.FC = (props) => {
 
   if (loading) {
     return <Loading />;
+  }
+
+  if (user && !user.email_verified) {
+    return <Redirect to="/verify" />;
   }
 
   let inner = isAuthenticated === true ? props.children : null;

--- a/src/auth/AuthWall.tsx
+++ b/src/auth/AuthWall.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
+import Loading from "../design-system/Loading";
 import { useAuth0 } from "./react-auth0-spa";
 
 const AuthWall: React.FC = (props) => {
@@ -11,6 +12,7 @@ const AuthWall: React.FC = (props) => {
     if (loading || isAuthenticated) {
       return;
     }
+
     const fn = async () => {
       await loginWithRedirect({
         appState: { targetUrl: location.pathname },
@@ -18,6 +20,10 @@ const AuthWall: React.FC = (props) => {
     };
     fn();
   }, [loading, isAuthenticated, loginWithRedirect, location.pathname]);
+
+  if (loading) {
+    return <Loading />;
+  }
 
   let inner = isAuthenticated === true ? props.children : null;
 

--- a/src/auth/AuthWall.tsx
+++ b/src/auth/AuthWall.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 
 import { useAuth0 } from "./react-auth0-spa";
 
-const PrivateRoute: React.FC = (props) => {
+const AuthWall: React.FC = (props) => {
   const location = useLocation();
   const { loading, isAuthenticated, loginWithRedirect } = useAuth0() as any;
 
@@ -24,4 +24,4 @@ const PrivateRoute: React.FC = (props) => {
   return <>{inner}</>;
 };
 
-export default PrivateRoute;
+export default AuthWall;

--- a/src/auth/AuthWall.tsx
+++ b/src/auth/AuthWall.tsx
@@ -14,16 +14,9 @@ const AuthWall: React.FC = (props) => {
   } = useAuth0() as any;
 
   useEffect(() => {
-    if (loading || isAuthenticated) {
-      return;
-    }
+    if (loading || isAuthenticated) return;
 
-    const fn = async () => {
-      await loginWithRedirect({
-        appState: { targetUrl: location.pathname },
-      });
-    };
-    fn();
+    loginWithRedirect({ appState: { targetUrl: location.pathname } });
   }, [loading, isAuthenticated, loginWithRedirect, location.pathname]);
 
   if (loading) {
@@ -34,9 +27,12 @@ const AuthWall: React.FC = (props) => {
     return <Redirect to="/verify" />;
   }
 
-  let inner = isAuthenticated === true ? props.children : null;
+  // We could be here if loginWithRedirect hasn't completed yet.
+  if (!isAuthenticated) {
+    return <Loading />;
+  }
 
-  return <>{inner}</>;
+  return <>{props.children}</>;
 };
 
 export default AuthWall;

--- a/src/auth/PrivateRoute.tsx
+++ b/src/auth/PrivateRoute.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from "react";
-import { Route } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import { useAuth0 } from "./react-auth0-spa";
 
-const PrivateRoute = ({ children, path, ...rest }: any) => {
+const PrivateRoute: React.FC = (props) => {
+  const location = useLocation();
   const { loading, isAuthenticated, loginWithRedirect } = useAuth0() as any;
 
   useEffect(() => {
@@ -12,19 +13,15 @@ const PrivateRoute = ({ children, path, ...rest }: any) => {
     }
     const fn = async () => {
       await loginWithRedirect({
-        appState: { targetUrl: window.location.pathname },
+        appState: { targetUrl: location.pathname },
       });
     };
     fn();
-  }, [loading, isAuthenticated, loginWithRedirect, path]);
+  }, [loading, isAuthenticated, loginWithRedirect, location.pathname]);
 
-  let inner = isAuthenticated === true ? children : null;
+  let inner = isAuthenticated === true ? props.children : null;
 
-  return (
-    <Route path={path} {...rest}>
-      {inner}
-    </Route>
-  );
+  return <>{inner}</>;
 };
 
 export default PrivateRoute;

--- a/src/auth/PrivateRoute.tsx
+++ b/src/auth/PrivateRoute.tsx
@@ -1,12 +1,10 @@
-// @ts-nocheck
-
 import React, { useEffect } from "react";
 import { Route } from "react-router-dom";
 
 import { useAuth0 } from "./react-auth0-spa";
 
-const PrivateRoute = ({ component: Component, path, ...rest }: any) => {
-  const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
+const PrivateRoute = ({ children, path, ...rest }: any) => {
+  const { loading, isAuthenticated, loginWithRedirect } = useAuth0() as any;
 
   useEffect(() => {
     if (loading || isAuthenticated) {
@@ -20,10 +18,13 @@ const PrivateRoute = ({ component: Component, path, ...rest }: any) => {
     fn();
   }, [loading, isAuthenticated, loginWithRedirect, path]);
 
-  const render = (props) =>
-    isAuthenticated === true ? <Component {...props} /> : null;
+  let inner = isAuthenticated === true ? children : null;
 
-  return <Route path={path} render={render} {...rest} />;
+  return (
+    <Route path={path} {...rest}>
+      {inner}
+    </Route>
+  );
 };
 
 export default PrivateRoute;

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -1,7 +1,7 @@
 import { hot } from "react-hot-loader";
 import { Redirect, Route, Switch } from "react-router-dom";
 
-import PrivateRoute from "../auth/PrivateRoute";
+import AuthWall from "../auth/AuthWall";
 import { useAuth0 } from "../auth/react-auth0-spa";
 import Loading from "../design-system/Loading";
 import { GlobalStyles } from "../styles";
@@ -37,10 +37,10 @@ const App: React.FC = () => {
           } else {
             return (
               <Route key={path} path={path} exact>
-                <PrivateRoute>
+                <AuthWall>
                   <WindowTitle>{title}</WindowTitle>
                   {redirectIfUnverified(user, contents)}
-                </PrivateRoute>
+                </AuthWall>
               </Route>
             );
           }

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -4,7 +4,6 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import PrivateRoute from "../auth/PrivateRoute";
 import { useAuth0 } from "../auth/react-auth0-spa";
 import Loading from "../design-system/Loading";
-import VerificationNeeded from "../page-verification-needed/VerificationNeeded";
 import { GlobalStyles } from "../styles";
 import PageList from "./PageList";
 import WindowTitle from "./WindowTitle";
@@ -27,11 +26,6 @@ const App: React.FC = () => {
     <>
       <GlobalStyles />
       <Switch>
-        <Route path="/verify">
-          <WindowTitle>Verification Needed</WindowTitle>
-          <VerificationNeeded />
-        </Route>
-
         {PageList.map(({ path, title, isPrivate, contents }) => {
           if (!isPrivate) {
             return (

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -3,17 +3,12 @@ import { Redirect, Route, Switch } from "react-router-dom";
 
 import AuthWall from "../auth/AuthWall";
 import { useAuth0 } from "../auth/react-auth0-spa";
-import Loading from "../design-system/Loading";
 import { GlobalStyles } from "../styles";
 import PageList from "./PageList";
 import WindowTitle from "./WindowTitle";
 
 const App: React.FC = () => {
-  const { loading, user } = (useAuth0 as any)();
-
-  if (loading) {
-    return <Loading />;
-  }
+  const { user } = (useAuth0 as any)();
 
   const redirectIfUnverified = (userObject: any, contents: any) => {
     if (userObject && !userObject.email_verified) {
@@ -31,7 +26,7 @@ const App: React.FC = () => {
             return (
               <Route key={path} path={path} exact>
                 <WindowTitle>{title}</WindowTitle>
-                {redirectIfUnverified(user, contents)}
+                {contents}
               </Route>
             );
           } else {

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -36,10 +36,12 @@ const App: React.FC = () => {
             );
           } else {
             return (
-              <PrivateRoute key={path} path={path} exact>
-                <WindowTitle>{title}</WindowTitle>
-                {redirectIfUnverified(user, contents)}
-              </PrivateRoute>
+              <Route key={path} path={path} exact>
+                <PrivateRoute>
+                  <WindowTitle>{title}</WindowTitle>
+                  {redirectIfUnverified(user, contents)}
+                </PrivateRoute>
+              </Route>
             );
           }
         })}

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -1,22 +1,12 @@
 import { hot } from "react-hot-loader";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 
 import AuthWall from "../auth/AuthWall";
-import { useAuth0 } from "../auth/react-auth0-spa";
 import { GlobalStyles } from "../styles";
 import PageList from "./PageList";
 import WindowTitle from "./WindowTitle";
 
 const App: React.FC = () => {
-  const { user } = (useAuth0 as any)();
-
-  const redirectIfUnverified = (userObject: any, contents: any) => {
-    if (userObject && !userObject.email_verified) {
-      return <Redirect to="/verify" />;
-    }
-    return contents;
-  };
-
   return (
     <>
       <GlobalStyles />
@@ -34,7 +24,7 @@ const App: React.FC = () => {
               <Route key={path} path={path} exact>
                 <AuthWall>
                   <WindowTitle>{title}</WindowTitle>
-                  {redirectIfUnverified(user, contents)}
+                  {contents}
                 </AuthWall>
               </Route>
             );

--- a/src/entry-point-client/PageList.tsx
+++ b/src/entry-point-client/PageList.tsx
@@ -13,13 +13,6 @@ function getPageTitle(...parts: string[]) {
   return [...parts, "COVID-19 Dashboard"].join(" • ");
 }
 
-export const VerificationNeededPage: PageInfo = {
-  path: "/verify",
-  title: getPageTitle("Verification Needed"),
-  isPrivate: false,
-  contents: <VerificationNeeded />,
-};
-
 const PageList: PageInfo[] = [
   {
     path: "/",
@@ -32,6 +25,12 @@ const PageList: PageInfo[] = [
     title: getPageTitle("Get Involved"),
     isPrivate: false,
     contents: <GetInvolvedPage />,
+  },
+  {
+    path: "/verify",
+    title: getPageTitle("Verification Needed"),
+    isPrivate: false,
+    contents: <VerificationNeeded />,
   },
 ];
 

--- a/src/entry-point-static/build.tsx
+++ b/src/entry-point-static/build.tsx
@@ -6,10 +6,7 @@ import chalk from "chalk";
 import fs from "fs";
 import path from "path";
 
-import PageList, {
-  PageInfo,
-  VerificationNeededPage,
-} from "../entry-point-client/PageList";
+import PageList, { PageInfo } from "../entry-point-client/PageList";
 import generatePageContent from "./generatePageContent";
 
 console.log(chalk.blueBright("Rendering React statically into HTML files:"));
@@ -29,5 +26,3 @@ let template = fs.readFileSync("dist/index.html", "utf-8");
 for (let pageInfo of PageList) {
   generatePage(template, pageInfo);
 }
-
-generatePage(template, VerificationNeededPage);

--- a/src/entry-point-static/generatePageContent.tsx
+++ b/src/entry-point-static/generatePageContent.tsx
@@ -10,7 +10,7 @@ export default function generatePageContent(
   { title, path }: PageInfo,
 ) {
   let styleSheet = new ServerStyleSheet();
-  ReactDOMServer.renderToString(
+  let contentHtml = ReactDOMServer.renderToString(
     styleSheet.collectStyles(
       <StaticRouter location={path}>
         <App />
@@ -22,7 +22,7 @@ export default function generatePageContent(
   [
     ["TITLE PLACEHOLDER", title],
     ["<style></style>", stylesHtml],
-    ["CONTENT PLACEHOLDER", ""],
+    ["CONTENT PLACEHOLDER", contentHtml],
   ].map(([toFind, toReplace]) => {
     if (template.indexOf(toFind) === -1) {
       console.error(


### PR DESCRIPTION
## Description of the change

**Note the reviewers: Please review commit-by-commit!** Each commit is small and clearly describes what is going on.

This PR:
- Cleans up the auth and routing React code. See the commit names for the details!
- Fixes the remaining issue mentioned in #69, which is that when static rendering, a flash of content appears.

Details of the fix: When the auth state is loaded and the user has been determined to not be logged in, the home page shows up again briefly. This occurs:
- When static rendering! (Now that this is fixed, this PR also turns static HTML rendering back on, and it is verified to not be buggy anymore with the Loading component.)
- When PrivateRoute has asked to redirect the page, but the redirect hasn't happened yet.

See the "Fix PrivateRoute not actually gating its contents" commit for the fix.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
