### PR TITLE
Add Modal components for MultiFacilityPage

### DIFF
--- a/src/@types/svg.d.ts
+++ b/src/@types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}

--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -13,10 +13,13 @@ const Colors = {
   teal: "#25b894",
   darkTeal: "#759f9e",
   gray: "#E0E4E4",
+  darkGray: "#c8d3d3",
   green: "#006C67",
+  darkGreen: "#00413E",
   lightBlue: "#33B6FF",
   paleGreen: "#D2DBDB",
   red: "#FF464A",
+  white: "#ffffff",
 };
 
 export default Colors;

--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -8,8 +8,7 @@ const StyledButton = styled.button<Props>`
   color: white;
   font-family: "Poppins", sans-serif;
   height: 48px;
-  width: ${(props) =>
-    props.styles && props.styles.width ? props.styles.width : "200px"};
+  width: ${(props) => props.styles?.width || "200px"};
   outline: none;
 `;
 

--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -1,20 +1,16 @@
 import React from "react";
-import styled, { InterpolationFunction } from "styled-components";
+import styled from "styled-components";
 
-interface StyleProps {
-  styles: React.CSSProperties;
-}
-
-const StyledButton = styled.button<StyleProps>`
+const StyledButton = styled.button<Props>`
   background: #00615c;
   font-size: 16px;
   border-radius: 12px;
   color: white;
   font-family: "Poppins", sans-serif;
   height: 48px;
-  width: 200px;
+  width: ${(props) =>
+    props.styles && props.styles.width ? props.styles.width : "200px"};
   outline: none;
-  ${(props: StyleProps) => props.styles as InterpolationFunction<StyleProps>};
 `;
 
 interface Props {
@@ -25,7 +21,7 @@ interface Props {
 
 const InputButton: React.FC<Props> = (props) => {
   return (
-    <StyledButton styles={props.styles || {}} onClick={props.onClick}>
+    <StyledButton styles={props.styles} onClick={props.onClick}>
       {props.label}
     </StyledButton>
   );

--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { InterpolationFunction } from "styled-components";
 
-const StyledButton = styled.button`
+interface StyleProps {
+  styles: React.CSSProperties;
+}
+
+const StyledButton = styled.button<StyleProps>`
   background: #00615c;
   font-size: 16px;
   border-radius: 12px;
@@ -10,15 +14,21 @@ const StyledButton = styled.button`
   height: 48px;
   width: 200px;
   outline: none;
+  ${(props: StyleProps) => props.styles as InterpolationFunction<StyleProps>};
 `;
 
 interface Props {
   label?: string;
-  onChange?: (e: React.ChangeEvent) => void;
+  styles?: React.CSSProperties;
+  onClick?: (e: React.MouseEvent) => void;
 }
 
 const InputButton: React.FC<Props> = (props) => {
-  return <StyledButton>{props.label}</StyledButton>;
+  return (
+    <StyledButton styles={props.styles || {}} onClick={props.onClick}>
+      {props.label}
+    </StyledButton>
+  );
 };
 
 export default InputButton;

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -31,7 +31,7 @@ const Modal: React.FC<Props> = (props) => {
       <ModalDialog
         title={modalTitle}
         open={open}
-        onClick={() => setOpen(false)}
+        closeModal={() => setOpen(false)}
       >
         {children}
       </ModalDialog>

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import Colors from "./Colors";
 import ModalDialog from "./ModalDialog";
+import { TitleProps } from "./ModalTitle";
 
 const ModalContainer = styled.div``;
 
@@ -16,7 +17,7 @@ const ModalTrigger = styled.button`
 `;
 
 interface Props {
-  modalTitle?: string;
+  modalTitle?: TitleProps["title"];
   trigger?: string | React.ReactElement<any>;
   children?: any;
 }

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -6,7 +6,7 @@ import ModalDialog from "./ModalDialog";
 
 const ModalContainer = styled.div``;
 
-const ModalTrigger = styled.h1`
+const ModalTrigger = styled.button`
   color: ${Colors.green};
   cursor: pointer;
   font-family: 'Libre Baskerville', serif;

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -6,10 +6,13 @@ import ModalDialog from "./ModalDialog";
 
 const ModalContainer = styled.div``;
 
-const ModalTrigger = styled.div`
+const ModalTrigger = styled.h1`
   color: ${Colors.green};
   cursor: pointer;
-  font-size: 14px;
+  font-family: 'Libre Baskerville', serif;
+  font-size: 32px;
+  line-height: 32px
+  letter-spacing: -0.03em
 `;
 
 interface Props {

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -15,7 +15,7 @@ const ModalTrigger = styled.div`
 interface Props {
   modalTitle?: string;
   trigger?: string | React.ReactElement<any>;
-  children?: React.ReactElement<any>;
+  children?: any;
 }
 
 const Modal: React.FC<Props> = (props) => {
@@ -28,7 +28,7 @@ const Modal: React.FC<Props> = (props) => {
       <ModalDialog
         title={modalTitle}
         open={open}
-        onClose={() => setOpen(false)}
+        onClick={() => setOpen(false)}
       >
         {children}
       </ModalDialog>

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import Colors from "./Colors";
+import ModalDialog from "./ModalDialog";
+
+const ModalContainer = styled.div``;
+
+const ModalTrigger = styled.div`
+  color: ${Colors.green};
+  cursor: pointer;
+  font-size: 14px;
+`;
+
+interface Props {
+  modalTitle?: string;
+  trigger?: string | React.ReactElement<any>;
+  children?: React.ReactElement<any>;
+}
+
+const Modal: React.FC<Props> = (props) => {
+  const [open, setOpen] = useState(false);
+  const { trigger, modalTitle, children } = props;
+
+  return (
+    <ModalContainer>
+      <ModalTrigger onClick={() => setOpen(true)}>{trigger}</ModalTrigger>
+      <ModalDialog
+        title={modalTitle}
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        {children}
+      </ModalDialog>
+    </ModalContainer>
+  );
+};
+
+export default Modal;

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import styled from "styled-components";
+
+import Colors from "./Colors";
+import closeIcon from "./icons/ic_close.svg";
+
+const BackgroundAside = styled.aside`
+  align-items: center;
+  background-color: rgb(214, 215, 215, 0.8);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  width: 100%;
+`;
+
+const ModalContainer = styled.div`
+  align-self: center;
+  background-color: ${Colors.slate};
+  border-radius: 5px;
+  height: 90vh;
+  width: 65vw;
+  padding: 35px;
+  position: static;
+`;
+
+const ModalTitleContainer = styled.div`
+  border-bottom: 0.5px solid #c8d3d3;
+  display: inline-block;
+  font-size: 14px;
+  font-family: "Poppins", sans-serif;
+  padding-bottom: 20px;
+  width: 100%;
+`;
+
+const CloseButtonImg = styled.img`
+  display: inline-block;
+  height: 20px;
+  padding: 0 1em;
+  float: right;
+`;
+
+interface Props {
+  title?: string;
+  open?: boolean;
+  onClose?: (e: React.MouseEvent<HTMLElement>) => void;
+  children?: React.ReactElement<any>;
+}
+
+const ModalDialog: React.FC<Props> = (props) => {
+  const { title, open, onClose, children } = props;
+
+  if (!open) return null;
+
+  return ReactDOM.createPortal(
+    <BackgroundAside onClick={onClose}>
+      <ModalContainer>
+        <ModalTitleContainer>
+          {title}
+          <CloseButtonImg
+            onClick={onClose}
+            src={closeIcon}
+            alt="close button"
+            role="button"
+          />
+        </ModalTitleContainer>
+        {children}
+      </ModalContainer>
+    </BackgroundAside>,
+    document.getElementById("app") as HTMLElement,
+  );
+};
+
+export default ModalDialog;

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import closeIcon from "./icons/ic_close.svg";
+import ModalTitle, { TitleProps } from "./ModalTitle";
 
 const BackgroundAside = styled.aside`
   align-items: center;
@@ -28,14 +28,6 @@ const ModalContainer = styled.div`
   position: static;
 `;
 
-const ModalTitleContainer = styled.div`
-  display: inline-block;
-  font-size: 14px;
-  font-family: "Poppins", sans-serif;
-  padding-bottom: 20px;
-  width: 100%;
-`;
-
 const ModalContentContainer = styled.div`
   align-items: flex-end;
   border-top: 0.5px solid ${Colors.darkGray};
@@ -43,25 +35,14 @@ const ModalContentContainer = styled.div`
   flex: 1 1;
 `;
 
-const CloseButtonImg = styled.img`
-  display: inline-block;
-  height: 20px;
-  padding: 0 1em;
-  float: right;
-`;
-
 interface Props {
   numSteps?: number;
-  title?: string;
+  title?: TitleProps["title"];
   open?: boolean;
   closeModal: (e: React.MouseEvent<HTMLElement>) => void;
   children?: React.ReactElement<any>;
 }
 
-interface TitleProps {
-  title?: string;
-  closeModal: (e: React.MouseEvent<HTMLElement>) => void;
-}
 const isOutsideModal = (
   event: React.MouseEvent<HTMLElement>,
   element: HTMLDivElement | null,
@@ -69,21 +50,6 @@ const isOutsideModal = (
   event.target instanceof HTMLElement &&
   element &&
   !element.contains(event.target);
-
-export const ModalTitle: React.FC<TitleProps> = (props) => {
-  const { title, closeModal } = props;
-  return (
-    <ModalTitleContainer>
-      {title}
-      <CloseButtonImg
-        onClick={closeModal}
-        src={closeIcon}
-        alt="close button"
-        role="button"
-      />
-    </ModalTitleContainer>
-  );
-};
 
 const ModalDialog: React.FC<Props> = (props) => {
   const { title, open, closeModal, children } = props;

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -37,7 +37,9 @@ const ModalTitleContainer = styled.div`
 `;
 
 const ModalContentContainer = styled.div`
+  align-items: flex-end;
   border-top: 0.5px solid ${Colors.darkGray};
+  display: flex;
   flex: 1 1;
 `;
 
@@ -56,6 +58,10 @@ interface Props {
   children?: React.ReactElement<any>;
 }
 
+interface TitleProps {
+  title?: string;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+}
 const isOutsideModal = (
   event: React.MouseEvent<HTMLElement>,
   element: HTMLDivElement | null,
@@ -63,6 +69,21 @@ const isOutsideModal = (
   event.target instanceof HTMLElement &&
   element &&
   !element.contains(event.target);
+
+export const ModalTitle: React.FC<TitleProps> = (props) => {
+  const { title, onClick } = props;
+  return (
+    <ModalTitleContainer>
+      {title}
+      <CloseButtonImg
+        onClick={onClick}
+        src={closeIcon}
+        alt="close button"
+        role="button"
+      />
+    </ModalTitleContainer>
+  );
+};
 
 const ModalDialog: React.FC<Props> = (props) => {
   const { title, open, onClick, children } = props;
@@ -79,15 +100,7 @@ const ModalDialog: React.FC<Props> = (props) => {
   return ReactDOM.createPortal(
     <BackgroundAside onClick={handleOnClick}>
       <ModalContainer ref={ref}>
-        <ModalTitleContainer>
-          {title}
-          <CloseButtonImg
-            onClick={onClick}
-            src={closeIcon}
-            alt="close button"
-            role="button"
-          />
-        </ModalTitleContainer>
+        <ModalTitle title={title} onClick={onClick} />
         <ModalContentContainer>{children}</ModalContentContainer>
       </ModalContainer>
     </BackgroundAside>,

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 
@@ -20,6 +20,8 @@ const ModalContainer = styled.div`
   align-self: center;
   background-color: ${Colors.slate};
   border-radius: 5px;
+  display: flex;
+  flex-direction: column;
   height: 90vh;
   width: 65vw;
   padding: 35px;
@@ -27,12 +29,16 @@ const ModalContainer = styled.div`
 `;
 
 const ModalTitleContainer = styled.div`
-  border-bottom: 0.5px solid #c8d3d3;
   display: inline-block;
   font-size: 14px;
   font-family: "Poppins", sans-serif;
   padding-bottom: 20px;
   width: 100%;
+`;
+
+const ModalContentContainer = styled.div`
+  border-top: 0.5px solid ${Colors.darkGray};
+  flex: 1 1;
 `;
 
 const CloseButtonImg = styled.img`
@@ -43,30 +49,46 @@ const CloseButtonImg = styled.img`
 `;
 
 interface Props {
+  numSteps?: number;
   title?: string;
   open?: boolean;
-  onClose?: (e: React.MouseEvent<HTMLElement>) => void;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
   children?: React.ReactElement<any>;
 }
 
+const isOutsideModal = (
+  event: React.MouseEvent<HTMLElement>,
+  element: HTMLDivElement | null,
+) =>
+  event.target instanceof HTMLElement &&
+  element &&
+  !element.contains(event.target);
+
 const ModalDialog: React.FC<Props> = (props) => {
-  const { title, open, onClose, children } = props;
+  const { title, open, onClick, children } = props;
+  const ref = useRef<HTMLDivElement>(null);
 
   if (!open) return null;
 
+  const handleOnClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (isOutsideModal(event, ref.current)) {
+      onClick(event);
+    }
+  };
+
   return ReactDOM.createPortal(
-    <BackgroundAside onClick={onClose}>
-      <ModalContainer>
+    <BackgroundAside onClick={handleOnClick}>
+      <ModalContainer ref={ref}>
         <ModalTitleContainer>
           {title}
           <CloseButtonImg
-            onClick={onClose}
+            onClick={onClick}
             src={closeIcon}
             alt="close button"
             role="button"
           />
         </ModalTitleContainer>
-        {children}
+        <ModalContentContainer>{children}</ModalContentContainer>
       </ModalContainer>
     </BackgroundAside>,
     document.getElementById("app") as HTMLElement,

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -54,13 +54,13 @@ interface Props {
   numSteps?: number;
   title?: string;
   open?: boolean;
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+  closeModal: (e: React.MouseEvent<HTMLElement>) => void;
   children?: React.ReactElement<any>;
 }
 
 interface TitleProps {
   title?: string;
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+  closeModal: (e: React.MouseEvent<HTMLElement>) => void;
 }
 const isOutsideModal = (
   event: React.MouseEvent<HTMLElement>,
@@ -71,12 +71,12 @@ const isOutsideModal = (
   !element.contains(event.target);
 
 export const ModalTitle: React.FC<TitleProps> = (props) => {
-  const { title, onClick } = props;
+  const { title, closeModal } = props;
   return (
     <ModalTitleContainer>
       {title}
       <CloseButtonImg
-        onClick={onClick}
+        onClick={closeModal}
         src={closeIcon}
         alt="close button"
         role="button"
@@ -86,21 +86,21 @@ export const ModalTitle: React.FC<TitleProps> = (props) => {
 };
 
 const ModalDialog: React.FC<Props> = (props) => {
-  const { title, open, onClick, children } = props;
+  const { title, open, closeModal, children } = props;
   const ref = useRef<HTMLDivElement>(null);
 
   if (!open) return null;
 
   const handleOnClick = (event: React.MouseEvent<HTMLElement>) => {
     if (isOutsideModal(event, ref.current)) {
-      onClick(event);
+      closeModal(event);
     }
   };
 
   return ReactDOM.createPortal(
     <BackgroundAside onClick={handleOnClick}>
       <ModalContainer ref={ref}>
-        <ModalTitle title={title} onClick={onClick} />
+        <ModalTitle title={title} closeModal={closeModal} />
         <ModalContentContainer>{children}</ModalContentContainer>
       </ModalContainer>
     </BackgroundAside>,

--- a/src/design-system/ModalSteps.tsx
+++ b/src/design-system/ModalSteps.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled from "styled-components";
+
+import Colors from "./Colors";
+
+interface StepProps {
+  step: number;
+  active?: boolean;
+}
+
+const Step = styled.span<{ active?: boolean }>`
+  align-items: center;
+  display: flex;
+  background-color: ${(props) => (props.active ? Colors.teal : "transparent")};
+  border-radius: 50%;
+  border: 0.5px solid
+    ${(props) => (props.active ? Colors.teal : Colors.darkGray)};
+  color: ${(props) => (props.active ? Colors.white : Colors.green)};
+  height: 20px;
+  justify-content: center;
+  margin: 0 5px;
+  padding: 1em;
+  width: 20px;
+`;
+
+export const ModalStep: React.FC<StepProps> = (props) => {
+  const { step, active } = props;
+  return <Step active={active}>{step}</Step>;
+};
+
+interface Props {
+  numSteps: number;
+  activeStep: number;
+}
+
+const Steps = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  margin: 10px 0;
+`;
+
+const ModalSteps: React.FC<Props> = (props) => {
+  const { numSteps, activeStep } = props;
+  return (
+    <Steps>
+      {[...Array(numSteps)].map((_, idx: number) => {
+        const step = idx + 1;
+        return (
+          <ModalStep
+            key={`${ModalStep}-${step}`}
+            active={activeStep === step}
+            step={step}
+          />
+        );
+      })}
+    </Steps>
+  );
+};
+
+export default ModalSteps;

--- a/src/design-system/ModalTitle.tsx
+++ b/src/design-system/ModalTitle.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import styled from "styled-components";
+
+import closeIcon from "./icons/ic_close.svg";
+
+export interface TitleProps {
+  title?: string;
+  closeModal: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+const CloseButtonImg = styled.img`
+  display: inline-block;
+  height: 20px;
+  padding: 0 1em;
+  float: right;
+`;
+
+const ModalTitleContainer = styled.div`
+  display: inline-block;
+  font-size: 14px;
+  font-family: "Poppins", sans-serif;
+  padding-bottom: 20px;
+  width: 100%;
+`;
+
+const ModalTitle: React.FC<TitleProps> = (props) => {
+  const { title, closeModal } = props;
+  return (
+    <ModalTitleContainer>
+      {title}
+      <CloseButtonImg
+        onClick={closeModal}
+        src={closeIcon}
+        alt="close button"
+        role="button"
+      />
+    </ModalTitleContainer>
+  );
+};
+
+export default ModalTitle;

--- a/src/design-system/icons/ic_close.svg
+++ b/src/design-system/icons/ic_close.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#FFF" fill-opacity="0" d="M0 0h24v24H0z"/>
+        <g stroke="#222" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3.997 20L20 4.004M3.997 4.003L20 20.001"/>
+        </g>
+    </g>
+</svg>

--- a/src/page-multi-facility/AddFacilityModal.tsx
+++ b/src/page-multi-facility/AddFacilityModal.tsx
@@ -29,16 +29,18 @@ const AddFacilityModal: React.FC = () => {
 
   return (
     <AddFacilityModalContainer>
-      <Modal modalTitle="Add Facility" trigger="Add Facilities">
-        <ModalFooter>
-          <ModalSteps activeStep={activeStep} numSteps={numSteps} />
-          <InputButton
-            styles={{ width: "80px" }}
-            label="Next"
-            onClick={handleButtonClick}
-          />
-        </ModalFooter>
-      </Modal>
+      <div className="flex-1 pl-8">
+        <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
+          <ModalFooter>
+            <ModalSteps activeStep={activeStep} numSteps={numSteps} />
+            <InputButton
+              styles={{ width: "80px" }}
+              label="Next"
+              onClick={handleButtonClick}
+            />
+          </ModalFooter>
+        </Modal>
+      </div>
     </AddFacilityModalContainer>
   );
 };

--- a/src/page-multi-facility/AddFacilityModal.tsx
+++ b/src/page-multi-facility/AddFacilityModal.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+import InputButton from "../design-system/InputButton";
+import Modal from "../design-system/Modal";
+import ModalSteps from "../design-system/ModalSteps";
+
+const AddFacilityModalContainer = styled.div``;
+
+const ModalFooter = styled.div`
+  border-top: 0.5px solid ${Colors.darkGray};
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  padding: 1em 0;
+  width: 100%;
+`;
+
+const AddFacilityModal: React.FC = () => {
+  const [activeStep, setActiveStep] = useState(1);
+  const numSteps = 3;
+
+  const handleButtonClick = () => {
+    if (activeStep < numSteps) {
+      setActiveStep(activeStep + 1);
+    }
+  };
+
+  return (
+    <AddFacilityModalContainer>
+      <Modal modalTitle="Add Facility" trigger="Add Facilities">
+        <ModalFooter>
+          <ModalSteps activeStep={activeStep} numSteps={numSteps} />
+          <InputButton
+            styles={{ width: "80px" }}
+            label="Next"
+            onClick={handleButtonClick}
+          />
+        </ModalFooter>
+      </Modal>
+    </AddFacilityModalContainer>
+  );
+};
+
+export default AddFacilityModal;

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 
 import InputToggle from "../design-system/InputToggle";
+import Modal from "../design-system/Modal";
 import SiteHeader from "../site-header/SiteHeader";
 
 const MultiFacilityPageDiv = styled.div``;
@@ -19,6 +20,7 @@ const MultiFacilityPage: React.FC = () => {
               toggled={toggled}
               onChange={() => setToggled(!toggled)}
             />
+            <Modal modalTitle="Add Facility" trigger="Add Facilities" />
           </main>
         </div>
       </div>

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import styled from "styled-components";
 
 import InputToggle from "../design-system/InputToggle";
-import Modal from "../design-system/Modal";
 import SiteHeader from "../site-header/SiteHeader";
+import AddFacilityModal from "./AddFacilityModal";
 
 const MultiFacilityPageDiv = styled.div``;
 
@@ -20,7 +20,7 @@ const MultiFacilityPage: React.FC = () => {
               toggled={toggled}
               onChange={() => setToggled(!toggled)}
             />
-            <Modal modalTitle="Add Facility" trigger="Add Facilities" />
+            <AddFacilityModal />
           </main>
         </div>
       </div>


### PR DESCRIPTION
## Description of the change

> Adds a Modal component with a ModalTrigger and a ModalDialog. Also adds `@types/svg.d.ts` for importing svgs. 

I'm opening this PR as a WIP, I'll continue adding the following components unless someone else comments that they are working on it!

TODO: 
https://www.figma.com/proto/EGJS9njuKHWdFHUS4lrHA4/%F0%9F%9A%80Recidiviz-CJStatus?node-id=735%3A545&viewport=403%2C338%2C0.09717194736003876&scaling=min-zoom

- [x] Add Step components for the 1 / 2 / 3 steps at the bottom of the Modal 
- [x] Add the Next button in the bottom right corner
- [x] Add a ref to the modal dialog so that only click events on the background trigger the modal to close

I am assuming that the actual modal content with the form submission is not part of this task, but let me know if it should be!

Thanks!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues
Related to #93 
Closes #102

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
