### PR TITLE
Update Firestore security rules and Firestore queries so that users can only access their own scenarios

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -8,8 +8,19 @@ service cloud.firestore {
   }
 
   match /databases/{database}/documents {
-    match /scenarios/{documents=**} {
-      allow read, write: if request.auth.uid != null;
+    match /scenarios/{scenario} {
+      function userCanAccess(scenario) {
+        return scenario.data.roles[request.auth.uid] == 'owner';
+      }
+
+      allow create: if request.auth.uid != null;
+
+      // Scenario owners (and only scenario owners) should have read/write access to their scenarios and child documents
+      allow read, write: if userCanAccess(resource);
+
+      match /{documents=**} {
+        allow read, write: if userCanAccess(get(/databases/$(database)/documents/scenarios/$(scenario)));
+      }
     }
   }
 }


### PR DESCRIPTION
## Description of the change

Users should be able to continue to access existing scenarios as expected. I tested this with existing scenarios and in the initial flow when the user doesn't yet have a baseline scenario.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #118

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
