### PR TITLE
update page title and remove subhead

### DIFF
--- a/src/entry-point-client/PageList.tsx
+++ b/src/entry-point-client/PageList.tsx
@@ -13,7 +13,7 @@ export interface PageInfo {
 }
 
 function getPageTitle(...parts: string[]) {
-  return [...parts, "COVID-19 Dashboard"].join(" • ");
+  return ["Recidiviz", "Covid-19 Incarceration Model", ...parts].join(" • ");
 }
 
 const PageList: PageInfo[] = [

--- a/src/site-header/SiteHeader.tsx
+++ b/src/site-header/SiteHeader.tsx
@@ -26,11 +26,6 @@ const LogoContainer = styled.div`
   font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.05em;
-  text-transform: uppercase;
-`;
-
-const Subhead = styled.div`
-  margin-left: 1em;
 `;
 
 const SiteHeader: React.FC = () => {
@@ -43,7 +38,6 @@ const SiteHeader: React.FC = () => {
       <Link to="/">
         <LogoContainer>
           <Logo />
-          <Subhead>COVID-19 Incarceration Model</Subhead>
         </LogoContainer>
       </Link>
       {/* <!-- Nav Items and Social Links --> */}

--- a/src/site-header/SiteHeader.tsx
+++ b/src/site-header/SiteHeader.tsx
@@ -18,16 +18,6 @@ const Nav = styled.nav`
   justify-content: space-between;
 `;
 
-const LogoContainer = styled.div`
-  align-items: flex-end;
-  color: ${Colors.red};
-  display: flex;
-  font-family: "Poppins", sans-serif;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: -0.05em;
-`;
-
 const SiteHeader: React.FC = () => {
   const { isAuthenticated, loginWithRedirect, logout } = (useAuth0 as any)();
 
@@ -36,9 +26,7 @@ const SiteHeader: React.FC = () => {
   return (
     <Nav>
       <Link to="/">
-        <LogoContainer>
-          <Logo />
-        </LogoContainer>
+        <Logo />
       </Link>
       {/* <!-- Nav Items and Social Links --> */}
       <div className="flex items-center justify-between">


### PR DESCRIPTION
update page title and remove subhead

## Description of the change

change page title from `Page Name • COVID-19 Dashboard` to `Recidiviz • Covid-19 Incarceration Model • Page Name`. For home page (and default), will just say `Recidiviz • Covid-19 Incarceration Model`

I worked with Andrew sending screenshots and we arrived at this design.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of [#167 ]
> P1: Remove ‘COVID-19 INCARCERATION MODEL’ in page header / top nav, make the page title ‘Recidiviz | Covid-19 Incarceration Model’

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
