### PR TITLE
Changes the welcome modal redirect to facility page

### DIFF
--- a/src/page-multi-facility/CreateBaselineScenarioPage.tsx
+++ b/src/page-multi-facility/CreateBaselineScenarioPage.tsx
@@ -37,8 +37,8 @@ const CreateBaselineScenarioPage: React.FC = () => {
   const handleOnClick = async () => {
     const baselineScenarioRef = await createBaselineScenario();
     if (baselineScenarioRef) {
-      // TODO: Replace this with create facility page path when ready
-      history.push("/");
+      // Redirect to new facility page after entering welcome modal
+      history.push("/facility");
     }
   };
 

--- a/src/page-multi-facility/CreateBaselineScenarioPage.tsx
+++ b/src/page-multi-facility/CreateBaselineScenarioPage.tsx
@@ -37,7 +37,7 @@ const CreateBaselineScenarioPage: React.FC = () => {
   const handleOnClick = async () => {
     const baselineScenarioRef = await createBaselineScenario();
     if (baselineScenarioRef) {
-      // Redirect to new facility page after entering welcome modal
+      // Redirect to new facility page after exiting welcome modal
       history.push("/facility");
     }
   };


### PR DESCRIPTION
## Description of the change

According to the mocks, after the welcome modal is clicked through we should go straight to the facility details page, not the scenario details page. This updates that, and in the process gets around a bug that caused the modal to not disappear after clicking okay (since the modal route is the same as the scenario details route, `history.push` doesn't seem to redirect).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #70 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
