### PR TITLE
Enable deleting a facility

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -18,6 +18,7 @@ const Colors = {
   lightBlue: "#33B6FF",
   paleGreen: "#D2DBDB",
   red: "#FF464A",
+  darkRed: "#C53B3E",
   white: "#ffffff",
   darkGreen: "#00413E",
 };

--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-const StyledButton = styled.button<Props>`
+export const StyledButton = styled.button<Props>`
   background: #00615c;
   font-size: 16px;
   border-radius: 12px;

--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -10,10 +10,10 @@ const ModalContainer = styled.div``;
 const ModalTrigger = styled.button`
   color: ${Colors.green};
   cursor: pointer;
-  font-family: 'Libre Baskerville', serif;
+  font-family: "Libre Baskerville", serif;
   font-size: 32px;
-  line-height: 32px
-  letter-spacing: -0.03em
+  line-height: 32px;
+  letter-spacing: -0.03em;
 `;
 
 interface Props {

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,8 +1,10 @@
 import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
+import styled from "styled-components";
 
-import { MarkColors as markColors } from "../design-system/Colors";
+import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
+import { StyledButton } from "../design-system/InputButton";
 import ModalDialog from "../design-system/ModalDialog";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import {
@@ -18,6 +20,42 @@ const groupStatus = {
   hospitalized: true,
   infectious: true,
 };
+
+const ModalContents = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  font-weight: normal;
+  justify-content: flex-start;
+  margin-top: 30px;
+`;
+
+const ModalText = styled.div`
+  font-size: 13px;
+  margin-right: 25px;
+`;
+
+const ModalButtons = styled.div`
+  /* display: flex;
+  flex-direction: column; */
+`;
+
+const ModalButton = styled(StyledButton)`
+  font-size: 14px;
+  font-weight: normal;
+`;
+
+const DeleteButton = styled(ModalButton)`
+  background: ${Colors.darkRed};
+  color: ${Colors.white};
+  margin-right: 15px;
+`;
+
+const CancelButton = styled(ModalButton)`
+  background: transparent;
+  border: 1px solid ${Colors.forest};
+  color: ${Colors.forest};
+`;
 
 interface Props {
   deleteFn: (id: string) => void;
@@ -39,7 +77,7 @@ const FacilityRow: React.FC<Props> = ({ deleteFn, facility }) => {
 
   // TODO: validate the arguments?
   const handleSubClick = (fn: Function, ...args: any[]) => {
-    return (event: React.MouseEvent<HTMLElement>) => {
+    return (event: React.MouseEvent<Element>) => {
       // This is required or else the openFacilityPage onClick will fire
       // since the Delete button lives within the same div that opens the
       // Facility Details page.
@@ -82,11 +120,20 @@ const FacilityRow: React.FC<Props> = ({ deleteFn, facility }) => {
                 open={showDeleteModal}
                 title="Are you sure?"
               >
-                <div>
-                  <div>This action cannot be undone</div>
-                  <button onClick={removeFacility}>do the thing</button>
-                  <button onClick={closeDeleteModal}>cancel</button>
-                </div>
+                <ModalContents>
+                  <ModalText>This action cannot be undone.</ModalText>
+                  <ModalButtons>
+                    <DeleteButton
+                      label="Delete facility"
+                      onClick={removeFacility}
+                    >
+                      Delete facility
+                    </DeleteButton>
+                    <CancelButton onClick={closeDeleteModal}>
+                      Cancel
+                    </CancelButton>
+                  </ModalButtons>
+                </ModalContents>
               </ModalDialog>
             </div>
           </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 
+import { deleteFacility } from "../database/index";
 import { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
@@ -29,9 +30,26 @@ const FacilityRow: React.FC<Props> = ({ facility }) => {
 
   const { id, name, updatedAt } = facility;
 
-  const openFacilityPage = (event: React.MouseEvent<HTMLElement>) => {
+  const openFacilityPage = () => {
     setFacility(facility);
     history.push("/multi-facility/facility");
+  };
+
+  const removeFacility = (event: React.MouseEvent<HTMLElement>) => {
+    // This is required or else the openFacilityPage onClick will fire
+    // since the Delete button lives within the same div that opens the
+    // Facility Details page.
+    event.stopPropagation();
+
+    // TODO: Needs confirmation modal
+
+    // In this context id should always be present, but TypeScript
+    // is complaining so I'm adding this check to appease it.
+    if (id) deleteFacility(id);
+
+    // TODO: Figure out how to update the facilities list so that the
+    // deleted facilty no longer appears on the page without having
+    // to manually refresh.
   };
 
   return (
@@ -47,14 +65,8 @@ const FacilityRow: React.FC<Props> = ({ facility }) => {
               Last update: <DateMMMMdyyyy date={new Date(updatedAt.toDate())} />
             </div>
             <div className="mr-8">
-              <a className="px-1" href="#">
+              <a className="px-1" href="#" onClick={removeFacility}>
                 Delete
-              </a>
-              <a className="px-1" href="#">
-                Edit
-              </a>
-              <a className="px-1" href="#">
-                Share
               </a>
             </div>
           </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -57,6 +57,17 @@ const CancelButton = styled(ModalButton)`
   color: ${Colors.forest};
 `;
 
+// TODO: validate the arguments?
+const handleSubClick = (fn: Function, ...args: any[]) => {
+  return (event: React.MouseEvent<Element>) => {
+    // This is required or else the openFacilityPage onClick will fire
+    // since the Delete button lives within the same div that opens the
+    // Facility Details page.
+    event.stopPropagation();
+    fn(...args);
+  };
+};
+
 interface Props {
   deleteFn: (id: string) => void;
   facility: Facility;
@@ -73,17 +84,6 @@ const FacilityRow: React.FC<Props> = ({ deleteFn, facility }) => {
   const openFacilityPage = () => {
     setFacility(facility);
     history.push("/multi-facility/facility");
-  };
-
-  // TODO: validate the arguments?
-  const handleSubClick = (fn: Function, ...args: any[]) => {
-    return (event: React.MouseEvent<Element>) => {
-      // This is required or else the openFacilityPage onClick will fire
-      // since the Delete button lives within the same div that opens the
-      // Facility Details page.
-      event.stopPropagation();
-      fn(...args);
-    };
   };
 
   const openDeleteModal = handleSubClick(updateShowDeleteModal, true);

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -2,12 +2,11 @@ import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
-import { getFacilities, saveScenario } from "../database";
+import { deleteFacility, getFacilities, saveScenario } from "../database";
 import Colors from "../design-system/Colors";
 import Loading from "../design-system/Loading";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
-import AddFacilityModal from "./AddFacilityModal";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
 import { ScenarioType } from "./MultiFacilityPage";
@@ -73,24 +72,29 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
     fetchScenario();
   }, []);
 
-  useEffect(() => {
-    async function fetchFacilities() {
-      const facilitiesData = await getFacilities();
+  async function fetchFacilities() {
+    const facilitiesData = await getFacilities();
 
-      if (facilitiesData) {
-        setFacilities({
-          data: facilitiesData,
-          loading: false,
-        });
-      }
+    if (facilitiesData) {
+      setFacilities({
+        data: facilitiesData,
+        loading: false,
+      });
     }
+  }
 
+  useEffect(() => {
     fetchFacilities();
   }, []);
 
-  const openAddFacilityPage = (event: React.MouseEvent<HTMLElement>) => {
+  const openAddFacilityPage = () => {
     setFacility(null);
     history.push("/multi-facility/facility");
+  };
+
+  const deleteFn = async (id: string) => {
+    await deleteFacility(id);
+    fetchFacilities();
   };
 
   return (
@@ -118,7 +122,7 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
                 facilityModel={facility.modelInputs}
                 localeDataSource={localeDataSource}
               >
-                <FacilityRow facility={facility} />
+                <FacilityRow deleteFn={deleteFn} facility={facility} />
               </EpidemicModelProvider>
             );
           })


### PR DESCRIPTION
## Description of the change

This picks up where @sprad left off in #146 to complete the delete functionality with a confirmation modal and refresh of the facility list to remove the deleted item.

There weren't mocks for the delete modal so I had to freestyle ... note the fact that our modal component does not have a configurable size at the moment so it looks a little roomy. @cawarren let me know please if there's something you want me to change in this flow. (e.g. closing the modal is equivalent to clicking "cancel" so maybe that's redundant but I erred on the side of caution.)

<img width="1369" alt="Screen Shot 2020-04-19 at 1 34 42 PM" src="https://user-images.githubusercontent.com/5385319/79700271-5fd15800-8249-11ea-9337-dcb5fa907c9c.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #147 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
