### PR TITLE
Add live model persistence to the frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "3.0.0",
     "eslint-plugin-simple-import-sort": "5.0.2",
+    "firebase": "^7.14.0",
     "hex-alpha": "^1.0.2",
     "husky": "4.2.3",
     "lint-staged": "10.0.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "3.0.0",
     "eslint-plugin-simple-import-sort": "5.0.2",
-    "firebase": "^7.14.0",
+    "firebase": "7.14.0",
     "hex-alpha": "^1.0.2",
     "husky": "4.2.3",
     "lint-staged": "10.0.9",

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -1,0 +1,115 @@
+import * as firebase from "firebase";
+import "firebase/auth";
+import "firebase/database";
+import { pickBy } from "lodash";
+
+import createAuth0Client from "@auth0/auth0-spa-js";
+
+import config from "../auth/auth_config.json";
+import { EpidemicModelUpdate } from '../impact-dashboard/EpidemicModelContext';
+
+// As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
+const tokenExchangeEndpoint =
+  "https://us-central1-c19-backend.cloudfunctions.net/getFirebaseToken";
+const modelInputsCollectionId = "model_inputs";
+
+// Note: None of these are secrets.
+let firebaseConfig = {
+  apiKey: "AIzaSyDbZSkjnfP7mt4W_aDqMKHJizsiQB1yCEw",
+  authDomain: "c19-backend.firebaseapp.com",
+  databaseURL: "https://c19-backend.firebaseio.com",
+  projectId: "c19-backend",
+  storageBucket: "c19-backend.appspot.com",
+  messagingSenderId: "508068404480",
+  appId: "1:508068404480:web:65bfe28b619e1ad572e7e5",
+};
+
+firebase.initializeApp(firebaseConfig);
+
+/**
+ * Silently authenticates the user to Firebase if possible.
+ */
+const authenticate = async () => {
+  // TODO: Error handling.
+  if (firebase.auth().currentUser) return;
+
+  const rekeyedConfig = {
+    domain: config.domain,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    client_id: config.clientId,
+    audience: config.audience,
+  };
+
+  const auth0Token = await (
+    await createAuth0Client(rekeyedConfig)
+  ).getTokenSilently();
+
+  const tokenExchangeResponse = await fetch(tokenExchangeEndpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${auth0Token}`,
+    },
+  });
+
+  const { firebaseToken: customToken } = await tokenExchangeResponse.json();
+
+  await firebase.auth().signInWithCustomToken(customToken);
+};
+
+const getInputModelsDocRef = async () => {
+  await authenticate();
+
+  if (!firebase.auth().currentUser) {
+    throw new Error(
+      "Firebase user unexpectedly not set",
+    );
+  }
+
+  const db = firebase.firestore();
+  return db
+    .collection(modelInputsCollectionId)
+    .doc((firebase.auth().currentUser || {}).uid);
+};
+
+// TODO: Guard against the possibility of autosaves completing out of order.
+export const saveState = async (persistedState: object): Promise<void> => {
+  try {
+    const docRef = await getInputModelsDocRef();
+
+    if (!docRef) return;
+
+    docRef.set({
+      timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+      inputs: {
+        // keys set to undefined aren't useful to store
+        0: pickBy(persistedState, (value) => value !== undefined),
+      },
+    });
+  } catch (error) {
+    console.error("Encountered error while attempting to save:");
+    console.error(error);
+  }
+};
+
+export const getSavedState = async (): Promise<EpidemicModelUpdate> => {
+  try {
+    const docRef = await getInputModelsDocRef();
+
+    if (!docRef) return {};
+
+    const doc = await docRef.get();
+
+    if (!doc.exists) return {};
+
+    const data = doc.data();
+
+    return !data || !data.inputs || !data.inputs[0] ? null : data.inputs[0];
+  } catch (error) {
+    console.error(
+      "Encountered error while attempting to retrieve saved state:",
+    );
+    console.error(error);
+
+    return {};
+  }
+};

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -8,7 +8,7 @@ import { pickBy } from "lodash";
 import createAuth0Client from "@auth0/auth0-spa-js";
 
 import config from "../auth/auth_config.json";
-import { EpidemicModelUpdate } from "../impact-dashboard/EpidemicModelContext";
+import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
 const tokenExchangeEndpoint =
@@ -73,7 +73,7 @@ const getInputModelsDocRef = async () => {
 
 // TODO: Guard against the possibility of autosaves completing out of order.
 export const saveState = async (
-  persistedState: EpidemicModelUpdate,
+  persistedState: EpidemicModelPersistent,
 ): Promise<void> => {
   try {
     const docRef = await getInputModelsDocRef();
@@ -93,15 +93,15 @@ export const saveState = async (
   }
 };
 
-export const getSavedState = async (): Promise<EpidemicModelUpdate> => {
+export const getSavedState = async (): Promise<EpidemicModelPersistent | null> => {
   try {
     const docRef = await getInputModelsDocRef();
 
-    if (!docRef) return {};
+    if (!docRef) return null;
 
     const doc = await docRef.get();
 
-    if (!doc.exists) return {};
+    if (!doc.exists) return null;
 
     const data = doc.data();
 
@@ -112,6 +112,6 @@ export const getSavedState = async (): Promise<EpidemicModelUpdate> => {
     );
     console.error(error);
 
-    return {};
+    return null;
   }
 };

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -1,12 +1,14 @@
-import * as firebase from "firebase";
+// the core Firebase SDK must be imported before other Firebase modules
+// eslint-disable-next-line simple-import-sort/sort
+import * as firebase from "firebase/app";
 import "firebase/auth";
-import "firebase/database";
+import "firebase/firestore";
 import { pickBy } from "lodash";
 
 import createAuth0Client from "@auth0/auth0-spa-js";
 
 import config from "../auth/auth_config.json";
-import { EpidemicModelUpdate } from '../impact-dashboard/EpidemicModelContext';
+import { EpidemicModelUpdate } from "../impact-dashboard/EpidemicModelContext";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
 const tokenExchangeEndpoint =
@@ -15,7 +17,7 @@ const modelInputsCollectionId = "model_inputs";
 
 // Note: None of these are secrets.
 let firebaseConfig = {
-  apiKey: "AIzaSyDbZSkjnfP7mt4W_aDqMKHJizsiQB1yCEw",
+  apiKey: "AIzaSyDdCp7P-oncmuRpMtpxdb5M0nXq6U3qU7A",
   authDomain: "c19-backend.firebaseapp.com",
   databaseURL: "https://c19-backend.firebaseio.com",
   projectId: "c19-backend",
@@ -60,9 +62,7 @@ const getInputModelsDocRef = async () => {
   await authenticate();
 
   if (!firebase.auth().currentUser) {
-    throw new Error(
-      "Firebase user unexpectedly not set",
-    );
+    throw new Error("Firebase user unexpectedly not set");
   }
 
   const db = firebase.firestore();
@@ -72,7 +72,9 @@ const getInputModelsDocRef = async () => {
 };
 
 // TODO: Guard against the possibility of autosaves completing out of order.
-export const saveState = async (persistedState: object): Promise<void> => {
+export const saveState = async (
+  persistedState: EpidemicModelUpdate,
+): Promise<void> => {
   try {
     const docRef = await getInputModelsDocRef();
 

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -218,7 +218,15 @@ function epidemicModelReducer(
 
     case "insert_saved_state":
       // insert any saved data via a separate action to bypass the reset logic in the `update` action
-      return Object.assign({}, state, action.payload);
+      let { stateCode, countyName, countyLevelData } = action.payload;
+      countyLevelData = countyLevelData || state.countyLevelData;
+
+      return Object.assign(
+        {},
+        state,
+        action.payload,
+        stateCode && countyName ? getLocaleData(countyLevelData, stateCode, countyName) : {}
+      );
   }
 }
 

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -91,7 +91,8 @@ interface Metadata extends MetadataUpdate {
   hospitalBeds: number;
 }
 
-type EpidemicModelPersistent = ModelInputsPersistent & MetadataPersistent;
+export type EpidemicModelPersistent = ModelInputsPersistent &
+  MetadataPersistent;
 // we have to type all them out here again
 // but at least we can validate that none are illegal
 // TODO: is there a smarter way to get these values?
@@ -365,7 +366,7 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
             otherParams,
           ) as EpidemicModelUpdate;
           if (size(preexistingState) === 0) {
-            preexistingState = await getSavedState();
+            preexistingState = (await getSavedState()) || {};
           }
 
           // dispatch the saved state last so it's not overwritten in local state


### PR DESCRIPTION
## Description of the change

Updates frontend to autosave model inputs as the user changes them. Per discussion with Andrew, hydrating the state via query parameters will still work and will supersede state saved to Firestore. We also decided it's acceptable that selecting a different state/county will blow away saved state (since local state resets) since this persistence should be updated in a matter of days.

Manual testing performed:

1.  Start with all site storage cleared and no data for user in Firestore
2. Go to the app, without any query params, and sign in
3. Change the state selection and a few population numbers
4. Revisit the app (again, no query params) and verify state retained
5. Copy the full URL (with the state params), modify a param, and load that URL
6. Verify the modified param is respected in the UI
7. Revisit the app (again, no query params) and verify the state set by the modified query param is retained
8. Sign out and sign back in and verify the state is unchanged

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
