### PR TITLE
properly initialize model context with locale data and saved model

### DIFF
--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -62,8 +62,6 @@ interface MetadataPersistent {
   // fields that we want to store
   countyName?: string;
   stateCode?: string;
-  hospitalBeds?: number;
-  confirmedCases?: number;
 }
 
 // some fields are required to display a sensible UI, define them here
@@ -80,8 +78,6 @@ export type EpidemicModelPersistent = ModelInputsPersistent &
 export const persistedKeys: Array<keyof EpidemicModelPersistent> = [
   "countyName",
   "stateCode",
-  "hospitalBeds",
-  "confirmedCases",
   "age0Cases",
   "age0Population",
   "age20Cases",
@@ -139,23 +135,15 @@ function getLocaleData(
   countyName: string,
 ) {
   return {
-    stateCode,
+    confirmedCases:
+      dataSource.get(stateCode)?.get(countyName)?.reportedCases || 0,
     countyName,
+    hospitalBeds: dataSource.get(stateCode)?.get(countyName)?.hospitalBeds || 0,
     localeDataSource: dataSource,
+    stateCode,
     totalIncarcerated:
       dataSource.get(stateCode)?.get(countyName)?.totalIncarceratedPopulation ||
       0,
-    hospitalBeds: dataSource.get(stateCode)?.get(countyName)?.hospitalBeds || 0,
-    ageUnknownPopulation:
-      dataSource.get(stateCode)?.get(countyName)?.totalIncarceratedPopulation ||
-      0,
-    ageUnknownCases:
-      dataSource.get(stateCode)?.get(countyName)?.estimatedIncarceratedCases ||
-      0,
-    confirmedCases:
-      dataSource.get(stateCode)?.get(countyName)?.reportedCases || 0,
-    staffCases: 0,
-    staffPopulation: 0,
   };
 }
 
@@ -210,14 +198,11 @@ export function EpidemicModelProvider({
   localeDataSource,
 }: EpidemicModelProviderProps) {
   const resetBase = getResetBase();
+  const stateCode = facilityModel?.stateCode || resetBase.stateCode;
+  const countyName = facilityModel?.countyName || resetBase.countyName;
   const initialState = {
     ...resetBase,
-    ...getLocaleData(
-      localeDataSource,
-      resetBase.stateCode,
-      resetBase.countyName,
-    ),
-    // any passed data (e.g. fetched from database) takes precedence
+    ...getLocaleData(localeDataSource, stateCode, countyName),
     ...(facilityModel || {}),
   };
 


### PR DESCRIPTION
## Description of the change

Following up on my comments on #138 I have fixed the issue with locale data ... as @sprad suspected there was a bug in the reset logic. Fixing it means we can remove `confirmedCases` and `hospitalBeds` from the saved model objects and join that saved data with the proper external locale data.

Now that the form is intended for a specific facility only, I don't really think that seeding the incarcerated population inputs with state- or county-wide data is such a sensible default anymore, so I just took that out. There is now just a single function to get all the default values for a locale and ensure that all required context fields are populated (which includes some metadata fields that are not locale-specific).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
