### PR TITLE
multi-facility dashboard: fix up headings and add icons per design

### DIFF
--- a/src/design-system/icons/ic_add.svg
+++ b/src/design-system/icons/ic_add.svg
@@ -1,0 +1,8 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <circle cx="10" cy="10" r="9.5" stroke="#C8D3D3"/>
+  </g>
+  <g transform="translate(6,6)">
+    <path opacity="0.5" d="M5 1C5 0.447715 4.55228 0 4 0C3.44772 0 3 0.447715 3 1V3H1C0.447715 3 0 3.44772 0 4C0 4.55228 0.447715 5 1 5H3V7C3 7.55228 3.44772 8 4 8C4.55228 8 5 7.55228 5 7V5H7C7.55228 5 8 4.55228 8 4C8 3.44772 7.55228 3 7 3H5V1Z" fill="#005450"/>
+  </g>
+</svg>

--- a/src/design-system/icons/ic_folder.svg
+++ b/src/design-system/icons/ic_folder.svg
@@ -1,0 +1,8 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path d="M12 4.5V3C12 2.55 11.7 2.25 11.25 2.25H6.3L4.275 0.225C4.125 0.075 3.975 0 3.75 0H0.75C0.3 0 0 0.3 0 0.75V4.5H12Z" fill="#005450"/>
+  </g>
+  <g transform="translate(0, 6)">
+    <path d="M0 0V5.25C0 5.7 0.3 6 0.75 6H11.25C11.7 6 12 5.7 12 5.25V0H0Z" fill="#005450"/>
+  </g>
+</svg>

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { deleteFacility, getFacilities, saveScenario } from "../database";
 import Colors from "../design-system/Colors";
+import iconAddSrc from "../design-system/icons/ic_add.svg";
 import Loading from "../design-system/Loading";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
@@ -26,13 +27,23 @@ interface Props {
 }
 
 const AddFacilityButton = styled.button`
-  color: ${Colors.green};
+  color: ${Colors.forest};
   cursor: pointer;
   font-family: "Libre Baskerville", serif;
-  font-size: 32px;
-  line-height: 32px;
-  letter-spacing: -0.03em;
+  font-size: 24px;
+  line-height: 1;
   text-align: left;
+`;
+
+const IconAdd = styled.img`
+  display: inline;
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+`;
+
+const AddFacilityButtonText = styled.span`
+  vertical-align: middle;
 `;
 
 const MultiFacilityImpactDashboard: React.FC<Props> = ({
@@ -108,7 +119,8 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
       )}
       <div className="flex flex-col flex-1 pb-6 pl-8">
         <AddFacilityButton onClick={openAddFacilityPage}>
-          + Add Facility
+          <IconAdd alt="add facility" src={iconAddSrc} />
+          <AddFacilityButtonText>Add Facility</AddFacilityButtonText>
         </AddFacilityButton>
         <ProjectionsHeader />
         {facilities.loading ? (

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -2,7 +2,9 @@ import { format } from "date-fns";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import Colors from "../design-system/Colors";
 import iconEditSrc from "../design-system/icons/ic_edit.svg";
+import iconFolderSrc from "../design-system/icons/ic_folder.svg";
 import InputText from "../design-system/InputText";
 import InputTextArea from "../design-system/InputTextArea";
 import PromoBoxWithButton from "../design-system/PromoBoxWithButton";
@@ -15,6 +17,13 @@ const ScenarioNameLabel = styled.label`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+`;
+
+const IconFolder = styled.img`
+  display: inline;
+  width: 12px;
+  height: 12px;
+  margin-right: 12px;
 `;
 
 const IconEdit = styled.img`
@@ -30,7 +39,8 @@ const IconEdit = styled.img`
 `;
 
 const ScenarioHeading = styled.h1`
-  font-size: 1.875rem;
+  color: ${Colors.forest};
+  font-size: 24px;
   line-height: 1.2;
 `;
 
@@ -71,7 +81,8 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
         <ScenarioNameLabel>
           {!editingName ? (
             <ScenarioHeading onClick={() => setEditingName(true)}>
-              {name}
+              <IconFolder alt="folder" src={iconFolderSrc} />
+              <span>{name}</span>
             </ScenarioHeading>
           ) : (
             <InputText


### PR DESCRIPTION
## Description of the change

straighten out fonts, colors, and icons for `Scenario Name` and `+ Add Facility` as per Figma designs.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #167

> ‘Add Facility’ is larger than ‘Baseline Scenario’, doesn’t have circled plus sign

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
