### PR TITLE
Add R0 selector to input forms

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -8,11 +8,12 @@ export function darken(color: string, amount: number) {
 
 const Colors = {
   black: "#000",
-  green: "#006C67",
   forest: "#005450",
+  gray: "#E0E4E4",
+  green: "#006C67",
   lightBlue: "#33B6FF",
+  paleGreen: "#D2DBDB",
   red: "#FF464A",
-  grey: "#D2DBDB",
 };
 
 export default Colors;

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import Colors from "./Colors";
+
 export interface InputLabelProps {
   labelAbove?: string;
   labelHelp?: string;
@@ -38,17 +40,15 @@ export function useInputValue<T>(props: InputValueProps<T>) {
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;
 
 export const StyledInput = styled.input`
-  background: #e0e4e4;
+  background: ${Colors.gray};
   border-radius: 2px;
   border: none;
   box-shadow: none;
   box-sizing: border-box;
-  color: #00413e;
+  color: ${Colors.forest};
   flex: 1 1 auto;
-  font-family: "Rubik", sans-serif;
-  font-size: 16px;
+  font: 16px/1.2 "Rubik", sans-serif;
   height: 48px;
-  line-height: 1.2;
   margin-top: 8px;
   outline: 0 solid transparent;
   padding: 0 16px;

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import styled from "styled-components";
 
 export interface InputLabelProps {
   labelAbove?: string;
@@ -35,3 +36,21 @@ export function useInputValue<T>(props: InputValueProps<T>) {
 }
 
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;
+
+export const StyledInput = styled.input`
+  background: #e0e4e4;
+  border-radius: 2px;
+  border: none;
+  box-shadow: none;
+  box-sizing: border-box;
+  color: #00413e;
+  flex: 1 1 auto;
+  font-family: "Rubik", sans-serif;
+  font-size: 16px;
+  height: 48px;
+  line-height: 1.2;
+  margin-top: 8px;
+  outline: 0 solid transparent;
+  padding: 0 16px;
+  width: 100%;
+`;

--- a/src/design-system/InputDate.tsx
+++ b/src/design-system/InputDate.tsx
@@ -43,7 +43,7 @@ const InputContainer = styled.div`
         &:enabled {
           &:hover,
           &:focus {
-            background: ${hexAlpha(Colors.grey, 0.5)};
+            background: ${hexAlpha(Colors.paleGreen, 0.5)};
           }
         }
       }
@@ -51,7 +51,7 @@ const InputContainer = styled.div`
 
     &__tile {
       &:hover {
-        background: ${hexAlpha(Colors.grey, 0.5)};
+        background: ${hexAlpha(Colors.paleGreen, 0.5)};
       }
       &--hasActive {
         background: ${hexAlpha(Colors.green, 0.3)};

--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
+import { StyledInput } from "./Input";
 import TextLabel from "./TextLabel";
 
 interface Props {
@@ -20,32 +21,24 @@ const SelectContainer = styled.div`
   margin-right: 8px;
 `;
 
-const SelectInput = styled.select`
+const StyledSelect = styled(StyledInput)`
   -webkit-appearance: none;
   -moz-appearance: none;
-  width: 100%;
-  border: none;
-  padding: 18px;
-  background: #e0e4e4;
-  outline: 0 solid transparent;
-  margin-top: 8px;
-  border-radius: 2px;
-  font-size: 16px;
-  color: #00413e;
 `;
 
 const InputSelect: React.FC<Props> = (props) => {
   return (
     <SelectContainer>
       <TextLabel>{props.label}</TextLabel>
-      <SelectInput
+      <StyledSelect
+        as="select"
         disabled={props.disabled}
         onChange={props.onChange}
         value={props.value}
         name={props.label}
       >
         {props.children}
-      </SelectInput>
+      </StyledSelect>
     </SelectContainer>
   );
 };

--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
+import Colors from "./Colors";
 import { StyledInput } from "./Input";
 import TextLabel from "./TextLabel";
 
@@ -21,24 +22,46 @@ const SelectContainer = styled.div`
   margin-right: 8px;
 `;
 
+const caretSize = 5;
+const SelectWrapper = styled.div`
+  position: relative;
+
+  &::after {
+    border-left: ${caretSize}px solid transparent;
+    border-right: ${caretSize}px solid transparent;
+    border-top: ${caretSize}px solid ${Colors.forest};
+    content: "";
+    display: inline-block;
+    height: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 8px;
+    top: calc(50% + ${caretSize / 2}px);
+    width: 0;
+  }
+`;
+
 const StyledSelect = styled(StyledInput)`
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  appearance: none;
+  padding-right: ${caretSize * 2 + 16}px;
+  text-overflow: ellipsis;
 `;
 
 const InputSelect: React.FC<Props> = (props) => {
   return (
     <SelectContainer>
       <TextLabel>{props.label}</TextLabel>
-      <StyledSelect
-        as="select"
-        disabled={props.disabled}
-        onChange={props.onChange}
-        value={props.value}
-        name={props.label}
-      >
-        {props.children}
-      </StyledSelect>
+      <SelectWrapper>
+        <StyledSelect
+          as="select"
+          disabled={props.disabled}
+          onChange={props.onChange}
+          value={props.value}
+          name={props.label}
+        >
+          {props.children}
+        </StyledSelect>
+      </SelectWrapper>
     </SelectContainer>
   );
 };

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -1,23 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import { InputBaseProps, useInputValue } from "./Input";
+import { InputBaseProps, StyledInput, useInputValue } from "./Input";
 import InputLabelAndHelp from "./InputLabelAndHelp";
-
-const Input = styled.input`
-  padding: 16px;
-  background: #e0e4e4;
-  outline: 0 solid transparent;
-  box-shadow: none;
-  border: none;
-  font-size: 16px;
-  border-radius: 2px;
-  font-family: "Rubik", sans-serif;
-  color: #00413e;
-  margin-top: 8px;
-  flex: 1 1 auto;
-  width: 100%;
-`;
 
 const TextInputContainer = styled.div`
   display: flex;
@@ -40,7 +25,7 @@ const InputText: React.FC<Props> = (props) => {
     <TextInputContainer>
       <InputLabelAndHelp label={props.labelAbove} labelHelp={props.labelHelp} />
       <VDiv>
-        <Input
+        <StyledInput
           type={props.type}
           value={inputValue ?? ""}
           placeholder={props.valuePlaceholder ?? props.labelPlaceholder}

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -25,6 +25,7 @@ const SubsectionHeader = styled.header`
   font-weight: 600;
   font-size: 14px;
   line-height: 16px;
+  margin-bottom: 12px;
 `;
 
 /* Charts */

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -8,7 +8,7 @@ import ImpactProjectionTable from "./ImpactProjectionTableContainer";
 import LocaleInformation from "./LocaleInformation";
 import MitigationInformation from "./MitigationInformation";
 
-const borderStyle = `1px solid ${Colors.grey}`;
+const borderStyle = `1px solid ${Colors.paleGreen}`;
 
 const SectionHeader = styled.header`
   font-family: Poppins;

--- a/src/impact-dashboard/MitigationInformation.tsx
+++ b/src/impact-dashboard/MitigationInformation.tsx
@@ -24,7 +24,7 @@ type RowProps = PlannedRelease & {
   updateRelease: (opts: ReleaseUpdate) => void;
 };
 
-const rateOfSpreadDisplayText = {
+const rateOfSpreadDisplayText: { [key in RateOfSpread]: string } = {
   low:
     "Low – we've reduced unnecessary interpersonal contact and quarantined at-risk groups",
   moderate:

--- a/src/impact-dashboard/MitigationInformation.tsx
+++ b/src/impact-dashboard/MitigationInformation.tsx
@@ -3,9 +3,14 @@ import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
 import InputDate from "../design-system/InputDate";
+import InputSelect from "../design-system/InputSelect";
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import Description from "./Description";
-import { PlannedRelease, PlannedReleases } from "./EpidemicModelContext";
+import {
+  PlannedRelease,
+  PlannedReleases,
+  RateOfSpread,
+} from "./EpidemicModelContext";
 import { FormGrid, FormGridCell, FormGridRow } from "./FormGrid";
 import useModel from "./useModel";
 
@@ -17,6 +22,14 @@ type ReleaseUpdate = {
 type RowProps = PlannedRelease & {
   index: number;
   updateRelease: (opts: ReleaseUpdate) => void;
+};
+
+const rateOfSpreadDisplayText = {
+  low:
+    "Low – we've reduced unnecessary interpersonal contact and quarantined at-risk groups",
+  moderate:
+    "Moderate – we've taken some steps to reduce contact but are still working on others",
+  high: "High – we've taken very few steps to reduce contact",
 };
 
 const Container = styled.div`
@@ -36,7 +49,12 @@ const ButtonAdd = styled.button`
   padding: 8px 16px;
 `;
 
-const Row: React.FC<RowProps> = ({ date, count, index, updateRelease }) => (
+const ReleaseRow: React.FC<RowProps> = ({
+  date,
+  count,
+  index,
+  updateRelease,
+}) => (
   <FormGridRow>
     <FormGridCell width={50}>
       <InputDate
@@ -72,7 +90,10 @@ const Row: React.FC<RowProps> = ({ date, count, index, updateRelease }) => (
 );
 
 const MitigationInformation: React.FC = () => {
-  const [{ plannedReleases = [{}] }, updateModel] = useModel();
+  const [
+    { plannedReleases = [{}], rateOfSpreadFactor },
+    updateModel,
+  ] = useModel();
   // all updates should be happen on this mutable copy,
   // which will replace the model state after user input
   const mutableReleases = cloneDeep(plannedReleases);
@@ -98,12 +119,37 @@ const MitigationInformation: React.FC = () => {
   return (
     <Container>
       <Description>
+        Select the most likely rate of spread. This will change the R0 (rate of
+        spread) in the model.
+      </Description>
+      <FormGrid>
+        <FormGridRow>
+          <FormGridCell>
+            <InputSelect
+              label="Rate of spread"
+              onChange={(e) =>
+                updateModel({
+                  rateOfSpreadFactor: e.target.value as RateOfSpread,
+                })
+              }
+              value={rateOfSpreadFactor}
+            >
+              {Object.values(RateOfSpread).map((val) => (
+                <option key={val} value={val}>
+                  {rateOfSpreadDisplayText[val]}
+                </option>
+              ))}
+            </InputSelect>
+          </FormGridCell>
+        </FormGridRow>
+      </FormGrid>
+      <Description>
         Enter planned reductions in the in-facility population (e.g., early
         releases to supervision).
       </Description>
       <FormGrid>
         {mutableReleases?.map(({ date, count }, index) => (
-          <Row
+          <ReleaseRow
             key={index}
             date={date}
             count={count}


### PR DESCRIPTION
## Description of the change

This adds a dropdown for the user to input a rate of spread factor. The model calculations already accept this value, it just never quite made it into the UI, so no calc updates were required. 

<img width="526" alt="Screen Shot 2020-04-13 at 6 08 41 PM" src="https://user-images.githubusercontent.com/5385319/79175332-498f4c00-7db2-11ea-8202-d9263fbc926c.png">

In the process I also made some style tweaks to the input elements for consistency, most notably adding a caret to `InputSelect` as a visual indicator that it's a dropown.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #95 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
