### PR TITLE
change tooltip help icon to softer green

### DIFF
--- a/src/design-system/HelpButtonWithTooltip.tsx
+++ b/src/design-system/HelpButtonWithTooltip.tsx
@@ -3,30 +3,28 @@ import styled from "styled-components";
 import Colors from "./Colors";
 import Tooltip from "./Tooltip";
 
-const HelpButton = styled.span<{ softened?: boolean }>`
-  background: ${(props) =>
-    props.softened ? `${Colors.darkTeal};` : `${Colors.forest};`}
+const HelpButton = styled.span`
+  background: ${Colors.darkTeal};
   color: white;
-  border-radius: ${(props) => (props.softened ? "11px;" : "14px;")}
-  line-height: ${(props) => (props.softened ? "10px;" : "12px;")}
-  width: ${(props) => (props.softened ? "12px;" : "16px;")}
-  height: ${(props) => (props.softened ? "12px;" : "16px;")}
+  border-radius: 11px;
+  line-height: 9px;
+  width: 12px;
+  height: 12px;
   display: inline-block;
   text-align: center;
-  font-size: ${(props) => (props.softened ? "9px;" : "9px;")}
+  font-size: 9px;
   align-self: center;
   padding: 2px;
 `;
 
 interface Props {
   children: React.ReactNode;
-  softened?: boolean;
 }
 
 const HelpButtonWithTooltip: React.FC<Props> = (props) => {
   return (
     <Tooltip content={props.children}>
-      <HelpButton softened={props.softened}>?</HelpButton>
+      <HelpButton>?</HelpButton>
     </Tooltip>
   );
 };

--- a/src/design-system/InputLabelAndHelp.tsx
+++ b/src/design-system/InputLabelAndHelp.tsx
@@ -21,11 +21,9 @@ const InputLabelAndHelp: React.FC<Props> = (props) => {
 
   return (
     <LabelContainer>
-      <TextLabel>{props.label}</TextLabel>
+      <TextLabel softened={props.softened}>{props.label}</TextLabel>
       {props.labelHelp && (
-        <HelpButtonWithTooltip softened={props.softened}>
-          {props.labelHelp}
-        </HelpButtonWithTooltip>
+        <HelpButtonWithTooltip>{props.labelHelp}</HelpButtonWithTooltip>
       )}
     </LabelContainer>
   );

--- a/src/design-system/TextLabel.tsx
+++ b/src/design-system/TextLabel.tsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 const TextLabel = styled.span<{ softened?: boolean }>`
-  ${(props) => (props.softened ? "text-transform: uppercase;" : null)}
+  ${(props) => (props.softened ? null : "text-transform: uppercase;")}
   font-size: 12px;
   font-weight: 100;
   font-family: "Poppins", sans-serif;
-  ${(props) => (props.softened ? "letter-spacing: 2px;" : null)}
+  ${(props) => (props.softened ? null : "letter-spacing: 2px;")}
   color: #00413e;
   padding-right: 5px;
 `;


### PR DESCRIPTION
## Description of the change

Changes the background color for tooltip icons to lighter green. Issue mentions `FacilityInputForm` specifically bug after checking with @cawarren I got the go ahead to change it globally.

Also fixes a styling bug in `TextLabel`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #213 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
