### PR TITLE
Add auto-populating non-editable locale information to facility page

### DIFF
--- a/src/impact-dashboard/LocaleInformation.tsx
+++ b/src/impact-dashboard/LocaleInformation.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import InputSelect from "../design-system/InputSelect";
 import InputTextNumeric from "../design-system/InputTextNumeric";
+import LocaleDetails from "../page-multi-facility/LocaleDetails";
 import useModel from "./useModel";
 
 const LocaleInformationDiv = styled.div`
@@ -49,50 +50,56 @@ const LocaleInformation: React.FC = () => {
   }, [model.localeDataSource, model.stateCode]);
 
   return (
-    <LocaleInformationDiv>
-      <LocaleInputDiv>
-        <InputSelect
-          label="State"
-          value={model.stateCode}
-          onChange={(event) => {
-            updateModel({ stateCode: event.target.value });
-          }}
-        >
-          {stateList.map(({ value }) => (
-            <option key={value} value={value}>
-              {value}
-            </option>
-          ))}
-        </InputSelect>
-      </LocaleInputDiv>
-      <LocaleInputDiv>
-        <InputSelect
-          label="County"
-          value={model.countyName}
-          onChange={(event) => {
-            updateModel({
-              stateCode: model.stateCode,
-              countyName: event.target.value,
-            });
-          }}
-        >
-          {countyList.map(({ value }) => (
-            <option key={value} value={value}>
-              {value}
-            </option>
-          ))}
-        </InputSelect>
-      </LocaleInputDiv>
-      <LocaleInputDiv>
-        <InputTextNumeric
-          type="number"
-          labelAbove="Confirmed case count"
-          labelHelp="Based on NYTimes data. Replace with your most up-to-date data."
-          valueEntered={model.confirmedCases}
-          onValueChange={(value) => updateModel({ confirmedCases: value })}
-        />
-      </LocaleInputDiv>
-    </LocaleInformationDiv>
+    <>
+      <LocaleInformationDiv>
+        <LocaleInputDiv>
+          <InputSelect
+            label="State"
+            value={model.stateCode}
+            onChange={(event) => {
+              updateModel({ stateCode: event.target.value });
+            }}
+          >
+            {stateList.map(({ value }) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </InputSelect>
+        </LocaleInputDiv>
+        <LocaleInputDiv>
+          <InputSelect
+            label="County"
+            value={model.countyName}
+            onChange={(event) => {
+              updateModel({
+                stateCode: model.stateCode,
+                countyName: event.target.value,
+              });
+            }}
+          >
+            {countyList.map(({ value }) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </InputSelect>
+        </LocaleInputDiv>
+        <LocaleInputDiv>
+          <InputTextNumeric
+            type="number"
+            labelAbove="Confirmed case count"
+            labelHelp="Based on NYTimes data. Replace with your most up-to-date data."
+            valueEntered={model.confirmedCases}
+            onValueChange={(value) => updateModel({ confirmedCases: value })}
+          />
+        </LocaleInputDiv>
+      </LocaleInformationDiv>
+      <LocaleDetails
+        stateCode={model.stateCode}
+        countyName={model.countyName}
+      />
+    </>
   );
 };
 

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -77,7 +77,6 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
             | LocaleRecord
             | undefined => {
             // rows without these fields are known to be junk; we filter these out below
-            console.log({ row });
             if (!row.County || !row.State) {
               return undefined;
             }

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -3,7 +3,7 @@ import { rollup } from "d3-array";
 import numeral from "numeral";
 import React from "react";
 
-type LocaleRecord = {
+export type LocaleRecord = {
   county: string;
   estimatedIncarceratedCases: number;
   hospitalBeds: number;

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -10,6 +10,7 @@ export type LocaleRecord = {
   reportedCases: number;
   state: string;
   totalIncarceratedPopulation: number;
+  icuBeds: number;
 };
 
 export type LocaleData = Map<string, Map<string, LocaleRecord>>;
@@ -76,6 +77,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
             | LocaleRecord
             | undefined => {
             // rows without these fields are known to be junk; we filter these out below
+            console.log({ row });
             if (!row.County || !row.State) {
               return undefined;
             }
@@ -105,6 +107,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
                       estimatedTotalCases
                   : 0,
               ),
+              icuBeds: numeral(row["ICU Beds"]).value() || 0,
             };
           }).filter((row) => row !== undefined);
 

--- a/src/page-multi-facility/LocaleDetails.tsx
+++ b/src/page-multi-facility/LocaleDetails.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
 import {
-  LocaleDataProvider,
   LocaleRecord,
   useLocaleDataState,
 } from "../locale-data-context/LocaleDataContext";
@@ -37,7 +36,7 @@ const LocaleDetailDescription = styled.div`
   font-weight: normal;
 `;
 
-const localeData: { [key: string]: string | undefined } = {
+const localeRecordProperties: { [key: string]: keyof LocaleRecord } = {
   "Population": "totalIncarceratedPopulation",
   "Cases": "reportedCases",
   "Likely Cases": "estimatedIncarceratedCases",
@@ -57,23 +56,22 @@ const LocaleDetails: React.FC<Props> = ({ stateCode, countyName }) => {
   if (!data || !stateCode || !countyName) return null;
 
   const stateData = data.get(stateCode);
-  const locale: LocaleRecord | undefined =
+  const localeRecord: LocaleRecord | undefined =
     stateData && stateData.get(countyName);
 
   return (
     <LocaleDetailsContainer>
-      {locale &&
-        Object.keys(localeData).map((detail) => {
-          const property = localeData[detail] as keyof LocaleRecord;
-          const value =
-            property && locale[property]
-              ? numeral(locale[property]).format("0,0")
-              : enDash;
+      {localeRecord &&
+        Object.keys(localeRecordProperties).map((headerText: string) => {
+          const property = localeRecordProperties[headerText];
+          const value = localeRecord[property]
+            ? numeral(localeRecord[property]).format("0,0")
+            : enDash;
 
           return (
             <LocaleDetail key={`LocaleDetail-${property}`}>
               <LocaleDetailValue>{value}</LocaleDetailValue>
-              <LocaleDetailDescription>{detail}</LocaleDetailDescription>
+              <LocaleDetailDescription>{headerText}</LocaleDetailDescription>
             </LocaleDetail>
           );
         })}

--- a/src/page-multi-facility/LocaleDetails.tsx
+++ b/src/page-multi-facility/LocaleDetails.tsx
@@ -1,0 +1,85 @@
+import numeral from "numeral";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+import {
+  LocaleDataProvider,
+  LocaleRecord,
+  useLocaleDataState,
+} from "../locale-data-context/LocaleDataContext";
+
+const LocaleDetailsContainer = styled.div`
+  color: ${Colors.green};
+  display: flex;
+  flex-flow: row nowrap;
+  line-height: 150%;
+  letter-spacing: -0.02em;
+  margin: 2em 0;
+`;
+
+const LocaleDetail = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: 32px;
+`;
+
+const LocaleDetailValue = styled.div`
+  font-family: "Poppins", sans serif;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 8px;
+`;
+
+const LocaleDetailDescription = styled.div`
+  font-family: "Helvetica";
+  font-size: 13px;
+  font-weight: normal;
+`;
+
+const localeData: { [key: string]: string | undefined } = {
+  "Population": "totalIncarceratedPopulation",
+  "Cases": "reportedCases",
+  "Likely Cases": "estimatedIncarceratedCases",
+  "Hospital Beds": "hospitalBeds",
+  "ICU Beds": undefined,
+};
+
+const enDash = "–";
+
+interface Props {
+  stateCode: string;
+  countyName?: string;
+}
+
+const LocaleDetails: React.FC<Props> = ({ stateCode, countyName }) => {
+  const { data } = useLocaleDataState();
+  if (!data || !stateCode || !countyName) return null;
+
+  const stateData = data.get(stateCode);
+  const locale: LocaleRecord | undefined =
+    stateData && stateData.get(countyName);
+
+  return (
+    <LocaleDataProvider>
+      <LocaleDetailsContainer>
+        {locale &&
+          Object.keys(localeData).map((detail) => {
+            const property = localeData[detail] as keyof LocaleRecord;
+            const value =
+              property && locale[property]
+                ? numeral(locale[property]).format("0,0")
+                : enDash;
+
+            return (
+              <LocaleDetail key={`LocaleDetail-${property}`}>
+                <LocaleDetailValue>{value}</LocaleDetailValue>
+                <LocaleDetailDescription>{detail}</LocaleDetailDescription>
+              </LocaleDetail>
+            );
+          })}
+      </LocaleDetailsContainer>
+    </LocaleDataProvider>
+  );
+};
+
+export default LocaleDetails;

--- a/src/page-multi-facility/LocaleDetails.tsx
+++ b/src/page-multi-facility/LocaleDetails.tsx
@@ -61,25 +61,23 @@ const LocaleDetails: React.FC<Props> = ({ stateCode, countyName }) => {
     stateData && stateData.get(countyName);
 
   return (
-    <LocaleDataProvider>
-      <LocaleDetailsContainer>
-        {locale &&
-          Object.keys(localeData).map((detail) => {
-            const property = localeData[detail] as keyof LocaleRecord;
-            const value =
-              property && locale[property]
-                ? numeral(locale[property]).format("0,0")
-                : enDash;
+    <LocaleDetailsContainer>
+      {locale &&
+        Object.keys(localeData).map((detail) => {
+          const property = localeData[detail] as keyof LocaleRecord;
+          const value =
+            property && locale[property]
+              ? numeral(locale[property]).format("0,0")
+              : enDash;
 
-            return (
-              <LocaleDetail key={`LocaleDetail-${property}`}>
-                <LocaleDetailValue>{value}</LocaleDetailValue>
-                <LocaleDetailDescription>{detail}</LocaleDetailDescription>
-              </LocaleDetail>
-            );
-          })}
-      </LocaleDetailsContainer>
-    </LocaleDataProvider>
+          return (
+            <LocaleDetail key={`LocaleDetail-${property}`}>
+              <LocaleDetailValue>{value}</LocaleDetailValue>
+              <LocaleDetailDescription>{detail}</LocaleDetailDescription>
+            </LocaleDetail>
+          );
+        })}
+    </LocaleDetailsContainer>
   );
 };
 

--- a/src/page-multi-facility/LocaleDetails.tsx
+++ b/src/page-multi-facility/LocaleDetails.tsx
@@ -1,4 +1,5 @@
 import numeral from "numeral";
+import React from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";

--- a/src/page-multi-facility/LocaleDetails.tsx
+++ b/src/page-multi-facility/LocaleDetails.tsx
@@ -42,7 +42,7 @@ const localeData: { [key: string]: string | undefined } = {
   "Cases": "reportedCases",
   "Likely Cases": "estimatedIncarceratedCases",
   "Hospital Beds": "hospitalBeds",
-  "ICU Beds": undefined,
+  "ICU Beds": "icuBeds",
 };
 
 const enDash = "–";


### PR DESCRIPTION
## Description of the change

> Adds the auto-populating locale information section on the facility page. 

@macfarlandian I'm not sure if I'm using `LocaleDataProvider` as intended, let me know if it would be better to pass in the `model` from the `LocaleInformation` component. I noticed they have different property names and data structures. Also, neither of the data models had a field that looked similar to `ICU Beds`, so I currently left that in as blank. thanks for your help!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #214 
Part of #167 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
