### PR TITLE
move multi-facility page to site home

### DIFF
--- a/src/entry-point-client/PageList.tsx
+++ b/src/entry-point-client/PageList.tsx
@@ -2,7 +2,6 @@ import GetInvolvedPage from "../page-get-involved/GetInvolvedPage";
 import ModelInspectionPage from "../page-model-inspection/";
 import FacilityPage from "../page-multi-facility/FacilityPage";
 import MultiFacilityPage from "../page-multi-facility/MultiFacilityPage";
-import OverviewPage from "../page-overview/OverviewPage";
 import UnsupportedBrowserPage from "../page-unsupported-browser/UnsupportedBrowserPage";
 import VerificationNeeded from "../page-verification-needed/VerificationNeeded";
 

--- a/src/entry-point-client/PageList.tsx
+++ b/src/entry-point-client/PageList.tsx
@@ -22,7 +22,7 @@ const PageList: PageInfo[] = [
     path: "/",
     title: getPageTitle(),
     isPrivate: true,
-    contents: <OverviewPage />,
+    contents: <MultiFacilityPage />,
   },
   {
     path: "/get-involved",
@@ -43,13 +43,7 @@ const PageList: PageInfo[] = [
     contents: <VerificationNeeded />,
   },
   {
-    path: "/multi-facility",
-    title: getPageTitle(),
-    isPrivate: true,
-    contents: <MultiFacilityPage />,
-  },
-  {
-    path: "/multi-facility/facility",
+    path: "/facility",
     title: getPageTitle(),
     isPrivate: true,
     contents: <FacilityPage />,

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -44,7 +44,7 @@ const FacilityInputForm: React.FC = () => {
       name: facilityName,
       modelInputs: JSON.parse(JSON.stringify(model))[0],
     });
-    history.push("/multi-facility");
+    history.push("/");
   };
 
   return (

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -83,7 +83,7 @@ const FacilityRow: React.FC<Props> = ({ deleteFn, facility }) => {
 
   const openFacilityPage = () => {
     setFacility(facility);
-    history.push("/multi-facility/facility");
+    history.push("/facility");
   };
 
   const openDeleteModal = handleSubClick(updateShowDeleteModal, true);

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -89,7 +89,7 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
 
   const openAddFacilityPage = () => {
     setFacility(null);
-    history.push("/multi-facility/facility");
+    history.push("/facility");
   };
 
   const deleteFn = async (id: string) => {


### PR DESCRIPTION
## Description of the change

This updates routes so that the multi-facility page is now site home, and the facility edit page is now at `/facility`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
