### PR TITLE
daily reports copy swap

### DIFF
--- a/src/page-multi-facility/LocaleInformationSection.tsx
+++ b/src/page-multi-facility/LocaleInformationSection.tsx
@@ -48,8 +48,8 @@ const LocaleInformationSection: React.FC<Props> = ({
           value={systemType}
           onChange={(event) => setSystemType(event.target.value)}
         >
-          {systemTypeList.map(({ value }) => (
-            <option key={value} value={value}>
+          {systemTypeList.map(({ value }, index) => (
+            <option key={value || `system-type-${index}`} value={value}>
               {value}
             </option>
           ))}

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -134,7 +134,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           />
           <PromoBoxWithButton
             text={
-              "Turn on 'DailyReports' to receive daily analysis and status updates from Recidiviz and CSG."
+              "Turn on 'Daily Reports' to receive briefings based on the data in this scenario, prepared by Recidiviz and CSG."
             }
           />
         </div>


### PR DESCRIPTION
and fix .map warning

## Description of the change

1. simple copy change per master copy spreadsheet
2. rider fix for _element must have unique key..._ warning due to `undefined` value.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #167 
> P1: Daily reports promo copy has typo → update to final copy, resolve ‘DailyReports’ concatenation

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
