### PR TITLE
Add "unsupported browser" page and functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,15 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script src="https://d3js.org/d3.v5.min.js"></script>
     <script src="src/entry-point-client/index.tsx"></script>
+
+    <!--
+      Redirect if src/entry-point-client/index.tsx doesn't load properly.
+      The variable `window.appLoaded` is set at the bottom of index.tsx.
+     -->
+    <script>
+      if (location.pathname === "/" && !window.appLoaded)
+        location.href = "/unsupported-browser";
+    </script>
     <link
       href="https://fonts.googleapis.com/css?family=Libre+Baskerville|Poppins|Rubik:300,400&display=swap"
       rel="stylesheet"

--- a/src/entry-point-client/PageList.tsx
+++ b/src/entry-point-client/PageList.tsx
@@ -1,5 +1,6 @@
 import GetInvolvedPage from "../page-get-involved/GetInvolvedPage";
 import OverviewPage from "../page-overview/OverviewPage";
+import UnsupportedBrowserPage from "../page-unsupported-browser/UnsupportedBrowserPage";
 import VerificationNeeded from "../page-verification-needed/VerificationNeeded";
 
 export interface PageInfo {
@@ -25,6 +26,12 @@ const PageList: PageInfo[] = [
     title: getPageTitle("Get Involved"),
     isPrivate: false,
     contents: <GetInvolvedPage />,
+  },
+  {
+    path: "/unsupported-browser",
+    title: getPageTitle("Unsupported Browser"),
+    isPrivate: false,
+    contents: <UnsupportedBrowserPage />,
   },
   {
     path: "/verify",

--- a/src/entry-point-client/index.tsx
+++ b/src/entry-point-client/index.tsx
@@ -43,3 +43,7 @@ if (process.env.NODE_ENV === "development") {
 } else {
   ReactDOM.hydrate(element, container);
 }
+
+// If the user is using a browser so old that the JS causes a syntax error, in
+// index.html we redirect to the "unsupported browser" page.
+(window as any).appLoaded = true;

--- a/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
+++ b/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
@@ -12,19 +12,21 @@ const UnsupportedBrowserPage: React.FC = () => (
         <main className="py-8 sm:py-16 sm:py-24">
           <div className="max-w-3xl mx-auto px-6 sm:px-8 lg:px-10 flex flex-col justify-start">
             <p className="leading-7 text-base sm:text-lg my-6">
-              Sorry, you're using a legacy browser that that site does not
-              support.
+              We’re sorry, legacy browsers such as Internet Explorer are not
+              currently supported by the COVID-19 model. Please try loading the
+              website in a modern browser such as Microsoft Edge, Google Chrome,
+              Firefox, or Safari.
             </p>
             <p className="leading-7 text-base sm:text-lg my-6">
-              Please use Google Chrome, Firefox, Microsoft Edge, or any other
-              modern browser.
-            </p>
-            <p className="leading-7 text-base sm:text-lg my-6">
-              If you have further issues, please email us at{" "}
-              <a href="mailto:covid@recidiviz.org" className="font-semibold">
+              If you think you are seeing this message in error, or if you can’t
+              switch browsers, please email us at{" "}
+              <a
+                href="mailto:covid@recidiviz.org?Subject=COVID%20Model%20Browser%20Support"
+                className="font-semibold"
+              >
                 covid@recidiviz.org
-              </a>
-              .
+              </a>{" "}
+              so we can provide support.
             </p>
           </div>
         </main>

--- a/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
+++ b/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+import SiteHeader from "../site-header/SiteHeader";
+
+const GetInvolvedPageDiv = styled.div``;
+
+const UnsupportedBrowserPage: React.FC = () => (
+  <GetInvolvedPageDiv>
+    <div className="font-body text-green min-h-screen tracking-normal w-full">
+      <div className="max-w-screen-xl px-4 mx-auto">
+        <SiteHeader />
+        <main className="py-8 sm:py-16 sm:py-24">
+          <div className="max-w-3xl mx-auto px-6 sm:px-8 lg:px-10 flex flex-col justify-start">
+            <p className="leading-7 text-base sm:text-lg my-6">
+              Sorry, you're using a legacy browser that that site does not
+              support.
+            </p>
+            <p className="leading-7 text-base sm:text-lg my-6">
+              Please use Google Chrome, Firefox, Microsoft Edge, or any other
+              modern browser.
+            </p>
+            <p className="leading-7 text-base sm:text-lg my-6">
+              If you have further issues, please email us at{" "}
+              <a href="mailto:covid@recidiviz.org" className="font-semibold">
+                covid@recidiviz.org
+              </a>
+              .
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  </GetInvolvedPageDiv>
+);
+
+export default UnsupportedBrowserPage;

--- a/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
+++ b/src/page-unsupported-browser/UnsupportedBrowserPage.tsx
@@ -2,10 +2,10 @@ import styled from "styled-components";
 
 import SiteHeader from "../site-header/SiteHeader";
 
-const GetInvolvedPageDiv = styled.div``;
+const UnsupportedBrowserPageDiv = styled.div``;
 
 const UnsupportedBrowserPage: React.FC = () => (
-  <GetInvolvedPageDiv>
+  <UnsupportedBrowserPageDiv>
     <div className="font-body text-green min-h-screen tracking-normal w-full">
       <div className="max-w-screen-xl px-4 mx-auto">
         <SiteHeader />
@@ -32,7 +32,7 @@ const UnsupportedBrowserPage: React.FC = () => (
         </main>
       </div>
     </div>
-  </GetInvolvedPageDiv>
+  </UnsupportedBrowserPageDiv>
 );
 
 export default UnsupportedBrowserPage;


### PR DESCRIPTION
## Description of the change

Show the following page if the user is using a browser that runs into an error running the app JS:

![image](https://user-images.githubusercontent.com/1570168/78968957-a80ab080-7aba-11ea-942e-1a7221fa519a.png)

Note that the "unsupported browser" page works because it is rendered statically.

Fixes #72
Closes #68 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
