### PR TITLE
Separate locale data from EpidemicModelContext

### DIFF
--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -2,13 +2,14 @@ import { hot } from "react-hot-loader";
 import { Route, Switch } from "react-router-dom";
 
 import AuthWall from "../auth/AuthWall";
+import { LocaleDataProvider } from "../locale-data-context";
 import { GlobalStyles } from "../styles";
 import PageList from "./PageList";
 import WindowTitle from "./WindowTitle";
 
 const App: React.FC = () => {
   return (
-    <>
+    <LocaleDataProvider>
       <GlobalStyles />
       <Switch>
         {PageList.map(({ path, title, isPrivate, contents }) => {
@@ -31,7 +32,7 @@ const App: React.FC = () => {
           }
         })}
       </Switch>
-    </>
+    </LocaleDataProvider>
   );
 };
 

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -1,4 +1,5 @@
 import { zip } from "d3-array";
+import isEmpty from "lodash/isEmpty";
 import { useEffect, useState } from "react";
 
 import Loading from "../design-system/Loading";
@@ -48,6 +49,11 @@ const CurveChartContainer: React.FC<Props> = ({
   }, [modelData]);
 
   useEffect(() => {
+    if (isEmpty(curveData)) {
+      setCurveDataFiltered({});
+      return;
+    }
+
     let filteredGroupStatus = Object.keys(groupStatus).filter(
       (groupName) => groupStatus[groupName],
     );
@@ -60,7 +66,7 @@ const CurveChartContainer: React.FC<Props> = ({
     );
   }, [groupStatus, curveData]);
 
-  return modelData.countyLevelDataLoading ? (
+  return !curveDataFiltered ? (
     <Loading />
   ) : (
     <CurveChart

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -1,3 +1,5 @@
+import { sum } from "d3";
+import { pick } from "lodash";
 import React from "react";
 
 import { LocaleData } from "../locale-data-context";
@@ -49,7 +51,7 @@ interface ModelInputsUpdate extends ModelInputsPersistent {
   usePopulationSubsets?: boolean;
 }
 // some fields are required for calculations, define them here
-interface EpidemicModelInputs extends ModelInputsUpdate {
+export interface EpidemicModelInputs extends ModelInputsUpdate {
   rateOfSpreadFactor: RateOfSpread;
   usePopulationSubsets: boolean;
   facilityDormitoryPct: number;
@@ -204,7 +206,7 @@ function epidemicModelReducer(
   }
 }
 
-function EpidemicModelProvider({
+export function EpidemicModelProvider({
   children,
   facilityModel,
   localeDataSource,
@@ -235,7 +237,7 @@ function EpidemicModelProvider({
   );
 }
 
-function useEpidemicModelState() {
+export function useEpidemicModelState() {
   const context = React.useContext(EpidemicModelStateContext);
 
   if (context === undefined) {
@@ -247,7 +249,7 @@ function useEpidemicModelState() {
   return context;
 }
 
-function useEpidemicModelDispatch() {
+export function useEpidemicModelDispatch() {
   const context = React.useContext(EpidemicModelDispatchContext);
 
   if (context === undefined) {
@@ -259,9 +261,24 @@ function useEpidemicModelDispatch() {
   return context;
 }
 
-export {
-  EpidemicModelProvider,
-  useEpidemicModelState,
-  useEpidemicModelDispatch,
-  EpidemicModelInputs,
-};
+// *******
+// calculation helpers
+// *******
+
+export function totalConfirmedCases(model: EpidemicModelState): number {
+  return sum(
+    Object.values(
+      pick(model, [
+        "age0Cases",
+        "age20Cases",
+        "age45Cases",
+        "age55Cases",
+        "age65Cases",
+        "age75Cases",
+        "age85Cases",
+        "ageUnknownCases",
+        "staffCases",
+      ]),
+    ),
+  );
+}

--- a/src/impact-dashboard/ImpactDashboard.tsx
+++ b/src/impact-dashboard/ImpactDashboard.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
+import { useLocaleDataState } from "../locale-data-context";
 import ChartArea from "./ChartArea";
-import { useEpidemicModelState } from "./EpidemicModelContext";
 import FacilityInformation from "./FacilityInformation";
 import ImpactProjectionTable from "./ImpactProjectionTableContainer";
 import LocaleInformation from "./LocaleInformation";
@@ -62,7 +62,7 @@ const HorizontalDivider = styled.hr`
 `;
 
 const ImpactDashboard: React.FC = () => {
-  const { countyLevelDataFailed } = useEpidemicModelState();
+  const { failed: countyLevelDataFailed } = useLocaleDataState();
   return (
     <div>
       {countyLevelDataFailed ? (

--- a/src/impact-dashboard/ImpactDashboardContainer.tsx
+++ b/src/impact-dashboard/ImpactDashboardContainer.tsx
@@ -1,9 +1,15 @@
+import Loading from "../design-system/Loading";
+import { useLocaleDataState } from "../locale-data-context";
 import { EpidemicModelProvider } from "./EpidemicModelContext";
 import ImpactDashboard from "./ImpactDashboard";
 
 const ImpactDashboardContainer: React.FC = () => {
-  return (
-    <EpidemicModelProvider>
+  const { data, loading: localeDataLoading } = useLocaleDataState();
+
+  return localeDataLoading ? (
+    <Loading />
+  ) : (
+    <EpidemicModelProvider localeDataSource={data}>
       <ImpactDashboard />
     </EpidemicModelProvider>
   );

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -1,7 +1,6 @@
 import { sum } from "d3-array";
 import ndarray from "ndarray";
 
-import Loading from "../design-system/Loading";
 import { calculateCurves } from "../infection-model";
 import {
   getAllValues,
@@ -154,9 +153,8 @@ const ImpactProjectionTableContainer: React.FC = () => {
     week3: null,
     overall: value,
   }));
-  return modelData.countyLevelDataLoading ? (
-    <Loading />
-  ) : (
+
+  return (
     <ImpactProjectionTable {...{ incarceratedData, staffData, peakData }} />
   );
 };

--- a/src/impact-dashboard/LocaleInformation.tsx
+++ b/src/impact-dashboard/LocaleInformation.tsx
@@ -23,28 +23,30 @@ const LocaleInformation: React.FC = () => {
   const [countyList, updateCountyList] = useState([{ value: "Total" }]);
 
   useEffect(() => {
-    if (typeof model.countyLevelData !== "undefined") {
-      const newStateList = Array.from(
-        model.countyLevelData.keys(),
-      ).map((key) => ({ value: key }));
+    if (typeof model.localeDataSource !== "undefined") {
+      const newStateList = Array.from(model.localeDataSource.keys()).map(
+        (key) => ({
+          value: key,
+        }),
+      );
       updateStateList(newStateList);
     }
-  }, [model.countyLevelData]);
+  }, [model.localeDataSource]);
 
   useEffect(() => {
-    const countyLevelData = model.countyLevelData;
+    const localeDataSource = model.localeDataSource;
     const stateCode = model.stateCode;
-    if (countyLevelData !== undefined && stateCode !== undefined) {
+    if (localeDataSource !== undefined && stateCode !== undefined) {
       // TODO: TS is complaining about things being undefined
       // despite the above checks; replace these assertions
       // with proper type guards
-      const keys = countyLevelData?.get(stateCode)?.keys();
+      const keys = localeDataSource?.get(stateCode)?.keys();
       const newCountyList = Array.from(
         keys as Iterable<string>,
       ).map((value) => ({ value }));
       updateCountyList(newCountyList);
     }
-  }, [model.countyLevelData, model.stateCode]);
+  }, [model.localeDataSource, model.stateCode]);
 
   return (
     <LocaleInformationDiv>

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -1,0 +1,174 @@
+import { csvParse, DSVRowAny } from "d3";
+import { rollup } from "d3-array";
+import numeral from "numeral";
+import React from "react";
+
+type LocaleRecord = {
+  county: string;
+  estimatedIncarceratedCases: number;
+  hospitalBeds: number;
+  reportedCases: number;
+  state: string;
+  totalIncarceratedPopulation: number;
+};
+
+type LocaleData = Map<string, Map<string, LocaleRecord>>;
+
+type LocaleDataUpdate = {
+  loading?: boolean;
+  failed?: boolean;
+  data?: LocaleData;
+};
+
+type LocaleDataState = {
+  loading: boolean;
+  failed: boolean;
+  data: LocaleData;
+};
+
+type Action = { type: "update"; payload: LocaleDataUpdate };
+type Dispatch = (action: Action) => void;
+
+// estimated ratio of confirmed cases to actual cases
+const caseReportingRate = 0.14;
+
+const StateContext = React.createContext<LocaleDataState | undefined>(
+  undefined,
+);
+
+const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+
+function localeReducer(
+  state: LocaleDataState,
+  action: Action,
+): LocaleDataState {
+  switch (action.type) {
+    case "update":
+      return Object.assign({}, state, action.payload);
+  }
+}
+
+export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = React.useReducer(localeReducer, {
+    loading: true,
+    failed: false,
+    data: new Map(),
+  });
+
+  // fetch from external datasource
+  React.useEffect(
+    () => {
+      async function effect() {
+        try {
+          // TODO: fix the intermittent CORS issue on this fetch?
+          const response = await fetch(
+            "https://docs.google.com/spreadsheets/d/e/2PACX-1vSeEO7JySaN21_Cxa7ON_x" +
+              "UHDM-EEOFSMIjOAoLf6YOXBurMRXZYPFi7x_aOe-0awqDcL4KZTK1NhVI/pub?gid=" +
+              "1836987932&single=true&output=csv",
+          );
+          let rawCSV = await response.text();
+          // the first line is not the header row so we need to strip it
+          rawCSV = rawCSV.substring(rawCSV.indexOf("\n") + 1);
+
+          const parsedArray = csvParse(rawCSV, (row):
+            | LocaleRecord
+            | undefined => {
+            // rows without these fields are known to be junk; we filter these out below
+            if (!row.County || !row.State) {
+              return undefined;
+            }
+            // we only need a few columns, which we will explicitly format
+
+            // defaulting missing numbers to zero will not produce meaningful modeling
+            // but it should at least prevent the UI from breaking;
+            // users can still substitute their own values via form inputs
+            const reportedCases: number = numeral(row.cases).value() || 0;
+            const estimatedTotalCases: number =
+              reportedCases * (1 / caseReportingRate);
+            // TODO: distinguish jail vs prison?
+            const totalIncarceratedPopulation: number =
+              numeral(row["Total Incarcerated Population"]).value() || 0;
+            const totalPopulation: number =
+              numeral(row["Total Population"]).value() || 0;
+
+            return {
+              county: row.County,
+              state: row.State,
+              hospitalBeds: numeral(row["Hospital Beds"]).value() || 0,
+              totalIncarceratedPopulation,
+              reportedCases,
+              estimatedIncarceratedCases: Math.round(
+                totalPopulation
+                  ? (totalIncarceratedPopulation / totalPopulation) *
+                      estimatedTotalCases
+                  : 0,
+              ),
+            };
+          }).filter((row) => row !== undefined);
+
+          const nestedStateCounty: LocaleData = rollup(
+            parsedArray,
+            // there will only ever be one row object per county
+            (v: object[]) => v[0],
+            (d: DSVRowAny) => d.state as string,
+            (d: DSVRowAny) => d.county as string,
+            // some wrong/outdated typedefs for d3 are making typescript sad
+            // but this should check out
+          ) as LocaleData;
+
+          dispatch({
+            type: "update",
+            payload: {
+              data: nestedStateCounty,
+              loading: false,
+            },
+          });
+        } catch (error) {
+          console.error(error);
+          dispatch({
+            type: "update",
+            payload: { failed: true },
+          });
+        }
+      }
+      effect();
+    },
+    // we only want to run this once, on initial mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+};
+
+export function useLocaleDataState() {
+  const context = React.useContext(StateContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useLocaleDataState must be used within a LocaleDataProvider",
+    );
+  }
+
+  return context;
+}
+
+export function useLocaleDataDispatch() {
+  const context = React.useContext(DispatchContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useLocaleDataDispatch must be used within a LocaleDataProvider",
+    );
+  }
+
+  return context;
+}

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -12,7 +12,7 @@ type LocaleRecord = {
   totalIncarceratedPopulation: number;
 };
 
-type LocaleData = Map<string, Map<string, LocaleRecord>>;
+export type LocaleData = Map<string, Map<string, LocaleRecord>>;
 
 type LocaleDataUpdate = {
   loading?: boolean;

--- a/src/locale-data-context/index.tsx
+++ b/src/locale-data-context/index.tsx
@@ -1,0 +1,1 @@
+export * from "./LocaleDataContext";

--- a/src/page-model-inspection/ModelInspectionPage.tsx
+++ b/src/page-model-inspection/ModelInspectionPage.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
-import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import FacilityInformation from "../impact-dashboard/FacilityInformation";
 import LocaleInformation from "../impact-dashboard/LocaleInformation";
 import MitigationInformation from "../impact-dashboard/MitigationInformation";
@@ -36,10 +35,6 @@ const ChartsContainer = styled.div`
   margin: 0 15px;
 `;
 
-const ErrorMessage = styled.div`
-  margin: 10px;
-`;
-
 const ImpactDashboardVDiv = styled.div`
   display: flex;
   flex-direction: row;
@@ -62,31 +57,24 @@ const HorizontalDivider = styled.hr`
 `;
 
 const ModelInspectionPage: React.FC = () => {
-  const { countyLevelDataFailed } = useEpidemicModelState();
   return (
     <div>
-      {countyLevelDataFailed ? (
-        <ErrorMessage>Error: unable to load data!</ErrorMessage>
-      ) : (
-        <>
-          <SectionHeader>Locale Information</SectionHeader>
-          <LocaleInformation />
-          <SectionHeader>Facility Customization</SectionHeader>
-          <ImpactDashboardVDiv>
-            <FormColumn>
-              <SubsectionHeader>Facility Population</SubsectionHeader>
-              <FacilityInformation />
-              <HorizontalDivider />
-              <SubsectionHeader>COVID-19 Mitigation Efforts</SubsectionHeader>
-              <MitigationInformation />
-            </FormColumn>
-            <ChartsContainer>
-              <ModelOutputChartArea />
-            </ChartsContainer>
-          </ImpactDashboardVDiv>
-          <ModelInspectionTable />
-        </>
-      )}
+      <SectionHeader>Locale Information</SectionHeader>
+      <LocaleInformation />
+      <SectionHeader>Facility Customization</SectionHeader>
+      <ImpactDashboardVDiv>
+        <FormColumn>
+          <SubsectionHeader>Facility Population</SubsectionHeader>
+          <FacilityInformation />
+          <HorizontalDivider />
+          <SubsectionHeader>COVID-19 Mitigation Efforts</SubsectionHeader>
+          <MitigationInformation />
+        </FormColumn>
+        <ChartsContainer>
+          <ModelOutputChartArea />
+        </ChartsContainer>
+      </ImpactDashboardVDiv>
+      <ModelInspectionTable />
     </div>
   );
 };

--- a/src/page-model-inspection/ModelInspectionPageContainer.tsx
+++ b/src/page-model-inspection/ModelInspectionPageContainer.tsx
@@ -1,9 +1,15 @@
+import Loading from "../design-system/Loading";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
+import { useLocaleDataState } from "../locale-data-context";
 import ModelInspectionPage from "./ModelInspectionPage";
 
 const ModelInspectionPageContainer: React.FC = () => {
-  return (
-    <EpidemicModelProvider>
+  const { data, loading: localeDataLoading } = useLocaleDataState();
+
+  return localeDataLoading ? (
+    <Loading />
+  ) : (
+    <EpidemicModelProvider localeDataSource={data}>
       <ModelInspectionPage />
     </EpidemicModelProvider>
   );

--- a/src/page-model-inspection/ModelOutputChartContainer.tsx
+++ b/src/page-model-inspection/ModelOutputChartContainer.tsx
@@ -1,6 +1,5 @@
 import { sum, zip } from "d3-array";
 
-import Loading from "../design-system/Loading";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import { calculateCurves, CurveData } from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
@@ -25,9 +24,7 @@ const ModelOutputChartContainer: React.FC = () => {
     curveData[seirIndex[i]] = combinePopulations(projectionData, i);
   });
 
-  return modelData.countyLevelDataLoading ? (
-    <Loading />
-  ) : (
+  return (
     <ModelOutputChart
       curveData={curveData}
       hospitalBeds={modelData.hospitalBeds}

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -2,7 +2,10 @@ import React, { useContext } from "react";
 
 import { MarkColors as markColors } from "../design-system/Colors";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
-import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
+import {
+  totalConfirmedCases,
+  useEpidemicModelState,
+} from "../impact-dashboard/EpidemicModelContext";
 import { FacilityContext } from "./FacilityContext";
 
 const groupStatus = {
@@ -14,14 +17,12 @@ const groupStatus = {
 
 const FacilityRow: React.FC = () => {
   const facility = useContext(FacilityContext);
-
+  const confirmedCases = totalConfirmedCases(useEpidemicModelState());
   if (!facility) {
     throw new Error("Facility must be provided to the FacilityContext");
   }
 
-  const { name, modelInputs } = facility;
-
-  const confirmedCases = modelInputs.confirmedCases;
+  const { name } = facility;
 
   return (
     <div>
@@ -47,13 +48,11 @@ const FacilityRow: React.FC = () => {
           </div>
         </div>
         <div className="w-3/5">
-          {/* <EpidemicModelProvider facilityModel={modelInputs}>
-            <CurveChartContainer
-              chartHeight={200}
-              groupStatus={groupStatus}
-              markColors={markColors}
-            />
-          </EpidemicModelProvider> */}
+          <CurveChartContainer
+            chartHeight={200}
+            groupStatus={groupStatus}
+            markColors={markColors}
+          />
         </div>
       </div>
     </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -47,13 +47,13 @@ const FacilityRow: React.FC = () => {
           </div>
         </div>
         <div className="w-3/5">
-          <EpidemicModelProvider facilityModel={modelInputs}>
+          {/* <EpidemicModelProvider facilityModel={modelInputs}>
             <CurveChartContainer
               chartHeight={200}
               groupStatus={groupStatus}
               markColors={markColors}
             />
-          </EpidemicModelProvider>
+          </EpidemicModelProvider> */}
         </div>
       </div>
     </div>

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 
 import { getFacilities } from "../database";
 import Loading from "../design-system/Loading";
+import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
+import { useLocaleDataState } from "../locale-data-context";
 import AddFacilityModal from "./AddFacilityModal";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
@@ -19,6 +21,8 @@ const MultiFacilityImpactDashboardContainer = styled.main.attrs({
 })``;
 
 const MultiFacilityImpactDashboard: React.FC = () => {
+  const { data: localeDataSource } = useLocaleDataState();
+
   const [facilities, setFacilities] = useState({
     data: [] as Facilities,
     loading: true,
@@ -50,7 +54,12 @@ const MultiFacilityImpactDashboard: React.FC = () => {
           facilities?.data.map((facility, index) => {
             return (
               <FacilityContext.Provider key={index} value={facility}>
-                <FacilityRow />
+                <EpidemicModelProvider
+                  facilityModel={facility.modelInputs}
+                  localeDataSource={localeDataSource}
+                >
+                  <FacilityRow />
+                </EpidemicModelProvider>
               </FacilityContext.Provider>
             );
           })

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { getFacilities } from "../database";
 import Loading from "../design-system/Loading";
+import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
 import SiteHeader from "../site-header/SiteHeader";
 import AddFacilityModal from "./AddFacilityModal";
@@ -29,13 +30,10 @@ const MultiFacilityPage: React.FC = () => {
   });
 
   const {
-    data,
+    data: localeDataSource,
     failed: localeDataFailed,
     loading: localeDataLoading,
   } = useLocaleDataState();
-  if (!localeDataLoading && !localeDataFailed) {
-    console.log(data);
-  }
 
   useEffect(() => {
     async function fetchFacilities() {
@@ -77,7 +75,12 @@ const MultiFacilityPage: React.FC = () => {
                     facilities?.data.map((facility, index) => {
                       return (
                         <FacilityContext.Provider key={index} value={facility}>
-                          <FacilityRow />
+                          <EpidemicModelProvider
+                            facilityModel={facility.modelInputs}
+                            localeDataSource={localeDataSource}
+                          >
+                            <FacilityRow />
+                          </EpidemicModelProvider>
                         </FacilityContext.Provider>
                       );
                     })

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { getFacilities } from "../database";
 import Loading from "../design-system/Loading";
+import { useLocaleDataState } from "../locale-data-context";
 import SiteHeader from "../site-header/SiteHeader";
 import AddFacilityModal from "./AddFacilityModal";
 import { FacilityContext } from "./FacilityContext";
@@ -27,6 +28,15 @@ const MultiFacilityPage: React.FC = () => {
     loading: true,
   });
 
+  const {
+    data,
+    failed: localeDataFailed,
+    loading: localeDataLoading,
+  } = useLocaleDataState();
+  if (!localeDataLoading && !localeDataFailed) {
+    console.log(data);
+  }
+
   useEffect(() => {
     async function fetchFacilities() {
       const facilitiesData = await getFacilities();
@@ -47,22 +57,34 @@ const MultiFacilityPage: React.FC = () => {
         <div className="max-w-screen-xl px-4 mx-auto">
           <SiteHeader />
           <MultiFacilityImpactDashboard>
-            <ScenarioSidebar />
-            <div className="flex flex-col flex-1 pb-6 pl-8">
-              <AddFacilityModal />
-              <ProjectionsHeader />
-              {facilities.loading ? (
-                <Loading />
-              ) : (
-                facilities?.data.map((facility, index) => {
-                  return (
-                    <FacilityContext.Provider key={index} value={facility}>
-                      <FacilityRow />
-                    </FacilityContext.Provider>
-                  );
-                })
-              )}
-            </div>
+            {localeDataFailed ? (
+              // TODO: real error state
+              <div>
+                Unable to load state and county data. Please try refreshing the
+                page.
+              </div>
+            ) : localeDataLoading ? (
+              <Loading />
+            ) : (
+              <>
+                <ScenarioSidebar />
+                <div className="flex flex-col flex-1 pb-6 pl-8">
+                  <AddFacilityModal />
+                  <ProjectionsHeader />
+                  {facilities.loading ? (
+                    <Loading />
+                  ) : (
+                    facilities?.data.map((facility, index) => {
+                      return (
+                        <FacilityContext.Provider key={index} value={facility}>
+                          <FacilityRow />
+                        </FacilityContext.Provider>
+                      );
+                    })
+                  )}
+                </div>
+              </>
+            )}
           </MultiFacilityImpactDashboard>
         </div>
       </div>

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -1,8 +1,8 @@
-import { EpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
+import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
 
 export type Facility = {
   name: string;
-  modelInputs: EpidemicModelState;
+  modelInputs: EpidemicModelPersistent;
 };
 
 export type Facilities = Facility[];


### PR DESCRIPTION
## Description of the change

This untangles the loading of locale data (from the external spreadsheet) from the provisioning of an `EpidemicModelContext` and moves it to a new `LocaleDataContext` that I have just made globally available for now because multiple pages need it. Marshaling the required data to display a single facility now requires three roughly hierarchical contexts to be present: `LocaleDataContext`, `FacilityContext`, and `EpidemicModelContext`.  

`EpidemicModelContext` is much cleaner now because it no longer has to deal with the loading state of the locale data — it requires a source of locale data to be passed in when provisioned. It also does not bother with auto-saving or URL state management anymore, because we are no longer doing those things.

In terms of regression, I made sure that the existing Overview page as well as the Model Inspection page still work with this new data loading strategy. Not having any actual facility data and not being sure how to populate it, I haven't actually tested that `FacilityRow` behaves as expected now.

Something not strictly in scope but related enough that I decided to fix it (rather than reimplement it with the same mistake) was the conflation of "confirmed cases" with "estimated cases among the incarcerated", which @cawarren pointed out to me earlier this week. I assumed that the "cases" value we display for a facility should be the number of user-input cases at the facility, not the number of confirmed cases state- or county-wide, so I updated that at the same time as well. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #122 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
