### PR TITLE
Add tick values in increments of 25 to facility output chart

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -140,6 +140,7 @@ const xAxisOptions: any[] = [
     orient: "bottom",
     tickLineGenerator: () => null,
     label: "Days",
+    tickValues: [0, 25, 50, 75, 100],
   },
   {
     tickLineGenerator: () => null,


### PR DESCRIPTION
## Description of the change

> Set the x-axis for the curve chart output on the add facility page to 25 increments (0-100)

NOTE: I wasn't sure if this needed to be a function fo the x-axis data so I directly set the tick values to 25 increments from 0-100 since the data currently goes to 85. This was the easiest way to set this that I could tell from the docs, but I could spend more time with it if we need it to be responsive to changes in the length of `days`. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #167 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
