### PR TITLE
Adds circles with proper colors for the projection headers

### DIFF
--- a/src/page-multi-facility/ProjectionsHeader.tsx
+++ b/src/page-multi-facility/ProjectionsHeader.tsx
@@ -18,16 +18,19 @@ const ProjectionsHeader: React.FC = () => {
         <div>Projection</div>
         <div>
           <span className="ml-6">
-            <LegendCircle color={markColors.fatalities}>•</LegendCircle> Fatalities
+            <LegendCircle color={markColors.fatalities}>•</LegendCircle>{" "}
+            Fatalities
           </span>
           <span className="ml-6">
             <LegendCircle color={markColors.exposed}>•</LegendCircle> Exposed
           </span>
           <span className="ml-6">
-            <LegendCircle color={markColors.infectious}>•</LegendCircle> Infectious
+            <LegendCircle color={markColors.infectious}>•</LegendCircle>{" "}
+            Infectious
           </span>
           <span className="ml-6">
-            <LegendCircle color={markColors.hospitalized}>•</LegendCircle> Hospitalized
+            <LegendCircle color={markColors.hospitalized}>•</LegendCircle>{" "}
+            Hospitalized
           </span>
         </div>
       </div>

--- a/src/page-multi-facility/ProjectionsHeader.tsx
+++ b/src/page-multi-facility/ProjectionsHeader.tsx
@@ -1,3 +1,12 @@
+import styled from "styled-components";
+
+import { MarkColors as markColors } from "../design-system/Colors";
+
+const LegendCircle = styled.span`
+  color: ${(props) => props.color};
+  font-size: 18px;
+`;
+
 const ProjectionsHeader: React.FC = () => {
   return (
     <div className="border-t border-b border-gray-300 mt-5 mb-5 py-2 flex flex-row">
@@ -8,10 +17,18 @@ const ProjectionsHeader: React.FC = () => {
       <div className="w-3/5 flex flex-row justify-between">
         <div>Projection</div>
         <div>
-          <span className="ml-6">Fatalities</span>
-          <span className="ml-6">Exposed</span>
-          <span className="ml-6">Infectious</span>
-          <span className="ml-6">Hospitalized</span>
+          <span className="ml-6">
+            <LegendCircle color={markColors.fatalities}>•</LegendCircle> Fatalities
+          </span>
+          <span className="ml-6">
+            <LegendCircle color={markColors.exposed}>•</LegendCircle> Exposed
+          </span>
+          <span className="ml-6">
+            <LegendCircle color={markColors.infectious}>•</LegendCircle> Infectious
+          </span>
+          <span className="ml-6">
+            <LegendCircle color={markColors.hospitalized}>•</LegendCircle> Hospitalized
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description of the change

The projection headers are just text, but the mocks call for bullet point circles before each header, with the appropriate color. Now it looks like:

<img width="863" alt="Screen Shot 2020-04-19 at 23 31 10" src="https://user-images.githubusercontent.com/431895/79717167-0a6f6800-8296-11ea-8a52-fd35228ebc5c.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #70 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
