### PR TITLE
Timeseries chart for R(t)

### DIFF
--- a/src/design-system/ChartTooltip.tsx
+++ b/src/design-system/ChartTooltip.tsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+
+import Colors from "./Colors";
+
+const triangleSize = 7;
+
+const ChartTooltip = styled.div`
+  background: ${Colors.forest};
+  border-radius: 4px;
+  color: #fff;
+  font-family: "Rubik", sans-serif;
+  min-width: 60px;
+  padding: 12px;
+  position: relative;
+  transform: translateX(-50%) translateY(calc(-100% - ${2 * triangleSize}px));
+  z-index: 100;
+
+  &::after {
+    border-left: ${triangleSize}px solid transparent;
+    border-right: ${triangleSize}px solid transparent;
+    border-top: ${triangleSize}px solid ${Colors.forest};
+    bottom: -${triangleSize}px;
+    content: "";
+    display: block;
+    height: 0;
+    left: calc(50% - ${triangleSize}px);
+    position: absolute;
+    width: 0;
+  }
+`;
+
+export default ChartTooltip;

--- a/src/design-system/ChartWrapper.tsx
+++ b/src/design-system/ChartWrapper.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+const ChartWrapper = styled.div`
+  .frame {
+    font-family: "Poppins", sans-serif;
+    font-size: 11px;
+    font-weight: 300;
+    letter-spacing: 0;
+  }
+
+  .axis-baseline,
+  .tick {
+    stroke: #467472;
+  }
+
+  .tick {
+    stroke-opacity: 0.2;
+  }
+
+  .axis-baseline {
+    stroke-width: 2px;
+  }
+
+  .axis-title text,
+  .axis-label {
+    fill: #00413e;
+    font-weight: 400;
+    opacity: 0.7;
+  }
+
+  .axis-label {
+    font-size: 10px;
+  }
+`;
+
+export default ChartWrapper;

--- a/src/design-system/ChartWrapper.tsx
+++ b/src/design-system/ChartWrapper.tsx
@@ -29,6 +29,10 @@ const ChartWrapper = styled.div`
   .axis-label {
     font-size: 10px;
   }
+
+  circle.frame-hover {
+    display: none;
+  }
 `;
 
 export default ChartWrapper;

--- a/src/design-system/ChartWrapper.tsx
+++ b/src/design-system/ChartWrapper.tsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 
+import Colors from "./Colors";
+
 const ChartWrapper = styled.div`
   .frame {
     font-family: "Poppins", sans-serif;
@@ -8,24 +10,20 @@ const ChartWrapper = styled.div`
     letter-spacing: 0;
   }
 
-  .axis-baseline,
   .tick {
-    stroke: #467472;
-  }
-
-  .tick {
+    stroke: ${Colors.paleForest};
     stroke-opacity: 0.2;
   }
 
   .axis-baseline {
+    stroke: ${Colors.paleForest};
     stroke-width: 2px;
   }
 
   .axis-title text,
   .axis-label {
-    fill: #00413e;
+    fill: ${Colors.paleForest};
     font-weight: 400;
-    opacity: 0.7;
   }
 
   .axis-label {

--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -12,6 +12,7 @@ const Colors = {
   slate: "#e9ebeb",
   forest: "#005450",
   darkForest: "#033342",
+  paleForest: "#667c7b",
   teal: "#25b894",
   darkTeal: "#759f9e",
   gray: "#E0E4E4",

--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -7,6 +7,12 @@ export function darken(color: string, amount: number) {
   return lab(l - amount, a, b).hex();
 }
 
+export function lighten(color: string, amount: number) {
+  // good to use Lab color because it's perceptually uniform
+  const { l, a, b } = lab(color);
+  return lab(l + amount, a, b).hex();
+}
+
 const Colors = {
   black: "#000",
   slate: "#e9ebeb",
@@ -18,6 +24,7 @@ const Colors = {
   gray: "#E0E4E4",
   darkGray: "#c8d3d3",
   opacityGray: `${hexAlpha("#467472", 0.2)}`,
+  lightGray: "#E1E3E3",
   green: "#006C67",
   lightBlue: "#33B6FF",
   paleGreen: "#D2DBDB",

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -19,10 +19,6 @@ const CurveChartWrapper = styled(ChartWrapper)`
       stroke-linecap: round;
     }
   }
-
-  circle.frame-hover {
-    display: none;
-  }
 `;
 
 const TooltipTitle = styled.div`

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -4,9 +4,10 @@ import { add } from "date-fns";
 import ResponsiveXYFrame from "semiotic/lib/ResponsiveXYFrame";
 import styled from "styled-components";
 
+import ChartTooltip from "../design-system/ChartTooltip";
 import ChartWrapper from "../design-system/ChartWrapper";
-import Colors from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
+import Tooltip from "../design-system/Tooltip";
 import { MarkColors } from "./ChartArea";
 
 const CurveChartWrapper = styled(ChartWrapper)`
@@ -21,31 +22,6 @@ const CurveChartWrapper = styled(ChartWrapper)`
 
   circle.frame-hover {
     display: none;
-  }
-`;
-
-const triangleSize = "7";
-const TooltipContainer = styled.div`
-  background: ${Colors.forest};
-  color: #fff;
-  font-family: "Rubik", sans-serif;
-  min-width: 120px;
-  padding: 12px;
-  position: relative;
-  transform: translateX(-50%) translateY(calc(-100% - ${2 * triangleSize}px));
-  z-index: 100;
-
-  &::after {
-    border-left: ${triangleSize}px solid transparent;
-    border-right: ${triangleSize}px solid transparent;
-    border-top: ${triangleSize}px solid ${Colors.forest};
-    bottom: -${triangleSize}px;
-    content: "";
-    display: block;
-    height: 0;
-    left: calc(50% - ${triangleSize}px);
-    position: absolute;
-    width: 0;
   }
 `;
 
@@ -83,7 +59,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   const displayDate = add(new Date(), { days });
 
   return (
-    <TooltipContainer>
+    <ChartTooltip>
       <TooltipTitle>{title}</TooltipTitle>
       <TooltipDatalist>
         <TooltipDatum>
@@ -91,7 +67,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         </TooltipDatum>
         <TooltipDatum>People: {formatThousands(count)}</TooltipDatum>
       </TooltipDatalist>
-    </TooltipContainer>
+    </ChartTooltip>
   );
 };
 

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 import ChartTooltip from "../design-system/ChartTooltip";
 import ChartWrapper from "../design-system/ChartWrapper";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
-import Tooltip from "../design-system/Tooltip";
 import { MarkColors } from "./ChartArea";
 
 const CurveChartWrapper = styled(ChartWrapper)`

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -4,43 +4,13 @@ import { add } from "date-fns";
 import ResponsiveXYFrame from "semiotic/lib/ResponsiveXYFrame";
 import styled from "styled-components";
 
+import ChartWrapper from "../design-system/ChartWrapper";
 import Colors from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import { MarkColors } from "./ChartArea";
 
-const ChartContainer = styled.div`
+const CurveChartWrapper = styled(ChartWrapper)`
   height: ${(props) => props.chartHeight}px;
-
-  .frame {
-    font-family: "Poppins", sans-serif;
-    font-size: 11px;
-    font-weight: 300;
-    letter-spacing: 0;
-  }
-
-  .axis-baseline,
-  .tick {
-    stroke: #467472;
-  }
-
-  .tick {
-    stroke-opacity: 0.2;
-  }
-
-  .axis-baseline {
-    stroke-width: 2px;
-  }
-
-  .axis-title text,
-  .axis-label {
-    fill: #00413e;
-    font-weight: 400;
-    opacity: 0.7;
-  }
-
-  .axis-label {
-    font-size: 10px;
-  }
 
   .threshold-annotation {
     .subject {
@@ -195,9 +165,9 @@ const CurveChart: React.FC<CurveChartProps> = ({
   };
 
   return (
-    <ChartContainer chartHeight={chartHeight || 380}>
+    <CurveChartWrapper chartHeight={chartHeight || 380}>
       <ResponsiveXYFrame {...frameProps} />
-    </ChartContainer>
+    </CurveChartWrapper>
   );
 };
 

--- a/src/rt-timeseries/RtTimeseries.tsx
+++ b/src/rt-timeseries/RtTimeseries.tsx
@@ -1,0 +1,133 @@
+import { scaleTime, timeFormat } from "d3";
+// no type defs for Semiotic
+const ResponsiveXYFrame = require("semiotic/lib/ResponsiveXYFrame") as any;
+import styled from "styled-components";
+
+import ChartTooltip from "../design-system/ChartTooltip";
+import ChartWrapper from "../design-system/ChartWrapper";
+import Colors, { lighten } from "../design-system/Colors";
+
+export type Record = {
+  date: Date;
+  value: number;
+};
+
+interface Props {
+  data: {
+    Rt: Record[];
+    low90: Record[];
+    high90: Record[];
+  };
+}
+
+type Line = {
+  confidenceInterval?: boolean;
+  data: Record[];
+  title: string;
+};
+
+const formatDate = timeFormat("%-d %B");
+
+const RtTimeseriesWrapper = styled(ChartWrapper)`
+  .uncertainty {
+    fill: ${Colors.darkGray};
+    fill-opacity: 0.3;
+  }
+`;
+
+const TooltipContents = styled.div`
+  text-align: center;
+  white-space: nowrap;
+`;
+
+const TooltipLabel = styled.div``;
+const TooltipValue = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+`;
+
+const Tooltip: React.FC<{
+  data: Record;
+  parentLine: { title: string };
+}> = (props) => {
+  const {
+    data: { date, value },
+    parentLine: { title },
+  } = props;
+  return (
+    <ChartTooltip>
+      <TooltipContents>
+        <TooltipValue>{value}</TooltipValue>
+        <TooltipLabel>{title}</TooltipLabel>
+        <TooltipLabel>{formatDate(date)}</TooltipLabel>
+      </TooltipContents>
+    </ChartTooltip>
+  );
+};
+
+const RtTimeseries: React.FC<Props> = ({ data }) => {
+  const getLines = (): Line[] => {
+    return [
+      { title: "R(t)", data: data.Rt },
+      {
+        title: "90% Confidence Interval (low)",
+        confidenceInterval: true,
+        data: data.low90,
+      },
+      {
+        title: "90% Confidence Interval (high)",
+        confidenceInterval: true,
+        data: data.high90,
+      },
+    ];
+  };
+
+  return (
+    <RtTimeseriesWrapper>
+      <ResponsiveXYFrame
+        annotations={[
+          {
+            type: "area",
+            className: "uncertainty",
+            coordinates: [
+              // assuming these are sorted in date order this makes a clean shape
+              ...data.high90,
+              ...[...data.low90].reverse(),
+            ],
+          },
+          {
+            color: lighten(Colors.red, 30),
+            disable: ["connector"],
+            type: "y",
+            value: 1,
+          },
+        ]}
+        axes={[
+          {
+            label: { name: "Rate of spread", locationDistance: 30 },
+            orient: "left",
+            tickLineGenerator: () => null,
+          },
+        ]}
+        hoverAnnotation
+        lineDataAccessor="data"
+        lines={getLines()}
+        lineStyle={(d: Line) => ({
+          stroke: Colors.forest,
+          strokeWidth: d.confidenceInterval ? 0 : 1,
+        })}
+        margin={{ left: 40, bottom: 30, right: 10, top: 10 }}
+        responsiveHeight
+        responsiveWidth
+        tooltipContent={Tooltip}
+        xAccessor="date"
+        xScaleType={scaleTime()}
+        yAccessor="value"
+        yExtent={[0]}
+      />
+    </RtTimeseriesWrapper>
+  );
+};
+
+export default RtTimeseries;

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -3,6 +3,11 @@ import mapValues from "lodash/mapValues";
 
 import RtTimeseries, { Record } from "./RtTimeseries";
 
+type RawRecord = {
+  date: string;
+  value: number;
+};
+
 const convertToDate = isoParse;
 
 function dateExists(value: { date: Date | null }): value is Record {
@@ -12,62 +17,63 @@ function dateExists(value: { date: Date | null }): value is Record {
 }
 
 const RtTimeseriesContainer: React.FC = () => {
-  // TODO: this is dummy data
+  // TODO: uncomment dummy data for local testing
+  // TODO: get rid of this fake data when real data is wired up!
   const rawData = {
     Rt: [
-      { date: "2020-04-02T00:00:00.000Z", value: 3.0 },
-      { date: "2020-04-03T00:00:00.000Z", value: 3.01 },
-      { date: "2020-04-04T00:00:00.000Z", value: 2.67 },
-      { date: "2020-04-05T00:00:00.000Z", value: 2.87 },
-      { date: "2020-04-06T00:00:00.000Z", value: 2.9 },
-      { date: "2020-04-07T00:00:00.000Z", value: 3.57 },
-      { date: "2020-04-08T00:00:00.000Z", value: 3.6 },
-      { date: "2020-04-09T00:00:00.000Z", value: 3.25 },
-      { date: "2020-04-10T00:00:00.000Z", value: 2.85 },
-      { date: "2020-04-11T00:00:00.000Z", value: 2.49 },
-      { date: "2020-04-12T00:00:00.000Z", value: 2.17 },
-      { date: "2020-04-13T00:00:00.000Z", value: 2.05 },
-      { date: "2020-04-14T00:00:00.000Z", value: 2.1 },
-      { date: "2020-04-15T00:00:00.000Z", value: 2.17 },
-      { date: "2020-04-16T00:00:00.000Z", value: 2.23 },
-      { date: "2020-04-20T00:00:00.000Z", value: 2.17 },
-    ],
+      // { date: "2020-04-02T00:00:00.000Z", value: 3.0 },
+      // { date: "2020-04-03T00:00:00.000Z", value: 3.01 },
+      // { date: "2020-04-04T00:00:00.000Z", value: 2.67 },
+      // { date: "2020-04-05T00:00:00.000Z", value: 2.87 },
+      // { date: "2020-04-06T00:00:00.000Z", value: 2.9 },
+      // { date: "2020-04-07T00:00:00.000Z", value: 3.57 },
+      // { date: "2020-04-08T00:00:00.000Z", value: 3.6 },
+      // { date: "2020-04-09T00:00:00.000Z", value: 3.25 },
+      // { date: "2020-04-10T00:00:00.000Z", value: 2.85 },
+      // { date: "2020-04-11T00:00:00.000Z", value: 2.49 },
+      // { date: "2020-04-12T00:00:00.000Z", value: 2.17 },
+      // { date: "2020-04-13T00:00:00.000Z", value: 2.05 },
+      // { date: "2020-04-14T00:00:00.000Z", value: 2.1 },
+      // { date: "2020-04-15T00:00:00.000Z", value: 2.17 },
+      // { date: "2020-04-16T00:00:00.000Z", value: 2.23 },
+      // { date: "2020-04-20T00:00:00.000Z", value: 2.17 },
+    ] as RawRecord[],
     low90: [
-      { date: "2020-04-02T00:00:00.000Z", value: 0.01 },
-      { date: "2020-04-03T00:00:00.000Z", value: 0.09 },
-      { date: "2020-04-04T00:00:00.000Z", value: 0.05 },
-      { date: "2020-04-05T00:00:00.000Z", value: 1.22 },
-      { date: "2020-04-06T00:00:00.000Z", value: 1.3 },
-      { date: "2020-04-07T00:00:00.000Z", value: 2.01 },
-      { date: "2020-04-08T00:00:00.000Z", value: 2.23 },
-      { date: "2020-04-09T00:00:00.000Z", value: 2.11 },
-      { date: "2020-04-10T00:00:00.000Z", value: 1.84 },
-      { date: "2020-04-11T00:00:00.000Z", value: 1.56 },
-      { date: "2020-04-12T00:00:00.000Z", value: 1.31 },
-      { date: "2020-04-13T00:00:00.000Z", value: 1.27 },
-      { date: "2020-04-14T00:00:00.000Z", value: 1.35 },
-      { date: "2020-04-15T00:00:00.000Z", value: 1.47 },
-      { date: "2020-04-16T00:00:00.000Z", value: 1.56 },
-      { date: "2020-04-20T00:00:00.000Z", value: 1.55 },
-    ],
+      // { date: "2020-04-02T00:00:00.000Z", value: 0.01 },
+      // { date: "2020-04-03T00:00:00.000Z", value: 0.09 },
+      // { date: "2020-04-04T00:00:00.000Z", value: 0.05 },
+      // { date: "2020-04-05T00:00:00.000Z", value: 1.22 },
+      // { date: "2020-04-06T00:00:00.000Z", value: 1.3 },
+      // { date: "2020-04-07T00:00:00.000Z", value: 2.01 },
+      // { date: "2020-04-08T00:00:00.000Z", value: 2.23 },
+      // { date: "2020-04-09T00:00:00.000Z", value: 2.11 },
+      // { date: "2020-04-10T00:00:00.000Z", value: 1.84 },
+      // { date: "2020-04-11T00:00:00.000Z", value: 1.56 },
+      // { date: "2020-04-12T00:00:00.000Z", value: 1.31 },
+      // { date: "2020-04-13T00:00:00.000Z", value: 1.27 },
+      // { date: "2020-04-14T00:00:00.000Z", value: 1.35 },
+      // { date: "2020-04-15T00:00:00.000Z", value: 1.47 },
+      // { date: "2020-04-16T00:00:00.000Z", value: 1.56 },
+      // { date: "2020-04-20T00:00:00.000Z", value: 1.55 },
+    ] as RawRecord[],
     high90: [
-      { date: "2020-04-02T00:00:00.000Z", value: 6.99 },
-      { date: "2020-04-03T00:00:00.000Z", value: 5.95 },
-      { date: "2020-04-04T00:00:00.000Z", value: 5.05 },
-      { date: "2020-04-05T00:00:00.000Z", value: 5.03 },
-      { date: "2020-04-06T00:00:00.000Z", value: 4.77 },
-      { date: "2020-04-07T00:00:00.000Z", value: 5.28 },
-      { date: "2020-04-08T00:00:00.000Z", value: 4.99 },
-      { date: "2020-04-09T00:00:00.000Z", value: 4.45 },
-      { date: "2020-04-10T00:00:00.000Z", value: 3.88 },
-      { date: "2020-04-11T00:00:00.000Z", value: 3.4 },
-      { date: "2020-04-12T00:00:00.000Z", value: 3.02 },
-      { date: "2020-04-13T00:00:00.000Z", value: 2.9 },
-      { date: "2020-04-14T00:00:00.000Z", value: 2.9 },
-      { date: "2020-04-15T00:00:00.000Z", value: 2.94 },
-      { date: "2020-04-16T00:00:00.000Z", value: 2.94 },
-      { date: "2020-04-20T00:00:00.000Z", value: 2.85 },
-    ],
+      // { date: "2020-04-02T00:00:00.000Z", value: 6.99 },
+      // { date: "2020-04-03T00:00:00.000Z", value: 5.95 },
+      // { date: "2020-04-04T00:00:00.000Z", value: 5.05 },
+      // { date: "2020-04-05T00:00:00.000Z", value: 5.03 },
+      // { date: "2020-04-06T00:00:00.000Z", value: 4.77 },
+      // { date: "2020-04-07T00:00:00.000Z", value: 5.28 },
+      // { date: "2020-04-08T00:00:00.000Z", value: 4.99 },
+      // { date: "2020-04-09T00:00:00.000Z", value: 4.45 },
+      // { date: "2020-04-10T00:00:00.000Z", value: 3.88 },
+      // { date: "2020-04-11T00:00:00.000Z", value: 3.4 },
+      // { date: "2020-04-12T00:00:00.000Z", value: 3.02 },
+      // { date: "2020-04-13T00:00:00.000Z", value: 2.9 },
+      // { date: "2020-04-14T00:00:00.000Z", value: 2.9 },
+      // { date: "2020-04-15T00:00:00.000Z", value: 2.94 },
+      // { date: "2020-04-16T00:00:00.000Z", value: 2.94 },
+      // { date: "2020-04-20T00:00:00.000Z", value: 2.85 },
+    ] as RawRecord[],
   };
   // convert strings to Dates
   // TODO: presumably we will have to do this with real data also

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -1,0 +1,86 @@
+import { ascending, isoParse } from "d3";
+import mapValues from "lodash/mapValues";
+
+import RtTimeseries, { Record } from "./RtTimeseries";
+
+const convertToDate = isoParse;
+
+function dateExists(value: { date: Date | null }): value is Record {
+  // date formatting function may return null with invalid input
+  // so we do need a type guard to filter the results
+  return value.date != null;
+}
+
+const RtTimeseriesContainer: React.FC = () => {
+  // TODO: this is dummy data
+  const rawData = {
+    Rt: [
+      { date: "2020-04-02T00:00:00.000Z", value: 3.0 },
+      { date: "2020-04-03T00:00:00.000Z", value: 3.01 },
+      { date: "2020-04-04T00:00:00.000Z", value: 2.67 },
+      { date: "2020-04-05T00:00:00.000Z", value: 2.87 },
+      { date: "2020-04-06T00:00:00.000Z", value: 2.9 },
+      { date: "2020-04-07T00:00:00.000Z", value: 3.57 },
+      { date: "2020-04-08T00:00:00.000Z", value: 3.6 },
+      { date: "2020-04-09T00:00:00.000Z", value: 3.25 },
+      { date: "2020-04-10T00:00:00.000Z", value: 2.85 },
+      { date: "2020-04-11T00:00:00.000Z", value: 2.49 },
+      { date: "2020-04-12T00:00:00.000Z", value: 2.17 },
+      { date: "2020-04-13T00:00:00.000Z", value: 2.05 },
+      { date: "2020-04-14T00:00:00.000Z", value: 2.1 },
+      { date: "2020-04-15T00:00:00.000Z", value: 2.17 },
+      { date: "2020-04-16T00:00:00.000Z", value: 2.23 },
+      { date: "2020-04-20T00:00:00.000Z", value: 2.17 },
+    ],
+    low90: [
+      { date: "2020-04-02T00:00:00.000Z", value: 0.01 },
+      { date: "2020-04-03T00:00:00.000Z", value: 0.09 },
+      { date: "2020-04-04T00:00:00.000Z", value: 0.05 },
+      { date: "2020-04-05T00:00:00.000Z", value: 1.22 },
+      { date: "2020-04-06T00:00:00.000Z", value: 1.3 },
+      { date: "2020-04-07T00:00:00.000Z", value: 2.01 },
+      { date: "2020-04-08T00:00:00.000Z", value: 2.23 },
+      { date: "2020-04-09T00:00:00.000Z", value: 2.11 },
+      { date: "2020-04-10T00:00:00.000Z", value: 1.84 },
+      { date: "2020-04-11T00:00:00.000Z", value: 1.56 },
+      { date: "2020-04-12T00:00:00.000Z", value: 1.31 },
+      { date: "2020-04-13T00:00:00.000Z", value: 1.27 },
+      { date: "2020-04-14T00:00:00.000Z", value: 1.35 },
+      { date: "2020-04-15T00:00:00.000Z", value: 1.47 },
+      { date: "2020-04-16T00:00:00.000Z", value: 1.56 },
+      { date: "2020-04-20T00:00:00.000Z", value: 1.55 },
+    ],
+    high90: [
+      { date: "2020-04-02T00:00:00.000Z", value: 6.99 },
+      { date: "2020-04-03T00:00:00.000Z", value: 5.95 },
+      { date: "2020-04-04T00:00:00.000Z", value: 5.05 },
+      { date: "2020-04-05T00:00:00.000Z", value: 5.03 },
+      { date: "2020-04-06T00:00:00.000Z", value: 4.77 },
+      { date: "2020-04-07T00:00:00.000Z", value: 5.28 },
+      { date: "2020-04-08T00:00:00.000Z", value: 4.99 },
+      { date: "2020-04-09T00:00:00.000Z", value: 4.45 },
+      { date: "2020-04-10T00:00:00.000Z", value: 3.88 },
+      { date: "2020-04-11T00:00:00.000Z", value: 3.4 },
+      { date: "2020-04-12T00:00:00.000Z", value: 3.02 },
+      { date: "2020-04-13T00:00:00.000Z", value: 2.9 },
+      { date: "2020-04-14T00:00:00.000Z", value: 2.9 },
+      { date: "2020-04-15T00:00:00.000Z", value: 2.94 },
+      { date: "2020-04-16T00:00:00.000Z", value: 2.94 },
+      { date: "2020-04-20T00:00:00.000Z", value: 2.85 },
+    ],
+  };
+  // convert strings to Dates
+  // TODO: presumably we will have to do this with real data also
+  const data = mapValues(rawData, (records) =>
+    records
+      .map(({ date, value }) => ({ date: convertToDate(date), value }))
+      // ensure there are no null dates
+      .filter(dateExists)
+      // ensure records are sorted chronologically
+      .sort((a, b) => ascending(a.date, b.date)),
+  );
+
+  return <RtTimeseries data={data} />;
+};
+
+export default RtTimeseriesContainer;

--- a/src/rt-timeseries/index.tsx
+++ b/src/rt-timeseries/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./RtTimeseriesContainer";


### PR DESCRIPTION
## Description of the change

Creates a new chart for a new metric we are developing, R(t) (rate of spread over time). As this is a statistical model we also show the confidence intervals. Features in common with the `CurveChart` (tooltip, axis styles) were factored out to the design system for reuse. 

<img width="485" alt="Screen Shot 2020-04-23 at 3 21 08 PM" src="https://user-images.githubusercontent.com/5385319/80156472-da1b1880-8578-11ea-965e-624a1128404b.png">

(There are some slight differences from the mocks due to some design issues that are still being worked out but they don't have any major implications for this PR, so no reason to hold it up IMO.)

I also included a container component that does some data transformation on some fake data, which I was using for development. I don't think the transformation logic is likely to change much once it's wired up, but if we think it's a bad idea to commit the dummy data to `master` I can take that out. (I'm of two minds; I think it makes this PR more comprehensible but if we were to somehow inadvertently release a UI to prod with dummy data that would obviously be bad! We have checked in dummy data before but now that we are getting into more of a release cadence maybe that's a practice we want to abandon.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #201 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally **(Verified no regressions in existing chart from refactoring)**

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
