### PR TITLE
Add live model persistence to the frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "3.0.0",
     "eslint-plugin-simple-import-sort": "5.0.2",
+    "firebase": "7.14.0",
     "hex-alpha": "^1.0.2",
     "husky": "4.2.3",
     "lint-staged": "10.0.9",

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -82,10 +82,8 @@ export const saveState = async (
 
     docRef.set({
       timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-      inputs: {
-        // keys set to undefined aren't useful to store
-        0: pickBy(persistedState, (value) => value !== undefined),
-      },
+
+      inputs: pickBy(persistedState, (value) => value !== undefined),
     });
   } catch (error) {
     console.error("Encountered error while attempting to save:");
@@ -105,7 +103,7 @@ export const getSavedState = async (): Promise<EpidemicModelPersistent | null> =
 
     const data = doc.data();
 
-    return !data || !data.inputs || !data.inputs[0] ? null : data.inputs[0];
+    return !data || !data.inputs ? null : data.inputs;
   } catch (error) {
     console.error(
       "Encountered error while attempting to retrieve saved state:",

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -3,12 +3,12 @@
 import * as firebase from "firebase/app";
 import "firebase/auth";
 import "firebase/firestore";
-import { mapValues } from "lodash";
 
 import createAuth0Client from "@auth0/auth0-spa-js";
 
 import config from "../auth/auth_config.json";
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+import { prepareForStorage, prepareFromStorage } from "./utils";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
 const tokenExchangeEndpoint =
@@ -82,9 +82,7 @@ export const saveState = async (
 
     docRef.set({
       timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-
-      // `undefined` can't be serialized to JSON and thus can't be stored in Firestore
-      inputs: mapValues(persistedState, (value) => value || null),
+      inputs: prepareForStorage(persistedState),
     });
   } catch (error) {
     console.error("Encountered error while attempting to save:");
@@ -104,7 +102,7 @@ export const getSavedState = async (): Promise<EpidemicModelPersistent | null> =
 
     const data = doc.data();
 
-    return !data || !data.inputs ? null : mapValues(data.inputs, (value) => value || undefined);
+    return !data || !data.inputs ? null : prepareFromStorage(data.inputs);
   } catch (error) {
     console.error(
       "Encountered error while attempting to retrieve saved state:",

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -1,0 +1,117 @@
+// the core Firebase SDK must be imported before other Firebase modules
+// eslint-disable-next-line simple-import-sort/sort
+import * as firebase from "firebase/app";
+import "firebase/auth";
+import "firebase/firestore";
+import { pickBy } from "lodash";
+
+import createAuth0Client from "@auth0/auth0-spa-js";
+
+import config from "../auth/auth_config.json";
+import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+
+// As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
+const tokenExchangeEndpoint =
+  "https://us-central1-c19-backend.cloudfunctions.net/getFirebaseToken";
+const modelInputsCollectionId = "model_inputs";
+
+// Note: None of these are secrets.
+let firebaseConfig = {
+  apiKey: "AIzaSyDdCp7P-oncmuRpMtpxdb5M0nXq6U3qU7A",
+  authDomain: "c19-backend.firebaseapp.com",
+  databaseURL: "https://c19-backend.firebaseio.com",
+  projectId: "c19-backend",
+  storageBucket: "c19-backend.appspot.com",
+  messagingSenderId: "508068404480",
+  appId: "1:508068404480:web:65bfe28b619e1ad572e7e5",
+};
+
+firebase.initializeApp(firebaseConfig);
+
+/**
+ * Silently authenticates the user to Firebase if possible.
+ */
+const authenticate = async () => {
+  // TODO: Error handling.
+  if (firebase.auth().currentUser) return;
+
+  const rekeyedConfig = {
+    domain: config.domain,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    client_id: config.clientId,
+    audience: config.audience,
+  };
+
+  const auth0Token = await (
+    await createAuth0Client(rekeyedConfig)
+  ).getTokenSilently();
+
+  const tokenExchangeResponse = await fetch(tokenExchangeEndpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${auth0Token}`,
+    },
+  });
+
+  const { firebaseToken: customToken } = await tokenExchangeResponse.json();
+
+  await firebase.auth().signInWithCustomToken(customToken);
+};
+
+const getInputModelsDocRef = async () => {
+  await authenticate();
+
+  if (!firebase.auth().currentUser) {
+    throw new Error("Firebase user unexpectedly not set");
+  }
+
+  const db = firebase.firestore();
+  return db
+    .collection(modelInputsCollectionId)
+    .doc((firebase.auth().currentUser || {}).uid);
+};
+
+// TODO: Guard against the possibility of autosaves completing out of order.
+export const saveState = async (
+  persistedState: EpidemicModelPersistent,
+): Promise<void> => {
+  try {
+    const docRef = await getInputModelsDocRef();
+
+    if (!docRef) return;
+
+    docRef.set({
+      timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+      inputs: {
+        // keys set to undefined aren't useful to store
+        0: pickBy(persistedState, (value) => value !== undefined),
+      },
+    });
+  } catch (error) {
+    console.error("Encountered error while attempting to save:");
+    console.error(error);
+  }
+};
+
+export const getSavedState = async (): Promise<EpidemicModelPersistent | null> => {
+  try {
+    const docRef = await getInputModelsDocRef();
+
+    if (!docRef) return null;
+
+    const doc = await docRef.get();
+
+    if (!doc.exists) return null;
+
+    const data = doc.data();
+
+    return !data || !data.inputs || !data.inputs[0] ? null : data.inputs[0];
+  } catch (error) {
+    console.error(
+      "Encountered error while attempting to retrieve saved state:",
+    );
+    console.error(error);
+
+    return null;
+  }
+};

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -3,7 +3,7 @@
 import * as firebase from "firebase/app";
 import "firebase/auth";
 import "firebase/firestore";
-import { pickBy } from "lodash";
+import { mapValues } from "lodash";
 
 import createAuth0Client from "@auth0/auth0-spa-js";
 
@@ -83,7 +83,8 @@ export const saveState = async (
     docRef.set({
       timestamp: firebase.firestore.FieldValue.serverTimestamp(),
 
-      inputs: pickBy(persistedState, (value) => value !== undefined),
+      // `undefined` can't be serialized to JSON and thus can't be stored in Firestore
+      inputs: mapValues(persistedState, (value) => value || null),
     });
   } catch (error) {
     console.error("Encountered error while attempting to save:");
@@ -103,7 +104,7 @@ export const getSavedState = async (): Promise<EpidemicModelPersistent | null> =
 
     const data = doc.data();
 
-    return !data || !data.inputs ? null : data.inputs;
+    return !data || !data.inputs ? null : mapValues(data.inputs, (value) => value || undefined);
   } catch (error) {
     console.error(
       "Encountered error while attempting to retrieve saved state:",

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -1,0 +1,21 @@
+import { mapValues } from "lodash";
+
+import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+
+const undefinedString = "undefined";
+
+export const prepareForStorage = (state: EpidemicModelPersistent): object => {
+  return mapValues(state, (value) => {
+    if (value === undefinedString) {
+      throw new Error(`The string '${undefinedString}' cannot be persisted`);
+    }
+
+    return value === undefined ? undefinedString : value;
+  });
+};
+
+export const prepareFromStorage = (state: object): EpidemicModelPersistent => {
+  return mapValues(state, (value) =>
+    value === undefinedString ? undefined : value,
+  );
+};

--- a/src/hooks/useQueryParams.tsx
+++ b/src/hooks/useQueryParams.tsx
@@ -1,4 +1,4 @@
-import { isEqual as isGenerallyEqual } from "lodash";
+import { isEqual as isGenerallyEqual, mapValues } from "lodash";
 import queryString from "query-string";
 import { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
@@ -29,6 +29,16 @@ function isEqual(
   });
 }
 
+const stringify = (values) => {
+  // `undefined` keys would not be included in the query string
+  return queryString.stringify(mapValues(values, (value) => value || null));
+};
+
+const parse = (searchString) => {
+  // `undefined` keys are stringified as `null`
+  return mapValues(queryString.parse(searchString), (value) => value || undefined);
+};
+
 // A basic hook for fetching query param values and setting query param values
 // Optionally pass in an array of valid keys if you want to be strict about your set of query parameters
 const useQueryParams = (
@@ -37,7 +47,7 @@ const useQueryParams = (
 ): UseQueryParamsOutput => {
   const history = useHistory();
 
-  const defaultQueryParams = queryString.parse(
+  const defaultQueryParams = parse(
     history.location.search,
   ) as QueryParams;
   const hasExistingURLQueryParams = Object.keys(defaultQueryParams).length > 0;
@@ -50,14 +60,14 @@ const useQueryParams = (
 
   // If values have been updated, also set the query params
   useEffect(() => {
-    const currentQuery = queryString.parse(
+    const currentQuery = parse(
       history.location.search,
     ) as QueryParams;
 
     if (!isEqual(currentQuery, values, validKeys)) {
       const newLocation = {
         ...history.location,
-        search: queryString.stringify(values),
+        search: stringify(values),
       };
       if (action == "replace") {
         history.replace(newLocation);
@@ -70,7 +80,7 @@ const useQueryParams = (
 
   // If the query params in the url changes, also set the values
   useEffect(() => {
-    const nextValues = queryString.parse(location.search) as QueryParams;
+    const nextValues = parse(location.search) as QueryParams;
 
     if (!isEqual(values, nextValues, validKeys)) {
       setValues(nextValues);

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -1,9 +1,10 @@
 import { csvParse, DSVRowAny } from "d3";
 import { rollup } from "d3-array";
-import { mapValues, pick } from "lodash";
+import { mapValues, pick, size } from "lodash";
 import numeral from "numeral";
 import React, { useEffect } from "react";
 
+import { getSavedState, saveState } from "../database";
 import useQueryParams, { QueryParams } from "../hooks/useQueryParams";
 
 type CountyLevelRecord = {
@@ -16,7 +17,10 @@ type CountyLevelRecord = {
 
 type CountyLevelData = Map<string, Map<string, CountyLevelRecord>>;
 
-type Action = { type: "update"; payload: EpidemicModelUpdate };
+type Action = {
+  type: "update" | "insert_saved_state";
+  payload: EpidemicModelUpdate;
+};
 type Dispatch = (action: Action) => void;
 
 export enum RateOfSpread {
@@ -77,6 +81,7 @@ interface MetadataUpdate extends MetadataPersistent {
   countyLevelData?: CountyLevelData;
   countyLevelDataLoading?: boolean;
   countyLevelDataFailed?: boolean;
+  stateInitialized?: boolean;
   // this is not user input so don't store it
   hospitalBeds?: number;
 }
@@ -86,11 +91,12 @@ interface Metadata extends MetadataUpdate {
   hospitalBeds: number;
 }
 
-type EpidemicModelPersistent = ModelInputsPersistent & MetadataPersistent;
+export type EpidemicModelPersistent = ModelInputsPersistent &
+  MetadataPersistent;
 // we have to type all them out here again
 // but at least we can validate that none are illegal
 // TODO: is there a smarter way to get these values?
-export const urlParamKeys: Array<keyof EpidemicModelPersistent> = [
+export const persistedKeys: Array<keyof EpidemicModelPersistent> = [
   "countyName",
   "facilityName",
   "stateCode",
@@ -180,6 +186,8 @@ function epidemicModelReducer(
   state: EpidemicModelState,
   action: Action,
 ): EpidemicModelState {
+  let stateCode, countyName, countyLevelData;
+
   switch (action.type) {
     case "update":
       // the desired user flow is to fill out a form, review the entries,
@@ -189,9 +197,13 @@ function epidemicModelReducer(
 
       // change in state or county triggers a bigger reset
       let updates = { ...action.payload };
-      let { stateCode, countyName, countyLevelData } = updates;
+
+      ({ stateCode, countyName, countyLevelData } = updates);
 
       countyLevelData = countyLevelData || state.countyLevelData;
+      const stateInitialized =
+        updates.stateInitialized || state.stateInitialized;
+
       if (countyLevelData) {
         if (stateCode) {
           countyName = countyName || "Total";
@@ -202,15 +214,31 @@ function epidemicModelReducer(
           return Object.assign(
             getResetBase(stateCode, countyName),
             getLocaleData(countyLevelData, stateCode, countyName),
+            { stateInitialized },
           );
         }
       }
-      return Object.assign({}, state, updates);
+
+      return Object.assign({}, state, updates, { stateInitialized });
+
+    case "insert_saved_state":
+      // insert any saved data via a separate action to bypass the reset logic in the `update` action
+      ({ stateCode, countyName, countyLevelData } = action.payload);
+      countyLevelData = countyLevelData || state.countyLevelData;
+
+      return Object.assign(
+        {},
+        state,
+        action.payload,
+        countyLevelData && stateCode && countyName
+          ? getLocaleData(countyLevelData, stateCode, countyName)
+          : {},
+      );
   }
 }
 
 function sanitizeQueryParams(rawQueryParams: QueryParams) {
-  return mapValues(pick(rawQueryParams, urlParamKeys), (value) => {
+  return mapValues(pick(rawQueryParams, persistedKeys), (value) => {
     // most of these are numbers but some are strings
     const n = numeral(value).value();
     return n != null ? n : value?.toString();
@@ -237,7 +265,11 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
       if (state.countyLevelDataLoading) {
         return;
       }
-      replaceHistoryState(pick(state, urlParamKeys));
+
+      const persistedState = pick(state, persistedKeys);
+      replaceHistoryState(persistedState);
+
+      if (state.stateInitialized) saveState(persistedState);
     },
     // replaceHistoryState changes on every render so must be excluded
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -328,9 +360,26 @@ function EpidemicModelProvider({ children }: EpidemicModelProviderProps) {
               ),
             },
           });
+
+          // state in query params supersedes state in the database
+          let preexistingState = sanitizeQueryParams(
+            otherParams,
+          ) as EpidemicModelUpdate;
+          if (size(preexistingState) === 0) {
+            preexistingState = (await getSavedState()) || {};
+          }
+
+          // dispatch the saved state last so it's not overwritten in local state
+          if (preexistingState) {
+            dispatch({
+              type: "insert_saved_state",
+              payload: preexistingState,
+            });
+          }
+
           dispatch({
             type: "update",
-            payload: sanitizeQueryParams(otherParams) as EpidemicModelUpdate,
+            payload: { stateInitialized: true },
           });
         } catch (error) {
           console.error(error);

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -220,6 +220,8 @@ function epidemicModelReducer(
 
 function sanitizeQueryParams(rawQueryParams: QueryParams) {
   return mapValues(pick(rawQueryParams, persistedKeys), (value) => {
+    if (value === undefined) return value;
+
     // most of these are numbers but some are strings
     const n = numeral(value).value();
     return n != null ? n : value?.toString();


### PR DESCRIPTION
## Description of the change

(Builds on unmerged PR https://github.com/Recidiviz/covid19-dashboard/pull/85.)

Updates frontend to autosave model inputs as the user changes them. Per discussion with Andrew, hydrating the state via query parameters will still work and will supersede state saved to Firestore. We also decided it's acceptable that selecting a different state/county will blow away saved state (since local state resets) since this persistence should be updated in a matter of days.

Manual testing performed:

1.  Start with all site storage cleared and no data for user in Firestore
2. Go to the app, without any query params, and sign in
3. Change the state selection and a few population numbers
4. Revisit the app (again, no query params) and verify state retained
5. Copy the full URL (with the state params), modify a param, and load that URL
6. Verify the modified param is respected in the UI
7. Revisit the app (again, no query params) and verify the state set by the modified query param is retained
8. Sign out and sign back in and verify the state is unchanged

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #71

Closes #91

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
