### PR TITLE
remove height scroll on multi facility dashboard

### DIFF
--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -16,7 +16,6 @@ import { Facilities, Scenario } from "./types";
 
 const MultiFacilityImpactDashboardContainer = styled.main.attrs({
   className: `
-    h-screen
     flex
     mt-8
   `,


### PR DESCRIPTION
## Description of the change
remove `h-screen` class from `MultiFacilityImpactDashboardContainer` to prevent it from having a `height = 100vh`. I believe you would only want that on `...Page` components (as elsewhere in the app).

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of [#167 ]

> P1: Multi-facility page scrolls for no reason (nothing down there)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
