### PR TITLE
Adds the Ability to Read and Visualize Model Data from Cloud Firestore

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -6,4 +6,10 @@ service cloud.firestore {
       allow read, write: if request.auth.uid == userId
     }
   }
+
+  match /databases/{database}/documents {
+    match /scenarios/{documents=**} {
+      allow read, write: if request.auth.uid != null;
+    }
+  }
 }

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -150,7 +150,7 @@ export const getFacilities = async (): Promise<Array<Facility> | null> => {
     if (!baselineScenario) return null;
 
     const facilitiesResults = await baselineScenario
-      .collection("facilities")
+      .collection(facilitiesCollectionId)
       .get();
 
     const facilities = facilitiesResults.docs.map(

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -8,12 +8,15 @@ import createAuth0Client from "@auth0/auth0-spa-js";
 
 import config from "../auth/auth_config.json";
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+import { Facility } from "../page-multi-facility/types";
 import { prepareForStorage, prepareFromStorage } from "./utils";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
 const tokenExchangeEndpoint =
   "https://us-central1-c19-backend.cloudfunctions.net/getFirebaseToken";
 const modelInputsCollectionId = "model_inputs";
+const scenariosCollectionId = "scenarios";
+const facilitiesCollectionId = "facilities";
 
 // Note: None of these are secrets.
 let firebaseConfig = {
@@ -58,6 +61,10 @@ const authenticate = async () => {
   await firebase.auth().signInWithCustomToken(customToken);
 };
 
+const currrentUserId = () => {
+  return (firebase.auth().currentUser || {}).uid;
+};
+
 const getInputModelsDocRef = async () => {
   await authenticate();
 
@@ -66,9 +73,7 @@ const getInputModelsDocRef = async () => {
   }
 
   const db = firebase.firestore();
-  return db
-    .collection(modelInputsCollectionId)
-    .doc((firebase.auth().currentUser || {}).uid);
+  return db.collection(modelInputsCollectionId).doc(currrentUserId());
 };
 
 // TODO: Guard against the possibility of autosaves completing out of order.
@@ -107,6 +112,55 @@ export const getSavedState = async (): Promise<EpidemicModelPersistent | null> =
     console.error(
       "Encountered error while attempting to retrieve saved state:",
     );
+    console.error(error);
+
+    return null;
+  }
+};
+
+const getBaselineScenario = async () => {
+  await authenticate();
+
+  if (!firebase.auth().currentUser) {
+    throw new Error("Firebase user unexpectedly not set");
+  }
+
+  const db = firebase.firestore();
+  const query = db
+    .collection(scenariosCollectionId)
+    .where("baseline", "==", true);
+
+  const results = await query.get();
+  const userId = currrentUserId();
+
+  const baselineScenario = results.docs.find((doc) => {
+    const scenario = doc.data();
+    return userId && scenario.roles[userId] == "owner";
+  });
+
+  if (!baselineScenario) return null;
+
+  return baselineScenario.ref;
+};
+
+export const getFacilities = async (): Promise<Array<Facility> | null> => {
+  try {
+    const baselineScenario = await getBaselineScenario();
+
+    if (!baselineScenario) return null;
+
+    const facilitiesResults = await baselineScenario
+      .collection("facilities")
+      .get();
+
+    const facilities = facilitiesResults.docs.map(
+      (doc) => doc.data() as Facility,
+    );
+
+    return facilities;
+  } catch (error) {
+    console.error("Encountered error while attempting to retrieve facilities:");
+
     console.error(error);
 
     return null;

--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -22,4 +22,13 @@ const Colors = {
   darkGreen: "#00413E",
 };
 
+// Shared colors for the Projection charts
+export const MarkColors = {
+  exposed: Colors.green,
+  fatalities: Colors.black,
+  hospitalized: Colors.lightBlue,
+  hospitalBeds: darken(Colors.lightBlue, 20),
+  infectious: Colors.red,
+};
+
 export default Colors;

--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import styled from "styled-components";
 
-import Colors, { darken } from "../design-system/Colors";
+import { MarkColors as markColors } from "../design-system/Colors";
 import CurveChart from "./CurveChartContainer";
 import CurveChartLegend from "./CurveChartLegend";
 
@@ -27,14 +27,6 @@ const LegendContainer = styled.div`
 `;
 
 const ChartArea: React.FC = () => {
-  const markColors = {
-    exposed: Colors.green,
-    fatalities: Colors.black,
-    hospitalized: Colors.lightBlue,
-    hospitalBeds: darken(Colors.lightBlue, 20),
-    infectious: Colors.red,
-  };
-
   const [groupStatus, setGroupStatus] = useState({
     exposed: true,
     fatalities: true,

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -9,7 +9,7 @@ import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import { MarkColors } from "./ChartArea";
 
 const ChartContainer = styled.div`
-  height: ${props => props.chartHeight}px;
+  height: ${(props) => props.chartHeight}px;
 
   .frame {
     font-family: "Poppins", sans-serif;
@@ -195,7 +195,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   };
 
   return (
-    <ChartContainer chartHeight={chartHeight || 380 }>
+    <ChartContainer chartHeight={chartHeight || 380}>
       <ResponsiveXYFrame {...frameProps} />
     </ChartContainer>
   );

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -9,7 +9,7 @@ import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import { MarkColors } from "./ChartArea";
 
 const ChartContainer = styled.div`
-  height: 380px;
+  height: ${props => props.chartHeight}px;
 
   .frame {
     font-family: "Poppins", sans-serif;
@@ -129,12 +129,14 @@ interface CurveChartProps {
   curveData: {
     [propName: string]: number[];
   };
+  chartHeight?: number;
   hospitalBeds: number;
   markColors: MarkColors;
 }
 
 const CurveChart: React.FC<CurveChartProps> = ({
   curveData,
+  chartHeight,
   hospitalBeds,
   markColors,
 }) => {
@@ -193,7 +195,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   };
 
   return (
-    <ChartContainer>
+    <ChartContainer chartHeight={chartHeight || 380 }>
       <ResponsiveXYFrame {...frameProps} />
     </ChartContainer>
   );

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -26,7 +26,11 @@ function combinePopulations(data: CurveData, columnIndex: number) {
     getAllValues(getColView(data.staff, columnIndex)),
   ).map(([incarcerated, staff]) => incarcerated + staff);
 }
-const CurveChartContainer: React.FC<Props> = ({ markColors, groupStatus }) => {
+const CurveChartContainer: React.FC<Props> = ({
+  markColors,
+  groupStatus,
+  chartHeight,
+}) => {
   const modelData = useEpidemicModelState();
   const [curveData, updateCurveData] = useState({} as ChartData);
   const [curveDataFiltered, setCurveDataFiltered] = useState({} as ChartData);
@@ -60,6 +64,7 @@ const CurveChartContainer: React.FC<Props> = ({ markColors, groupStatus }) => {
     <Loading />
   ) : (
     <CurveChart
+      chartHeight={chartHeight}
       curveData={curveDataFiltered}
       hospitalBeds={modelData.hospitalBeds}
       markColors={markColors}

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -10,6 +10,7 @@ import CurveChart from "./CurveChart";
 import { useEpidemicModelState } from "./EpidemicModelContext";
 
 interface Props {
+  chartHeight?: number;
   markColors: MarkColors;
   groupStatus: Record<string, any>;
 }

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -128,7 +128,7 @@ export const persistedKeys: Array<keyof EpidemicModelPersistent> = [
 
 export type EpidemicModelUpdate = ModelInputsUpdate & MetadataUpdate;
 
-type EpidemicModelState = EpidemicModelInputs & Metadata;
+export type EpidemicModelState = EpidemicModelInputs & Metadata;
 
 type EpidemicModelProviderProps = { children: React.ReactNode };
 

--- a/src/page-multi-facility/FacilityContext.tsx
+++ b/src/page-multi-facility/FacilityContext.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { Facility } from "./types";
+
+export const FacilityContext = React.createContext<Facility | undefined>(
+  undefined,
+);

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,23 +1,24 @@
-import styled from "styled-components";
+import React, { useContext } from "react";
 
-import Colors from "../design-system/Colors";
-import Loading from "../design-system/Loading";
+import { MarkColors as markColors } from "../design-system/Colors";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
-import { Facility } from "./types";
+import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
+import { FacilityContext } from "./FacilityContext";
 
-const markColors = {
-  exposed: Colors.green,
-  fatalities: Colors.black,
-  hospitalized: Colors.lightBlue,
-  hospitalBeds: Colors.red,
-  infectious: Colors.red,
+const groupStatus = {
+  exposed: true,
+  fatalities: true,
+  hospitalized: true,
+  infectious: true,
 };
 
-interface Props {
-  facility: Facility;
-}
+const FacilityRow: React.FC = () => {
+  const facility = useContext(FacilityContext);
 
-const FacilityRow: React.FC<Props> = ({ facility }) => {
+  if (!facility) {
+    throw new Error("Facility must be provided to the FacilityContext");
+  }
+
   const { name, modelInputs } = facility;
 
   const confirmedCases = modelInputs.confirmedCases;
@@ -46,11 +47,13 @@ const FacilityRow: React.FC<Props> = ({ facility }) => {
           </div>
         </div>
         <div className="w-3/5">
-          <CurveChartContainer
-            modelData={modelInputs}
-            markColors={markColors}
-            chartHeight={200}
-          />
+          <EpidemicModelProvider facilityModel={modelInputs}>
+            <CurveChartContainer
+              chartHeight={200}
+              groupStatus={groupStatus}
+              markColors={markColors}
+            />
+          </EpidemicModelProvider>
         </div>
       </div>
     </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,10 +1,9 @@
 import styled from "styled-components";
+
 import Colors from "../design-system/Colors";
 import Loading from "../design-system/Loading";
-
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
-
-import { Facility } from "./types"
+import { Facility } from "./types";
 
 const markColors = {
   exposed: Colors.green,
@@ -19,38 +18,39 @@ interface Props {
 }
 
 const FacilityRow: React.FC<Props> = ({ facility }) => {
-  const {
-    name,
-    model_inputs
-  } = facility
+  const { name, modelInputs } = facility;
 
-  const confirmedCases = model_inputs.confirmedCases
+  const confirmedCases = modelInputs.confirmedCases;
 
   return (
     <div>
       <div className="flex flex-row h-48 mb-8 border-b border-grey-300">
         <div className="w-2/5 flex flex-col justify-between">
           <div className="flex flex-row">
-            <div className="w-1/4 text-red-600 font-bold">
-              {confirmedCases}
-            </div>
-            <div className="w-3/4 font-bold">
-              {name}
-            </div>
+            <div className="w-1/4 text-red-600 font-bold">{confirmedCases}</div>
+            <div className="w-3/4 font-bold">{name}</div>
           </div>
           <div className="text-xs text-gray-500 pb-4 flex flex-row justify-between">
-            <div>
-              Last update: on March 25, 2020
-            </div>
+            <div>Last update: on March 25, 2020</div>
             <div className="mr-8">
-              <a className="px-1" href="#">Delete</a>
-              <a className="px-1" href="#">Edit</a>
-              <a className="px-1" href="#">Share</a>
+              <a className="px-1" href="#">
+                Delete
+              </a>
+              <a className="px-1" href="#">
+                Edit
+              </a>
+              <a className="px-1" href="#">
+                Share
+              </a>
             </div>
           </div>
         </div>
         <div className="w-3/5">
-          <CurveChartContainer modelData={model_inputs} markColors={markColors} chartHeight={200} />
+          <CurveChartContainer
+            modelData={modelInputs}
+            markColors={markColors}
+            chartHeight={200}
+          />
         </div>
       </div>
     </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,0 +1,60 @@
+import styled from "styled-components";
+import Colors from "../design-system/Colors";
+import Loading from "../design-system/Loading";
+
+import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
+
+import { Facility } from "./types"
+
+const markColors = {
+  exposed: Colors.green,
+  fatalities: Colors.black,
+  hospitalized: Colors.lightBlue,
+  hospitalBeds: Colors.red,
+  infectious: Colors.red,
+};
+
+interface Props {
+  facility: Facility;
+}
+
+const FacilityRow: React.FC<Props> = ({ facility }) => {
+  const {
+    name,
+    model_inputs
+  } = facility
+
+  const confirmedCases = model_inputs.confirmedCases
+
+  return (
+    <div>
+      <div className="flex flex-row h-48 mb-8 border-b border-grey-300">
+        <div className="w-2/5 flex flex-col justify-between">
+          <div className="flex flex-row">
+            <div className="w-1/4 text-red-600 font-bold">
+              {confirmedCases}
+            </div>
+            <div className="w-3/4 font-bold">
+              {name}
+            </div>
+          </div>
+          <div className="text-xs text-gray-500 pb-4 flex flex-row justify-between">
+            <div>
+              Last update: on March 25, 2020
+            </div>
+            <div className="mr-8">
+              <a className="px-1" href="#">Delete</a>
+              <a className="px-1" href="#">Edit</a>
+              <a className="px-1" href="#">Share</a>
+            </div>
+          </div>
+        </div>
+        <div className="w-3/5">
+          <CurveChartContainer modelData={model_inputs} markColors={markColors} chartHeight={200} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FacilityRow;

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -1,10 +1,17 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
+import Loading from "../design-system/Loading";
 import SiteHeader from "../site-header/SiteHeader";
 import AddFacilityModal from "./AddFacilityModal";
+
+import { getFacilities } from "../database";
+
+import FacilityRow from "./FacilityRow";
 import ProjectionsHeader from "./ProjectionsHeader";
 import ScenarioSidebar from "./ScenarioSidebar";
+
+import { Facility  } from "./types"
 
 const MultiFacilityPageDiv = styled.div``;
 
@@ -17,6 +24,21 @@ const MultiFacilityImpactDashboard = styled.main.attrs({
 })``;
 
 const MultiFacilityPage: React.FC = () => {
+  const [facilities, setFacilities] =
+    useState({ data: [] as Array<Facility>, loading: true });
+
+  useEffect(() => {
+    async function fetchFacilities() {
+      const facilitiesData = await getFacilities() as Array<Facility>;
+
+      setFacilities({
+        data: facilitiesData,
+        loading: false
+      });
+    }
+    fetchFacilities();
+  }, []);
+
   return (
     <MultiFacilityPageDiv>
       <div className="font-body text-green min-h-screen tracking-normal w-full">
@@ -27,7 +49,11 @@ const MultiFacilityPage: React.FC = () => {
             <div className="flex flex-col flex-1 pb-6 pl-8">
               <AddFacilityModal />
               <ProjectionsHeader />
-              <div>Projections will go here</div>
+              { facilities.loading ? <Loading /> :
+                facilities.data.map((facility, index) => {
+                  return <FacilityRow key={index} facility={facility} />
+                })
+              }
             </div>
           </MultiFacilityImpactDashboard>
         </div>

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -5,10 +5,11 @@ import { getFacilities } from "../database";
 import Loading from "../design-system/Loading";
 import SiteHeader from "../site-header/SiteHeader";
 import AddFacilityModal from "./AddFacilityModal";
+import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
 import ProjectionsHeader from "./ProjectionsHeader";
 import ScenarioSidebar from "./ScenarioSidebar";
-import { Facilities, Facility } from "./types";
+import { Facilities } from "./types";
 
 const MultiFacilityPageDiv = styled.div``;
 
@@ -53,8 +54,12 @@ const MultiFacilityPage: React.FC = () => {
               {facilities.loading ? (
                 <Loading />
               ) : (
-                facilities.data.map((facility, index) => {
-                  return <FacilityRow key={index} facility={facility} />;
+                facilities?.data.map((facility, index) => {
+                  return (
+                    <FacilityContext.Provider key={index} value={facility}>
+                      <FacilityRow />
+                    </FacilityContext.Provider>
+                  );
                 })
               )}
             </div>

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -1,17 +1,14 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import { getFacilities } from "../database";
 import Loading from "../design-system/Loading";
 import SiteHeader from "../site-header/SiteHeader";
 import AddFacilityModal from "./AddFacilityModal";
-
-import { getFacilities } from "../database";
-
 import FacilityRow from "./FacilityRow";
 import ProjectionsHeader from "./ProjectionsHeader";
 import ScenarioSidebar from "./ScenarioSidebar";
-
-import { Facility  } from "./types"
+import { Facilities, Facility } from "./types";
 
 const MultiFacilityPageDiv = styled.div``;
 
@@ -24,17 +21,21 @@ const MultiFacilityImpactDashboard = styled.main.attrs({
 })``;
 
 const MultiFacilityPage: React.FC = () => {
-  const [facilities, setFacilities] =
-    useState({ data: [] as Array<Facility>, loading: true });
+  const [facilities, setFacilities] = useState({
+    data: [] as Facilities,
+    loading: true,
+  });
 
   useEffect(() => {
     async function fetchFacilities() {
-      const facilitiesData = await getFacilities() as Array<Facility>;
+      const facilitiesData = await getFacilities();
 
-      setFacilities({
-        data: facilitiesData,
-        loading: false
-      });
+      if (facilitiesData) {
+        setFacilities({
+          data: facilitiesData,
+          loading: false,
+        });
+      }
     }
     fetchFacilities();
   }, []);
@@ -49,11 +50,13 @@ const MultiFacilityPage: React.FC = () => {
             <div className="flex flex-col flex-1 pb-6 pl-8">
               <AddFacilityModal />
               <ProjectionsHeader />
-              { facilities.loading ? <Loading /> :
+              {facilities.loading ? (
+                <Loading />
+              ) : (
                 facilities.data.map((facility, index) => {
-                  return <FacilityRow key={index} facility={facility} />
+                  return <FacilityRow key={index} facility={facility} />;
                 })
-              }
+              )}
             </div>
           </MultiFacilityImpactDashboard>
         </div>

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -1,0 +1,6 @@
+import { EpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
+
+export type Facility = {
+  name: string;
+  model_inputs: EpidemicModelState;
+};

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -2,5 +2,7 @@ import { EpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 
 export type Facility = {
   name: string;
-  model_inputs: EpidemicModelState;
+  modelInputs: EpidemicModelState;
 };
+
+export type Facilities = Facility[];


### PR DESCRIPTION
## Description of the change

* Adding in a mechanism to query Firestore to grab a user's baseline scenario document and its underlying facilities.
* Passing each of the facility's model inputs to our projection charting code.

<img width="1351" alt="Screen Shot 2020-04-16 at 5 51 31 PM" src="https://user-images.githubusercontent.com/25503/79510357-3b883800-800b-11ea-9d7f-8e9b95d87112.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #114

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
