### PR TITLE
Locale information page - AddFacilityModal

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -20,7 +20,6 @@ const Colors = {
   paleGreen: "#D2DBDB",
   red: "#FF464A",
   white: "#ffffff",
-  darkGreen: "#00413E",
 };
 
 export default Colors;

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -37,7 +37,8 @@ const ModalTitleContainer = styled.div`
 `;
 
 const ModalContentContainer = styled.div`
-  align-items: flex-end;
+  align-items: space-between;
+  flex-direction: column;
   border-top: 0.5px solid ${Colors.darkGray};
   display: flex;
   flex: 1 1;

--- a/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
+++ b/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
@@ -6,7 +6,7 @@ import InputSelect from "../../design-system/InputSelect";
 import { useEpidemicModelState } from "../../impact-dashboard/EpidemicModelContext";
 import LocaleInformation from "../../impact-dashboard/LocaleInformation";
 
-const PageOneContainer = styled.div`
+const LocaleInformationContainer = styled.div`
   width: 100%;
   flex: 1 1;
 `;
@@ -29,20 +29,22 @@ const ErrorMessage = styled.div`
   margin: 10px;
 `;
 
-const PageOne: React.FC = () => {
+const LocaleInformationPage: React.FC = () => {
   const { countyLevelDataFailed } = useEpidemicModelState();
 
-  const systemTypeList = [{ value: "StatePrison" }, { value: "County Jail" }];
+  const systemTypeList = [{ value: "State Prison" }, { value: "County Jail" }];
+  const [systemType, updateSystemType] = useState(systemTypeList[0].value);
 
   return (
-    <PageOneContainer>
+    <LocaleInformationContainer>
       <Header>Locale Information</Header>
       <SystemTypeInputDiv>
         <InputSelect
           label="Type of System"
-          value="State Prison"
+          value={systemType}
           onChange={(event) => {
             console.log("updating type of system", event);
+            updateSystemType(event.target.value)
           }}
         >
           {systemTypeList.map(({ value }) => (
@@ -59,8 +61,8 @@ const PageOne: React.FC = () => {
           <LocaleInformation />
         </>
       )}
-    </PageOneContainer>
+    </LocaleInformationContainer>
   );
 };
 
-export default PageOne;
+export default LocaleInformationPage;

--- a/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
+++ b/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
@@ -47,7 +47,7 @@ const LocaleInformationPage: React.FC = () => {
               label="Type of System"
               value={systemType}
               onChange={(event) => {
-                updateSystemType(event.target.value)
+                updateSystemType(event.target.value);
               }}
             >
               {systemTypeList.map(({ value }) => (

--- a/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
+++ b/src/page-multi-facility/AddFacilityModal/LocaleInformationPage.tsx
@@ -38,26 +38,25 @@ const LocaleInformationPage: React.FC = () => {
   return (
     <LocaleInformationContainer>
       <Header>Locale Information</Header>
-      <SystemTypeInputDiv>
-        <InputSelect
-          label="Type of System"
-          value={systemType}
-          onChange={(event) => {
-            console.log("updating type of system", event);
-            updateSystemType(event.target.value)
-          }}
-        >
-          {systemTypeList.map(({ value }) => (
-            <option key={value} value={value}>
-              {value}
-            </option>
-          ))}
-        </InputSelect>
-      </SystemTypeInputDiv>
       {countyLevelDataFailed ? (
         <ErrorMessage>Error: unable to load data!</ErrorMessage>
       ) : (
         <>
+          <SystemTypeInputDiv>
+            <InputSelect
+              label="Type of System"
+              value={systemType}
+              onChange={(event) => {
+                updateSystemType(event.target.value)
+              }}
+            >
+              {systemTypeList.map(({ value }) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </InputSelect>
+          </SystemTypeInputDiv>
           <LocaleInformation />
         </>
       )}

--- a/src/page-multi-facility/AddFacilityModal/PageOne.tsx
+++ b/src/page-multi-facility/AddFacilityModal/PageOne.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+
+const PageOneContainer = styled.div`
+  width: 100%;
+  flex: 1 1
+`;
+
+
+const PageOne: React.FC = () => {
+  return (
+    <PageOneContainer>
+      Content
+    </PageOneContainer>
+  );
+};
+
+export default PageOne;

--- a/src/page-multi-facility/AddFacilityModal/PageOne.tsx
+++ b/src/page-multi-facility/AddFacilityModal/PageOne.tsx
@@ -1,18 +1,64 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
+import Colors from "../../design-system/Colors";
+import InputSelect from "../../design-system/InputSelect";
+import { useEpidemicModelState } from "../../impact-dashboard/EpidemicModelContext";
+import LocaleInformation from "../../impact-dashboard/LocaleInformation";
 
 const PageOneContainer = styled.div`
   width: 100%;
-  flex: 1 1
+  flex: 1 1;
 `;
 
+const SystemTypeInputDiv = styled.div`
+  width: 195px;
+  padding-bottom: 20px;
+`;
+
+const Header = styled.header`
+  font-family: Poppins;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 16px;
+  padding: 20px 0;
+  color: "${Colors.forest}"
+`;
+
+const ErrorMessage = styled.div`
+  margin: 10px;
+`;
 
 const PageOne: React.FC = () => {
+  const { countyLevelDataFailed } = useEpidemicModelState();
+
+  const systemTypeList = [{ value: "StatePrison" }, { value: "County Jail" }];
+
   return (
     <PageOneContainer>
-      Content
+      <Header>Locale Information</Header>
+      <SystemTypeInputDiv>
+        <InputSelect
+          label="Type of System"
+          value="State Prison"
+          onChange={(event) => {
+            console.log("updating type of system", event);
+          }}
+        >
+          {systemTypeList.map(({ value }) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </InputSelect>
+      </SystemTypeInputDiv>
+      {countyLevelDataFailed ? (
+        <ErrorMessage>Error: unable to load data!</ErrorMessage>
+      ) : (
+        <>
+          <LocaleInformation />
+        </>
+      )}
     </PageOneContainer>
   );
 };

--- a/src/page-multi-facility/AddFacilityModal/index.tsx
+++ b/src/page-multi-facility/AddFacilityModal/index.tsx
@@ -33,7 +33,7 @@ const AddFacilityModal: React.FC = () => {
     <EpidemicModelProvider>
       <AddFacilityModalContainer>
         <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
-          {(activeStep === 1) && <LocaleInformationPage />}
+          {activeStep === 1 && <LocaleInformationPage />}
           <ModalFooter>
             <ModalSteps activeStep={activeStep} numSteps={numSteps} />
             <InputButton

--- a/src/page-multi-facility/AddFacilityModal/index.tsx
+++ b/src/page-multi-facility/AddFacilityModal/index.tsx
@@ -34,7 +34,7 @@ const AddFacilityModal: React.FC = () => {
       <AddFacilityModalContainer>
         <div className="flex-1 pl-8">
           <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
-            <LocaleInformationPage />
+            {(activeStep === 1) && <LocaleInformationPage />}
             <ModalFooter>
               <ModalSteps activeStep={activeStep} numSteps={numSteps} />
               <InputButton

--- a/src/page-multi-facility/AddFacilityModal/index.tsx
+++ b/src/page-multi-facility/AddFacilityModal/index.tsx
@@ -6,7 +6,7 @@ import InputButton from "../../design-system/InputButton";
 import Modal from "../../design-system/Modal";
 import ModalSteps from "../../design-system/ModalSteps";
 import { EpidemicModelProvider } from "../../impact-dashboard/EpidemicModelContext";
-import PageOne from "./PageOne";
+import LocaleInformationPage from "./LocaleInformationPage";
 
 const AddFacilityModalContainer = styled.div``;
 
@@ -34,7 +34,7 @@ const AddFacilityModal: React.FC = () => {
       <AddFacilityModalContainer>
         <div className="flex-1 pl-8">
           <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
-            <PageOne />
+            <LocaleInformationPage />
             <ModalFooter>
               <ModalSteps activeStep={activeStep} numSteps={numSteps} />
               <InputButton

--- a/src/page-multi-facility/AddFacilityModal/index.tsx
+++ b/src/page-multi-facility/AddFacilityModal/index.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
-import InputButton from "../design-system/InputButton";
-import Modal from "../design-system/Modal";
-import ModalSteps from "../design-system/ModalSteps";
+import Colors from "../../design-system/Colors";
+import InputButton from "../../design-system/InputButton";
+import Modal from "../../design-system/Modal";
+import ModalSteps from "../../design-system/ModalSteps";
+import PageOne from "./PageOne"
 
 const AddFacilityModalContainer = styled.div``;
 
@@ -31,6 +32,7 @@ const AddFacilityModal: React.FC = () => {
     <AddFacilityModalContainer>
       <div className="flex-1 pl-8">
         <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
+          <PageOne />
           <ModalFooter>
             <ModalSteps activeStep={activeStep} numSteps={numSteps} />
             <InputButton

--- a/src/page-multi-facility/AddFacilityModal/index.tsx
+++ b/src/page-multi-facility/AddFacilityModal/index.tsx
@@ -5,7 +5,8 @@ import Colors from "../../design-system/Colors";
 import InputButton from "../../design-system/InputButton";
 import Modal from "../../design-system/Modal";
 import ModalSteps from "../../design-system/ModalSteps";
-import PageOne from "./PageOne"
+import { EpidemicModelProvider } from "../../impact-dashboard/EpidemicModelContext";
+import PageOne from "./PageOne";
 
 const AddFacilityModalContainer = styled.div``;
 
@@ -29,21 +30,23 @@ const AddFacilityModal: React.FC = () => {
   };
 
   return (
-    <AddFacilityModalContainer>
-      <div className="flex-1 pl-8">
-        <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
-          <PageOne />
-          <ModalFooter>
-            <ModalSteps activeStep={activeStep} numSteps={numSteps} />
-            <InputButton
-              styles={{ width: "80px" }}
-              label="Next"
-              onClick={handleButtonClick}
-            />
-          </ModalFooter>
-        </Modal>
-      </div>
-    </AddFacilityModalContainer>
+    <EpidemicModelProvider>
+      <AddFacilityModalContainer>
+        <div className="flex-1 pl-8">
+          <Modal modalTitle="Add Facility" trigger="+ Add Facilities">
+            <PageOne />
+            <ModalFooter>
+              <ModalSteps activeStep={activeStep} numSteps={numSteps} />
+              <InputButton
+                styles={{ width: "80px" }}
+                label="Next"
+                onClick={handleButtonClick}
+              />
+            </ModalFooter>
+          </Modal>
+        </div>
+      </AddFacilityModalContainer>
+    </EpidemicModelProvider>
   );
 };
 

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -10,7 +10,6 @@ const LeftColumn = styled.div`
   width: 300px;
 `;
 
-
 const MultiFacilityPageDiv = styled.div``;
 
 // <ToggleRow
@@ -30,7 +29,6 @@ const MultiFacilityPage: React.FC = () => {
           <SiteHeader />
           <main className="my-6">
             <LeftColumn>
-
               <PromoBoxWithButton
                 text={
                   "Turn on 'DailyReports' to receive Lorem ipsum dolor sit amet, consectetur adipiscing elit"

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -12,15 +12,6 @@ const LeftColumn = styled.div`
 
 const MultiFacilityPageDiv = styled.div``;
 
-// <ToggleRow
-//   label="Daily Reports"
-//   labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-// />
-// <ToggleRow
-//   label="Data Sharing"
-//   labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-// />
-
 const MultiFacilityPage: React.FC = () => {
   return (
     <MultiFacilityPageDiv>
@@ -29,6 +20,14 @@ const MultiFacilityPage: React.FC = () => {
           <SiteHeader />
           <main className="my-6">
             <LeftColumn>
+              <ToggleRow
+                label="Daily Reports"
+                labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+              />
+              <ToggleRow
+                label="Data Sharing"
+                labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+              />
               <PromoBoxWithButton
                 text={
                   "Turn on 'DailyReports' to receive Lorem ipsum dolor sit amet, consectetur adipiscing elit"

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import PromoBoxWithButton from "../design-system/PromoBoxWithButton";
 import SiteHeader from "../site-header/SiteHeader";
-import AddFacilityModal from "./AddFacilityModal";
+import AddFacilityModal from "./AddFacilityModal/index";
 import ToggleRow from "./ToggleRow";
 
 const LeftColumn = styled.div`
@@ -13,6 +13,15 @@ const LeftColumn = styled.div`
 
 const MultiFacilityPageDiv = styled.div``;
 
+// <ToggleRow
+//   label="Daily Reports"
+//   labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+// />
+// <ToggleRow
+//   label="Data Sharing"
+//   labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+// />
+
 const MultiFacilityPage: React.FC = () => {
   return (
     <MultiFacilityPageDiv>
@@ -21,14 +30,7 @@ const MultiFacilityPage: React.FC = () => {
           <SiteHeader />
           <main className="my-6">
             <LeftColumn>
-              <ToggleRow
-                label="Daily Reports"
-                labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-              />
-              <ToggleRow
-                label="Data Sharing"
-                labelHelp="Tooltip help Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-              />
+
               <PromoBoxWithButton
                 text={
                   "Turn on 'DailyReports' to receive Lorem ipsum dolor sit amet, consectetur adipiscing elit"


### PR DESCRIPTION
## Description of the change

Adds inputs to page one of the Add Facility Modal - Locale Information.

I used the existing `LocaleInformation` component from the `ImpactDashboard` which means I had to wrap the modal in `EpidemicModelProvider`. I'm not sure if this the right approach or if we want to be starting with empty inputs. Let me know if this was the wrong direction.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #112 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
