### PR TITLE
Persist system type at facility level

### DIFF
--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -36,12 +36,16 @@ const FacilityInputForm: React.FC = () => {
   const { facility } = useContext(FacilityContext);
   const history = useHistory();
   const [facilityName, setFacilityName] = useState(facility?.name);
+  const [systemType, setSystemType] = useState(
+    facility?.systemType || undefined,
+  );
   const model = useModel();
 
   const save = () => {
     saveFacility({
       id: facility?.id,
       name: facilityName,
+      systemType: systemType || null,
       modelInputs: JSON.parse(JSON.stringify(model))[0],
     });
     history.push("/multi-facility");
@@ -57,7 +61,10 @@ const FacilityInputForm: React.FC = () => {
           onValueChange={(value) => setFacilityName(value)}
         />
         <div className="mt-5 mb-5 border-b border-gray-300" />
-        <LocaleInformationSection />
+        <LocaleInformationSection
+          systemType={systemType}
+          setSystemType={setSystemType}
+        />
         <FacilityInformationSection />
         <MitigationInformation />
         <ButtonSection>

--- a/src/page-multi-facility/LocaleInformationSection.tsx
+++ b/src/page-multi-facility/LocaleInformationSection.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
@@ -25,13 +24,20 @@ const SectionHeader = styled.header`
   color: "${Colors.forest}"
 `;
 
-const LocaleInformationSection: React.FC = () => {
+interface Props {
+  systemType?: string;
+  setSystemType: (systemType?: string) => void;
+}
+
+const LocaleInformationSection: React.FC<Props> = ({
+  systemType,
+  setSystemType,
+}) => {
   const systemTypeList = [
-    { value: "Select..." },
+    { value: undefined },
     { value: "State Prison" },
     { value: "County Jail" },
   ];
-  const [systemType, updateSystemType] = useState(systemTypeList[0].value);
 
   return (
     <LocaleInformationSectionDiv>
@@ -40,9 +46,7 @@ const LocaleInformationSection: React.FC = () => {
         <InputSelect
           label="Type of System"
           value={systemType}
-          onChange={(event) => {
-            updateSystemType(event.target.value);
-          }}
+          onChange={(event) => setSystemType(event.target.value)}
         >
           {systemTypeList.map(({ value }) => (
             <option key={value} value={value}>

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -3,6 +3,7 @@ import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContex
 export type Facility = {
   id?: string;
   name: string;
+  systemType?: string;
   modelInputs: EpidemicModelPersistent;
   createdAt: Timestamp;
   updatedAt: Timestamp;


### PR DESCRIPTION
## Description of the change

Update to persist the selected system type (jail vs. prison) for a facility. UI was already in place.

Per discussion with Andrew, the selected type may be used to pre-populate model inputs, but it's not expected to be used as an input itself.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
