### PR TITLE
Version History Support for Facility Inputs

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -21,6 +21,7 @@ const tokenExchangeEndpoint =
 const modelInputsCollectionId = "model_inputs";
 const scenariosCollectionId = "scenarios";
 const facilitiesCollectionId = "facilities";
+const modelVersionCollectionId = "modelVersions";
 
 // Note: None of these are secrets.
 let firebaseConfig = {
@@ -90,6 +91,10 @@ const getDb = async () => {
 };
 
 const buildCreatePayload = (entity: any) => {
+  // Make sure the 'id' key doesn't exist on the entity object
+  // or else Firestore won't permit the addition.
+  delete entity.id;
+
   const timestamp = currrentTimestamp();
   return Object.assign({}, entity, {
     createdAt: timestamp,
@@ -368,7 +373,26 @@ export const saveFacility = async (facility: any): Promise<void> => {
       // Ensures we don't store any attributres that our model does not
       // know about.
       facility.modelInputs = pick(facility.modelInputs, persistedKeys);
+      facility.modelInputs.updatedAt = currrentTimestamp();
+      // TODO: For now, this assumes we're always entering data as of "today"
+      // However, in the near future, we should allow for a user submitted
+      // observed at value.  If it is not provided default to today. For dates
+      // observed in the past we'll have to assume the time portion of the
+      // timestamp is startOfDay** since we won't otherwise have any time
+      // information.
+      //
+      // ** https://date-fns.org/v1.29.0/docs/startOfDay
+      facility.modelInputs.observedAt = new Date();
     }
+
+    const db = await getDb();
+    const batch = db.batch();
+
+    const facilitiesCollection = baselineScenarioRef.collection(
+      facilitiesCollectionId,
+    );
+
+    let facilityDoc;
 
     // If the facility already has an id associated with it then
     // we just need to update that facility. Otherwise, we are
@@ -376,20 +400,25 @@ export const saveFacility = async (facility: any): Promise<void> => {
     // collection.
     if (facility.id) {
       const payload = buildUpdatePayload(facility);
-
-      baselineScenarioRef
-        .collection(facilitiesCollectionId)
-        .doc(facility.id)
-        .update(payload);
+      facilityDoc = facilitiesCollection.doc(facility.id);
+      batch.update(facilityDoc, payload);
     } else {
-      // Make sure this key doesn't exist on the facility object
-      // or else Firestore won't permit the addition.
-      delete facility.id;
-
       const payload = buildCreatePayload(facility);
-
-      baselineScenarioRef.collection(facilitiesCollectionId).add(payload);
+      facilityDoc = facilitiesCollection.doc();
+      batch.set(facilityDoc, payload);
     }
+
+    // If the facility's model inputs have been provided, store a new
+    // versioned copy of those inputs.
+    if (facility.modelInputs) {
+      const newModelVersionDoc = facilityDoc
+        .collection(modelVersionCollectionId)
+        .doc();
+
+      batch.set(newModelVersionDoc, facility.modelInputs);
+    }
+
+    await batch.commit();
   } catch (error) {
     console.error("Encountered error while attempting to save a facility:");
     console.error(error);


### PR DESCRIPTION
* Updating the data model and persistence layer to allow for the versioning of model inputs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #166

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

The following tests were performed locally:

1.  Create a brand new scenario-less user; Add a facility; Verify model inputs and a versioned copy were saved as expected. ✅
2.  Update a facility's fields; Verify model inputs and a versioned copy were saved as expected. ✅
3.  Remove fields (i.e set `age85Cases` and `age85Population` to empty in the form);  Verify model inputs and a versioned copy were saved as expected. ✅
4.  Adding multiple planned releases.  Verify model inputs and a versioned copy were saved as expected. ✅
5.  Add a new facility to an existing Scenario.  Verify model inputs and a versioned copy were saved as expected. ✅
6.  Intentionally throw an exception after saving the facility, but before saving the versioned model.  Verify nothing was saved as expected. ✅
7.  Intentionally throw an exception after saving the facility and versioned model, but before calling commit.  Verify nothing was saved as expected. ✅

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
