### PR TITLE
Include population turnover in calculation model 

### DIFF
--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -9,9 +9,20 @@ const TextInputContainer = styled.div`
   flex-direction: column;
 `;
 
-const VDiv = styled.div`
+const InputWrapper = styled(StyledInput)`
+  align-items: center;
   display: flex;
   flex-direction: row;
+`;
+
+const WrappedInput = styled(StyledInput)`
+  margin: 0;
+  padding: 0;
+  /*
+    This is a little weird but we need a fixed number to override
+    default sizing. Element will still flex as needed.
+  */
+  width: 0;
 `;
 
 interface Props extends InputBaseProps<string> {
@@ -36,8 +47,8 @@ const InputText: React.FC<Props> = (props) => {
   return (
     <TextInputContainer>
       <InputLabelAndHelp label={props.labelAbove} labelHelp={props.labelHelp} />
-      <VDiv>
-        <StyledInput
+      <InputWrapper as="div">
+        <WrappedInput
           type={props.type}
           ref={nameInput}
           value={inputValue ?? ""}
@@ -48,7 +59,7 @@ const InputText: React.FC<Props> = (props) => {
           onKeyDown={props.onKeyDown}
         />
         {props.children}
-      </VDiv>
+      </InputWrapper>
     </TextInputContainer>
   );
 };

--- a/src/design-system/InputTextNumeric.tsx
+++ b/src/design-system/InputTextNumeric.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 
 import { InputBaseProps } from "./Input";
 import InputText from "./InputText";
@@ -6,6 +7,10 @@ import InputText from "./InputText";
 interface Props extends InputBaseProps<number> {
   type: "number" | "percent";
 }
+
+const PctAddon = styled.div`
+  margin-left: 6px;
+`;
 
 const InputTextNumeric: React.FC<Props> = (props) => {
   function onValueChange(value: string | undefined) {
@@ -42,7 +47,9 @@ const InputTextNumeric: React.FC<Props> = (props) => {
         props.labelPlaceholder ??
         (props.type === "number" ? "Enter number" : "Enter a percentage")
       }
-    />
+    >
+      {props.type === "percent" && <PctAddon>%</PctAddon>}
+    </InputText>
   );
 };
 

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -38,10 +38,11 @@ interface ModelInputsPersistent {
   ageUnknownPopulation?: number;
   facilityDormitoryPct?: number;
   facilityOccupancyPct?: number;
+  plannedReleases?: PlannedReleases;
+  populationTurnover?: number;
   rateOfSpreadFactor?: RateOfSpread;
   staffCases?: number;
   staffPopulation?: number;
-  plannedReleases?: PlannedReleases;
 }
 
 interface ModelInputsUpdate extends ModelInputsPersistent {
@@ -56,6 +57,7 @@ export interface EpidemicModelInputs extends ModelInputsUpdate {
   usePopulationSubsets: boolean;
   facilityDormitoryPct: number;
   facilityOccupancyPct: number;
+  populationTurnover: number;
 }
 
 interface MetadataPersistent {
@@ -96,10 +98,11 @@ export const persistedKeys: Array<keyof EpidemicModelPersistent> = [
   "ageUnknownPopulation",
   "facilityDormitoryPct",
   "facilityOccupancyPct",
+  "plannedReleases",
+  "populationTurnover",
   "rateOfSpreadFactor",
   "staffCases",
   "staffPopulation",
-  "plannedReleases",
 ];
 
 export type EpidemicModelUpdate = ModelInputsUpdate & MetadataPersistent;
@@ -153,6 +156,7 @@ function getLocaleDefaults(
     rateOfSpreadFactor: RateOfSpread.high,
     facilityOccupancyPct: 1,
     facilityDormitoryPct: 0.15,
+    populationTurnover: 0,
   };
 }
 

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -152,7 +152,7 @@ const FacilityInformation: React.FC = () => {
               <InputTextNumeric
                 key="occupancy"
                 type="percent"
-                labelAbove="Occupancy rate (%)"
+                labelAbove="Occupancy rate"
                 labelHelp="Enter occupancy rate as a percent of capacity."
                 valueEntered={model.facilityOccupancyPct}
                 onValueChange={(value) =>
@@ -162,7 +162,7 @@ const FacilityInformation: React.FC = () => {
               <InputTextNumeric
                 key="bunks"
                 type="percent"
-                labelAbove="Bunk-Style Housing (%)"
+                labelAbove="Bunk-Style Housing"
                 labelHelp="Enter the percent of facility in dormitory bunk style housing."
                 valueEntered={model.facilityDormitoryPct as number}
                 onValueChange={(value) =>

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -179,8 +179,10 @@ const FacilityInformation: React.FC = () => {
                 labelAbove="Population turnover"
                 labelHelp={`Admissions as a percent of releases in a typical 3mo period
                   (e.g., April - June 2019). Can be over or under 100%.`}
-                valueEntered={undefined}
-                onValueChange={() => undefined}
+                valueEntered={model.populationTurnover}
+                onValueChange={(value) =>
+                  updateModel({ populationTurnover: value })
+                }
               />,
             ]}
           />

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -1,7 +1,9 @@
+import numeral from "numeral";
 import styled from "styled-components";
 
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import TextLabel from "../design-system/TextLabel";
+import { getAdjustedTotalPopulation } from "../infection-model";
 import Description from "./Description";
 import { EpidemicModelUpdate } from "./EpidemicModelContext";
 import { FormGrid, FormGridCell, FormGridRow } from "./FormGrid";
@@ -22,6 +24,11 @@ const LabelCell: React.FC = (props) => (
 const InputCell: React.FC = (props) => (
   <FormGridCell width={39}>{props.children}</FormGridCell>
 );
+
+const InputNote = styled(Description)`
+  margin-bottom: 0;
+  font-style: italic;
+`;
 
 interface FormRowProps {
   inputs: React.ReactNodeArray;
@@ -173,17 +180,25 @@ const FacilityInformation: React.FC = () => {
           />
           <FormRow
             inputs={[
-              <InputTextNumeric
-                key="turnover"
-                type="percent"
-                labelAbove="Population turnover"
-                labelHelp={`Admissions as a percent of releases in a typical 3mo period
+              <>
+                <InputTextNumeric
+                  key="turnover"
+                  type="percent"
+                  labelAbove="Population turnover"
+                  labelHelp={`Admissions as a percent of releases in a typical 3mo period
                   (e.g., April - June 2019). Can be over or under 100%.`}
-                valueEntered={model.populationTurnover}
-                onValueChange={(value) =>
-                  updateModel({ populationTurnover: value })
-                }
-              />,
+                  valueEntered={model.populationTurnover}
+                  onValueChange={(value) =>
+                    updateModel({ populationTurnover: value })
+                  }
+                />
+                {model.populationTurnover !== 0 && (
+                  <InputNote>
+                    Your updated total population impacted is{" "}
+                    {numeral(getAdjustedTotalPopulation(model)).format("0,0")}
+                  </InputNote>
+                )}
+              </>,
             ]}
           />
         </FormGrid>

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -23,6 +23,18 @@ const InputCell: React.FC = (props) => (
   <FormGridCell width={39}>{props.children}</FormGridCell>
 );
 
+interface FormRowProps {
+  inputs: React.ReactNodeArray;
+}
+
+const FormRow: React.FC<FormRowProps> = ({ inputs }) => (
+  <FormGridRow>
+    {inputs.map((input, i) => (
+      <FormGridCell key={i}>{input}</FormGridCell>
+    ))}
+  </FormGridRow>
+);
+
 interface FormHeaderRowProps {
   label: string;
 }
@@ -39,13 +51,13 @@ const FormHeaderRow: React.FC<FormHeaderRowProps> = (props) => (
   </LabelRow>
 );
 
-interface FormRowProps {
+interface AgeGroupRowProps {
   label: string;
   leftKey: keyof EpidemicModelUpdate;
   rightKey: keyof EpidemicModelUpdate;
 }
 
-const FormRow: React.FC<FormRowProps> = (props) => {
+const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
   const [model, updateModel] = useModel();
 
   return (
@@ -71,38 +83,9 @@ const FormRow: React.FC<FormRowProps> = (props) => {
   );
 };
 
-const BottomRow: React.FC = () => {
+const FacilityInformation: React.FC = () => {
   const [model, updateModel] = useModel();
 
-  return (
-    <FormGridRow>
-      <FormGridCell>
-        <InputTextNumeric
-          type="percent"
-          labelAbove="Capacity (%)"
-          labelHelp="Enter population as a percent of facility built capacity."
-          valueEntered={model.facilityOccupancyPct}
-          onValueChange={(value) =>
-            updateModel({ facilityOccupancyPct: value })
-          }
-        />
-      </FormGridCell>
-      <FormGridCell>
-        <InputTextNumeric
-          type="percent"
-          labelAbove="Bunk-Style Housing (%)"
-          labelHelp="Enter the percent of facility in dormitory bunk style housing."
-          valueEntered={model.facilityDormitoryPct as number}
-          onValueChange={(value) =>
-            updateModel({ facilityDormitoryPct: value })
-          }
-        />
-      </FormGridCell>
-    </FormGridRow>
-  );
-};
-
-const FacilityInformation: React.FC = () => {
   return (
     <FacilityInformationDiv>
       <Description>
@@ -114,7 +97,7 @@ const FacilityInformation: React.FC = () => {
       <div>
         <FormGrid>
           <FormHeaderRow label="Staff Population" />
-          <FormRow
+          <AgeGroupRow
             label="Facility Staff"
             leftKey="staffCases"
             rightKey="staffPopulation"
@@ -122,49 +105,85 @@ const FacilityInformation: React.FC = () => {
           {/* empty row for spacing */}
           <FormGridRow />
           <FormHeaderRow label="Total Population" />
-          <FormRow
+          <AgeGroupRow
             label="Ages Unknown"
             leftKey="ageUnknownCases"
             rightKey="ageUnknownPopulation"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 0-19"
             leftKey="age0Cases"
             rightKey="age0Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 20-44"
             leftKey="age20Cases"
             rightKey="age20Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 45-54"
             leftKey="age45Cases"
             rightKey="age45Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 55-64"
             leftKey="age55Cases"
             rightKey="age55Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 65-74"
             leftKey="age65Cases"
             rightKey="age65Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 75-84"
             leftKey="age75Cases"
             rightKey="age75Population"
           />
-          <FormRow
+          <AgeGroupRow
             label="Ages 85+"
             leftKey="age85Cases"
             rightKey="age85Population"
           />
         </FormGrid>
         <FormGrid>
-          <BottomRow />
+          <FormRow
+            inputs={[
+              <InputTextNumeric
+                key="occupancy"
+                type="percent"
+                labelAbove="Occupancy rate (%)"
+                labelHelp="Enter occupancy rate as a percent of capacity."
+                valueEntered={model.facilityOccupancyPct}
+                onValueChange={(value) =>
+                  updateModel({ facilityOccupancyPct: value })
+                }
+              />,
+              <InputTextNumeric
+                key="bunks"
+                type="percent"
+                labelAbove="Bunk-Style Housing (%)"
+                labelHelp="Enter the percent of facility in dormitory bunk style housing."
+                valueEntered={model.facilityDormitoryPct as number}
+                onValueChange={(value) =>
+                  updateModel({ facilityDormitoryPct: value })
+                }
+              />,
+            ]}
+          />
+          <FormRow
+            inputs={[
+              <InputTextNumeric
+                key="turnover"
+                type="percent"
+                labelAbove="Population turnover"
+                labelHelp={`Admissions as a percent of releases in a typical 3mo period
+                  (e.g., April - June 2019). Can be over or under 100%.`}
+                valueEntered={undefined}
+                onValueChange={() => undefined}
+              />,
+            ]}
+          />
         </FormGrid>
       </div>
     </FacilityInformationDiv>

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -35,6 +35,7 @@ function prepareCurveData(inputs: EpidemicModelInputs): CurveProjectionInputs {
     facilityDormitoryPct,
     facilityOccupancyPct,
     plannedReleases,
+    populationTurnover,
     rateOfSpreadFactor,
     staffCases,
     staffPopulation,
@@ -78,6 +79,7 @@ function prepareCurveData(inputs: EpidemicModelInputs): CurveProjectionInputs {
     facilityOccupancyPct,
     numDays,
     plannedReleases,
+    populationTurnover,
     rateOfSpreadFactor,
   };
 }

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -65,7 +65,7 @@ function prepareCurveData(inputs: EpidemicModelInputs): CurveProjectionInputs {
     usePopulationSubsets,
   } = inputs;
 
-  const numDays = 75;
+  const numDays = 90;
 
   const ageGroupPopulations = prepareAgeGroupPopulations(inputs);
 

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -24,6 +24,7 @@ export interface CurveProjectionInputs extends SimulationInputs {
   facilityOccupancyPct: number;
   rateOfSpreadFactor: RateOfSpread;
   plannedReleases?: PlannedReleases;
+  populationTurnover: number;
 }
 
 interface SingleDayInputs {
@@ -205,6 +206,9 @@ enum R0Dorms {
   high = 7,
 }
 
+// factor for estimating population adjustment based on expected turnover
+const populationAdjustmentRatio = 0.0879;
+
 export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   let {
     ageGroupInitiallyInfected,
@@ -213,6 +217,7 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     facilityOccupancyPct,
     numDays,
     plannedReleases,
+    populationTurnover,
     rateOfSpreadFactor,
   } = inputs;
 
@@ -260,6 +265,11 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     (1 - facilityOccupancyPct) *
       (rateOfSpreadDorms - rateOfSpreadDormsAdjustment);
 
+  // adjust population figures based on expected turnover
+  const adjustRate = populationTurnover * populationAdjustmentRatio;
+  ageGroupPopulations = ageGroupPopulations.map((pop, i) =>
+    i === ageGroupIndex.staff ? pop : pop + pop * adjustRate,
+  );
   const totalPopulationByDay = new Array(numDays);
   totalPopulationByDay[0] = sum(ageGroupPopulations);
 

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -206,8 +206,21 @@ enum R0Dorms {
   high = 7,
 }
 
-// factor for estimating population adjustment based on expected turnover
-const populationAdjustmentRatio = 0.0879;
+export const adjustPopulations = ({
+  ageGroupPopulations,
+  populationTurnover,
+}: {
+  ageGroupPopulations: CurveProjectionInputs["ageGroupPopulations"];
+  populationTurnover: number;
+}): number[] => {
+  // factor for estimating population adjustment based on expected turnover
+  const populationAdjustmentRatio = 0.0879;
+  const adjustRate = populationTurnover * populationAdjustmentRatio;
+
+  return ageGroupPopulations.map((pop, i) =>
+    i === ageGroupIndex.staff ? pop : pop + pop * adjustRate,
+  );
+};
 
 export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   let {
@@ -266,10 +279,10 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
       (rateOfSpreadDorms - rateOfSpreadDormsAdjustment);
 
   // adjust population figures based on expected turnover
-  const adjustRate = populationTurnover * populationAdjustmentRatio;
-  ageGroupPopulations = ageGroupPopulations.map((pop, i) =>
-    i === ageGroupIndex.staff ? pop : pop + pop * adjustRate,
-  );
+  ageGroupPopulations = adjustPopulations({
+    ageGroupPopulations,
+    populationTurnover,
+  });
   const totalPopulationByDay = new Array(numDays);
   totalPopulationByDay[0] = sum(ageGroupPopulations);
 


### PR DESCRIPTION
## Description of the change

Allows users to enter an expected 3-month population turnover rate, which we will use to adjust the given population numbers to account for population change over time.

Because this is implemented in the Excel model, I verified the JS output against the Excel output for correctness.

Also includes a UI improvement for percentage inputs that more clearly indicates to the user that a value is a percentage (we were previously working around this by adding "(%)" to the input labels because an earlier implementation of this feature was incomplete), and some refactoring of the form layout components. (This was actually done a week or so ago but it seems to have weathered all the subsequent UI changes without any problems so I left it in.)

<img width="560" alt="Screen Shot 2020-04-20 at 6 26 40 PM" src="https://user-images.githubusercontent.com/5385319/79815132-c1222580-8334-11ea-967d-c6082e4e34a8.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #61 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
