### PR TITLE
Include current day in projection output

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -110,7 +110,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   days,
   parentLine: { title },
 }) => {
-  const displayDate = add(new Date(), { days: days - 1 });
+  const displayDate = add(new Date(), { days });
 
   return (
     <TooltipContainer>
@@ -144,7 +144,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
       key: bucket,
       coordinates: values.map((count, index) => ({
         count,
-        days: index + 1,
+        days: index,
       })),
     })),
     lineType: { type: "area", interpolator: curveCatmullRom },

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -18,9 +18,9 @@ function buildTableRowFromCurves(
   calculator: Function,
 ): TableRow {
   const [week1, week2, week3, overall] = [
-    6,
-    13,
-    20,
+    7,
+    14,
+    21,
     data.shape[0] - 1,
   ].map((day) => calculator(data, day));
 

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -201,6 +201,19 @@ enum R0Dorms {
   high = 7,
 }
 
+function getTotalsBreakdown(singleDay: ndarray) {
+  const currentDayIncarceratedProjections = [];
+  const currentDayStaffProjections = [];
+  // sum up each column to get the total daily projection for each SEIR bucket
+  for (let colIndex = 0; colIndex < singleDay.shape[1]; colIndex++) {
+    const incarceratedValues = getAllValues(getColView(singleDay, colIndex));
+    const [staffCount] = incarceratedValues.splice(ageGroupIndex.staff, 1);
+    currentDayIncarceratedProjections.push(sum(incarceratedValues));
+    currentDayStaffProjections.push(staffCount);
+  }
+  return { currentDayIncarceratedProjections, currentDayStaffProjections };
+}
+
 function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
   let {
     ageGroupInitiallyInfected,
@@ -257,8 +270,8 @@ function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
     },
   );
 
-  // index expected population adjustments by day
-  // we currently don't include today so index everything relative to tomorrow
+  // index expected population adjustments by day;
+  // start with tomorrow since these are future releases
   const tomorrow = addDays(Date.now(), 1);
   const expectedPopulationChanges = Array(numDays).fill(0);
   plannedReleases?.forEach(({ date, count }) => {
@@ -271,12 +284,19 @@ function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
       expectedPopulationChanges[dateIndex] -= count;
     }
   });
-  const dailyIncarceratedProjections = [];
-  const dailyStaffProjections = [];
+
+  // initialize the projections with today's data
+  const {
+    currentDayIncarceratedProjections: initialIncarceratedProjections,
+    currentDayStaffProjections: initialStaffProjections,
+  } = getTotalsBreakdown(singleDayState);
+
+  const dailyIncarceratedProjections = [...initialIncarceratedProjections];
+  const dailyStaffProjections = [...initialStaffProjections];
+
   let day = 0;
-  while (day < numDays) {
-    const currentDayIncarceratedProjections = [];
-    const currentDayStaffProjections = [];
+  // we've already included today so knock one off
+  while (day < numDays - 1) {
     // each day's projection needs the sum of all infectious projections so far
     const totalInfectious = sum(
       getAllValues(getColView(singleDayState, seirIndex.infectious)),
@@ -304,15 +324,10 @@ function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
       setRowValues(singleDayState, ageGroup, projectionForAgeGroup);
     });
 
-    // sum up each column to get the total daily projection for each SEIR bucket
-    for (let colIndex = 0; colIndex < singleDayState.shape[1]; colIndex++) {
-      const incarceratedValues = getAllValues(
-        getColView(singleDayState, colIndex),
-      );
-      const [staffCount] = incarceratedValues.splice(ageGroupIndex.staff, 1);
-      currentDayIncarceratedProjections.push(sum(incarceratedValues));
-      currentDayStaffProjections.push(staffCount);
-    }
+    const {
+      currentDayIncarceratedProjections,
+      currentDayStaffProjections,
+    } = getTotalsBreakdown(singleDayState);
 
     // push this day's data to a flat list of daily projections,
     // which we will build a new matrix from

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -295,8 +295,7 @@ function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
   const dailyStaffProjections = [...initialStaffProjections];
 
   let day = 0;
-  // we've already included today so knock one off
-  while (day < numDays - 1) {
+  while (day < numDays) {
     // each day's projection needs the sum of all infectious projections so far
     const totalInfectious = sum(
       getAllValues(getColView(singleDayState, seirIndex.infectious)),
@@ -343,10 +342,10 @@ function getCurveProjections(inputs: SimulationInputs & CurveProjectionInputs) {
   // this will produce a matrix with row = day and col = SEIR bucket
   return {
     incarcerated: ndarray(dailyIncarceratedProjections, [
-      numDays,
+      numDays + 1,
       seirIndex.__length,
     ]),
-    staff: ndarray(dailyStaffProjections, [numDays, seirIndex.__length]),
+    staff: ndarray(dailyStaffProjections, [numDays + 1, seirIndex.__length]),
   };
 }
 


### PR DESCRIPTION
## Description of the change

This includes the current day as day zero in all model projections and hopefully eliminates the need for confusing off-by-one adjustments in the UI; consumers of the `getCurveProjections` function output can now always safely assume that the index of a day's data is equal to the number of days from the current day. I updated both the chart and the table to remove any such adjustments.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #83 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
