### PR TITLE
link EpidemicModelProviders to specific facilities

### DIFF
--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -118,7 +118,7 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
           facilities?.data.map((facility, index) => {
             return (
               <EpidemicModelProvider
-                key={index}
+                key={facility.id}
                 facilityModel={facility.modelInputs}
                 localeDataSource={localeDataSource}
               >


### PR DESCRIPTION
## Description of the change

Because the multiple `EpidemicModelContext` objects on the dashboard were keyed by index, they were susceptible to getting out of sync with their underlying facility data after one was deleted. Keying them off the facility's unique ID prevents that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Fixes #158 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
