### PR TITLE
Adds promise resolve to avoid race condition on save

### DIFF
--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -47,7 +47,7 @@ const FacilityInputForm: React.FC = () => {
       name: facilityName,
       systemType: systemType || null,
       modelInputs: JSON.parse(JSON.stringify(model))[0],
-    }).then(_ => {
+    }).then((_) => {
       history.push("/");
     });
   };

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -47,8 +47,9 @@ const FacilityInputForm: React.FC = () => {
       name: facilityName,
       systemType: systemType || null,
       modelInputs: JSON.parse(JSON.stringify(model))[0],
+    }).then(_ => {
+      history.push("/");
     });
-    history.push("/");
   };
 
   return (


### PR DESCRIPTION
## Description of the change

As originally revealed [here](https://github.com/Recidiviz/covid19-dashboard/pull/143#discussion_r410909753), there is a race condition on save where if the page that we navigate to loads before the save is complete, then an error is returned as the next page attempts to call a function on a field in the model which is not yet non-null. Specifically, the error happens at `updatedAt.toDate()` on L112 in `FacilityRow`. However, I think just fixing that field would begin a game of whack-a-mole and eventually another field would get invoked and cause a different break.

Since `database/index.saveFacility` returns a Promise, I think this is the way to avoid the race condition by ensuring the navigation to the next page happens only once the save has completed. We're not using a `catch` for any errors but we need a holistic error-presenting solution anyway.

_Note_: After initially reproducing this a couple of times myself, I have not been able to reproduce again in the last 15-20 minutes. However, I tested this by inserting an artificial delay of 3 seconds into the database call and ensuring that we didn't navigate away until the promise resolved.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #70 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
