### PR TITLE
Change color of "hospital beds" in chart

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -1,3 +1,11 @@
+import { lab } from "d3";
+
+export function darken(color: string, amount: number) {
+  // good to use Lab color because it's perceptually uniform
+  const { l, a, b } = lab(color);
+  return lab(l - amount, a, b).hex();
+}
+
 const Colors = {
   black: "#000",
   green: "#006C67",

--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
+import Colors, { darken } from "../design-system/Colors";
 import CurveChart from "./CurveChartContainer";
 import CurveChartLegend from "./CurveChartLegend";
 
@@ -30,7 +30,7 @@ const ChartArea: React.FC = () => {
     exposed: Colors.green,
     fatalities: Colors.black,
     hospitalized: Colors.lightBlue,
-    hospitalBeds: Colors.red,
+    hospitalBeds: darken(Colors.lightBlue, 20),
     infectious: Colors.red,
   };
   return (


### PR DESCRIPTION
## Description of the change

This changes the color of the hospital beds threshold marker to match the color we use for the "hospitalized" curve. 

The light blue color was a bit rough on the eyes in that small type and dotted line so I tweaked it to a slightly darker shade for better contrast. 

<img width="724" alt="Screen Shot 2020-04-10 at 6 27 59 PM" src="https://user-images.githubusercontent.com/5385319/79032206-88769500-7b59-11ea-84af-56dabf961b10.png">

Fixes #79 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
