### PR TITLE
Adds default facility name in case users forgets to set one

### DIFF
--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -44,7 +44,7 @@ const FacilityInputForm: React.FC = () => {
   const save = () => {
     saveFacility({
       id: facility?.id,
-      name: facilityName,
+      name: facilityName || "Unnamed Facility",
       systemType: systemType || null,
       modelInputs: JSON.parse(JSON.stringify(model))[0],
     });


### PR DESCRIPTION
## Description of the change

I considered adding validating the name is entered and displaying an error if it's not but thought it a slightly better user experience to just provide a default name that they can rename if they desire. Open to being wrong on this one!

I tested that this saves the facility model successfully with the title of "Unnamed Facility" and that saving multiple models in this way does not break. Multiple models with the same name is acceptable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #70 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
