### PR TITLE
Fixing Spacing Issue on the Facility Page

### DIFF
--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -16,13 +16,18 @@ import LocaleInformationSection from "./LocaleInformationSection";
 const FacilityInputFormDiv = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
 `;
 const LeftColumn = styled.div`
   margin: 20px;
+  width: 45%;
 `;
 const RightColumn = styled.div`
   margin: 20px;
+  width: 55%;
+`;
+
+const ButtonSection = styled.div`
+  margin-top: 30px;
 `;
 
 // TODO add section header tooltips
@@ -55,7 +60,10 @@ const FacilityInputForm: React.FC = () => {
         <LocaleInformationSection />
         <FacilityInformationSection />
         <MitigationInformation />
-        <InputButton label="Save" onClick={save} />
+        <ButtonSection>
+          <InputButton label="Save" onClick={save} />
+        </ButtonSection>
+        <div className="mt-8" />
       </LeftColumn>
       <RightColumn>
         <ChartArea />


### PR DESCRIPTION
* Previously, the projection chart and table were a bit "smooshed" on the right hand side of the screen.  Adding specific width styles to more cleanly layout the page.

**Before**

<img width="1329" alt="Screen Shot 2020-04-19 at 12 55 48 PM" src="https://user-images.githubusercontent.com/25503/79694307-84bfce00-823d-11ea-98cd-336f4d47bfcd.png">

**After**

<img width="1294" alt="Screen Shot 2020-04-19 at 12 56 02 PM" src="https://user-images.githubusercontent.com/25503/79694311-8ab5af00-823d-11ea-874e-7e07f677aa4b.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
