### PR TITLE
make sure InputText container doesn't collapse

### DIFF
--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -7,6 +7,7 @@ import InputLabelAndHelp from "./InputLabelAndHelp";
 const TextInputContainer = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
 `;
 
 const InputWrapper = styled(StyledInput)`


### PR DESCRIPTION
## Description of the change

A change to the `InputText` component in #171 caused the component to collapse outside of the table context where it was mostly being used, which I didn't realize because I failed to test it thoroughly enough. Sorry! This fixes that. I verified that there is no regression anywhere else I saw this component being used.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
