### PR TITLE
Changes Auth0 version to 1.6.x to avoid apparent break in 1.7.x with …

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "postinstall": "touch node_modules/.bin/.keep"
   },
   "dependencies": {
-    "@auth0/auth0-spa-js": "^1.6.5",
+    "@auth0/auth0-spa-js": "~1.6.5",
     "@babel/runtime": "^7.9.2",
     "@hot-loader/react-dom": "16.13.0",
     "@popperjs/core": "2.2.1",


### PR DESCRIPTION
## Description of the change

Sometime in the last several hours, deploys on Now.sh started failing. This is apparently because about 3 hours ago, [a new release of auth0-spa-js](https://github.com/auth0/auth0-spa-js/releases) broke parcel build integration with 1.7.0. Our packages.json dependency specifies ^1.6.5 which allows the bump in minor version. Changing this to ~1.6.5 only allows bumps in the patch build. This should be considered temporary until auth0-spa-js 1.7.x doesn't break our build.

Tested this locally by toggling between ^1.6.5 and ~1.6.5 and running yarn build. The error happens with the former, but not the latter. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
