### PR TITLE
129 unwind persistence from baseline scenario

### DIFF
--- a/src/database/__tests__/testcases.tsx
+++ b/src/database/__tests__/testcases.tsx
@@ -8,11 +8,13 @@
  */
 import { deleteFacility, saveFacility } from "../index";
 
+const scenarioId = "someScenarioId";
+
 // 1. Full Form Submission - New Facility
 //
 // Note: some fields get submitted along with the form submission
 // that aren't actually valid model inputs (i.e. localeDataSource)
-saveFacility({
+saveFacility(scenarioId, {
   name: "Ascension Correctional Facility",
   modelInputs: {
     stateCode: "Louisiana",
@@ -66,7 +68,7 @@ saveFacility({
 //  - For booleans I'm just toggling them
 //  - For number I'm incrementing them by 1 or .1
 //  - For dates I'm adding a day
-saveFacility({
+saveFacility(scenarioId, {
   id: "ID FROM EXISTING FACILITY",
   name: "Ascension Correctional Facility - u",
   modelInputs: {
@@ -115,7 +117,7 @@ saveFacility({
 
 // 3. Shallow Name Change
 
-saveFacility({
+saveFacility(scenarioId, {
   id: "ID FROM EXISTING FACILITY",
   name: "Arlington Correctional Facility",
 });
@@ -124,7 +126,7 @@ saveFacility({
 
 // 4. Shallow model input change
 
-saveFacility({
+saveFacility(scenarioId, {
   id: "ID FROM EXISTING FACILITY",
   modelInputs: {
     age0Population: 26,
@@ -136,7 +138,7 @@ saveFacility({
 
 // 5.  Update only the age0Population
 
-saveFacility({
+saveFacility(scenarioId, {
   id: "HKdRt67o21iU11KqNbXt",
   modelInputs: {
     stateCode: "Virginia",
@@ -185,13 +187,13 @@ saveFacility({
 
 // 6.  Delete a facility
 
-deleteFacility("EXISTING FACILITY ID");
+deleteFacility(scenarioId, "EXISTING FACILITY ID");
 
 // Works as expected ✅
 
 // 7.  Attempt to update an non-existent facility
 
-saveFacility({
+saveFacility(scenarioId, {
   id: "NON-EXISTENT ID",
   name: "Broken",
 });
@@ -200,6 +202,6 @@ saveFacility({
 
 // 8.  Attempt to delete a non-existent facility
 
-deleteFacility("NON-EXISTENT ID");
+deleteFacility(scenarioId, "NON-EXISTENT ID");
 
 // Firestore treats this as a no-op ✅

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -8,17 +8,12 @@ import createAuth0Client from "@auth0/auth0-spa-js";
 import { pick } from "lodash";
 
 import config from "../auth/auth_config.json";
-import {
-  EpidemicModelPersistent,
-  persistedKeys,
-} from "../impact-dashboard/EpidemicModelContext";
+import { persistedKeys } from "../impact-dashboard/EpidemicModelContext";
 import { Facility, Scenario } from "../page-multi-facility/types";
-import { prepareForStorage, prepareFromStorage } from "./utils";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
 const tokenExchangeEndpoint =
   "https://us-central1-c19-backend.cloudfunctions.net/getFirebaseToken";
-const modelInputsCollectionId = "model_inputs";
 const scenariosCollectionId = "scenarios";
 const facilitiesCollectionId = "facilities";
 const modelVersionCollectionId = "modelVersions";
@@ -108,61 +103,17 @@ const buildUpdatePayload = (entity: any) => {
     updatedAt: timestamp,
   });
 
-  // We don't want to actually store the id as a field. It should
-  // only be used as a Firestore document reference.
+  // We don't want to actually store the id as a field. It should only be used
+  // as a Firestore document reference.  Note: we are intentionally calling
+  // `delete payload.id` and not `delete entity.id` (like we do in
+  // buildCreatePayload) because we do not want to mutate the entity object and
+  // throw away the reference to its own id.
   delete payload.id;
 
   return payload;
 };
 
-const getInputModelsDocRef = async () => {
-  const db = await getDb();
-  return db.collection(modelInputsCollectionId).doc(currrentUserId());
-};
-
-// TODO: Guard against the possibility of autosaves completing out of order.
-export const saveState = async (
-  persistedState: EpidemicModelPersistent,
-): Promise<void> => {
-  try {
-    const docRef = await getInputModelsDocRef();
-
-    if (!docRef) return;
-
-    docRef.set({
-      timestamp: currrentTimestamp(),
-      inputs: prepareForStorage(persistedState),
-    });
-  } catch (error) {
-    console.error("Encountered error while attempting to save:");
-    console.error(error);
-  }
-};
-
-export const getSavedState = async (): Promise<EpidemicModelPersistent | null> => {
-  try {
-    const docRef = await getInputModelsDocRef();
-
-    if (!docRef) return null;
-
-    const doc = await docRef.get();
-
-    if (!doc.exists) return null;
-
-    const data = doc.data();
-
-    return !data || !data.inputs ? null : prepareFromStorage(data.inputs);
-  } catch (error) {
-    console.error(
-      "Encountered error while attempting to retrieve saved state:",
-    );
-    console.error(error);
-
-    return null;
-  }
-};
-
-export const getBaselineScenarioRef = async () => {
+const getBaselineScenarioRef = async (): Promise<firebase.firestore.DocumentReference | void> => {
   const db = await getDb();
 
   // Note: Firestore queries must only return documents that the user has access to. Otherwise, an error will be thrown.
@@ -174,104 +125,121 @@ export const getBaselineScenarioRef = async () => {
 
   const results = await query.get();
 
-  if (results.docs.length === 0) return null;
+  if (results.docs.length === 0) return;
 
   return results.docs[0].ref;
 };
 
-export const saveScenario = async (scenario: {}): Promise<void> => {
-  try {
-    // We're cheating here because for the launch we know there is only a
-    // baseline scenario. In subsequent launches, we'll need to pass in
-    // the ID of the specific scenario that we want to save. See:
-    // https://github.com/Recidiviz/covid19-dashboard/issues/129
-    const baselineScenarioRef = await getBaselineScenarioRef();
+export const getBaselineScenario = async (): Promise<Scenario | null> => {
+  const baselineScenarioRef = await getBaselineScenarioRef();
 
-    if (!baselineScenarioRef) return;
-
-    const payload = buildUpdatePayload(scenario);
-
-    return await baselineScenarioRef.update(payload);
-  } catch (error) {
-    console.error("Encountered an error while saving the scenario:");
-    console.error(error);
-  }
-};
-
-export const getBaselineScenario = async (
-  baselineScenarioRef: firebase.firestore.DocumentReference | null,
-) => {
   if (!baselineScenarioRef) return null;
 
   const result = await baselineScenarioRef.get();
   let scenario: Scenario = result.data() as Scenario;
+  scenario.id = baselineScenarioRef.id;
 
-  // NOTE: We should be able to remove this check and save once this issue
-  // is resolved: https://github.com/Recidiviz/covid19-dashboard/issues/186
-  if (scenario && !scenario.hasOwnProperty("promoStatuses")) {
-    scenario = {
-      ...scenario,
-      promoStatuses: {
-        dataSharing: true,
-        dailyReports: true,
-        addFacilities: true,
-      },
-    };
-    await saveScenario(scenario);
-  }
   return scenario;
 };
 
-export const createBaselineScenario = async () => {
+const getScenarioRef = async (
+  scenarioId: string,
+): Promise<firebase.firestore.DocumentReference | void> => {
   try {
-    let baselineScenarioRef = await getBaselineScenarioRef();
-
-    if (baselineScenarioRef) {
-      return baselineScenarioRef;
-    }
-
-    const userId = currrentUserId();
-
     const db = await getDb();
 
-    const payload = buildCreatePayload({
-      name: "Baseline Scenario",
-      baseline: true,
-      dataSharing: false,
-      dailyReports: false,
-      promoStatuses: {
-        dataSharing: true,
-        dailyReports: true,
-        addFacilities: true,
-      },
-      description:
-        "Welcome to your new scenario. To get started, add in facility data on the right-hand side of the page. Your initial scenario is also your 'Baseline' - meaning this is where you should keep real-world numbers about the current state of your facilities, their cases, and mitigation steps.",
-      roles: {
-        [userId]: "owner",
-      },
-    });
-
-    baselineScenarioRef = await db
+    const scenarioRef = await db
       .collection(scenariosCollectionId)
-      .add(payload);
+      .doc(scenarioId);
 
-    return baselineScenarioRef;
+    return scenarioRef;
   } catch (error) {
-    console.error("Encountered an error while creating the baseline scenario:");
+    console.error(
+      `Encountered error while attempting to retrieve the scenario ref (${scenarioId}):`,
+    );
+    console.error(error);
+  }
+};
+
+export const getScenario = async (
+  scenarioId: string,
+): Promise<Scenario | null> => {
+  try {
+    const scenarioRef = await getScenarioRef(scenarioId);
+
+    if (!scenarioRef) return null;
+
+    const scenarioResult = await scenarioRef.get();
+    const scenario = scenarioResult.data() as Scenario;
+    scenario.id = scenarioResult.id;
+
+    return scenario;
+  } catch (error) {
+    console.error(
+      `Encountered error while attempting to retrieve the scenario (${scenarioId}):`,
+    );
+    console.error(error);
+
+    return null;
+  }
+};
+
+export const saveScenario = async (scenario: any): Promise<Scenario | null> => {
+  try {
+    const db = await getDb();
+    let scenarioId;
+
+    // If the scenario already has an id associated with it then we just need
+    // to update that scenario. Otherwise, we are creating a new scenario.
+    if (scenario.id) {
+      const payload = buildUpdatePayload(scenario);
+
+      await db
+        .collection(scenariosCollectionId)
+        .doc(scenario.id)
+        .update(payload);
+
+      scenarioId = scenario.id;
+    } else {
+      const userId = currrentUserId();
+      const payload = buildCreatePayload(
+        Object.assign({}, scenario, {
+          roles: {
+            // Automatically assign the logged-in user as the
+            // "owner" of the scenario being saved.
+            [userId]: "owner",
+          },
+        }),
+      );
+
+      const scenarioDocRef = await db
+        .collection(scenariosCollectionId)
+        .add(payload);
+
+      scenarioId = scenarioDocRef.id;
+    }
+
+    return await getScenario(scenarioId);
+  } catch (error) {
+    console.error("Encountered error while attempting to save a scenario:");
     console.error(error);
     return null;
   }
 };
 
-export const getFacilities = async (): Promise<Array<Facility> | null> => {
+export const getFacilities = async (
+  scenarioId: string,
+): Promise<Array<Facility> | null> => {
   try {
-    // Cheating for launch expediency.
-    // See: https://github.com/Recidiviz/covid19-dashboard/issues/129
-    const baselineScenarioRef = await getBaselineScenarioRef();
+    const scenario = await getScenario(scenarioId);
 
-    if (!baselineScenarioRef) return null;
+    if (!scenario) return null;
 
-    const facilitiesResults = await baselineScenarioRef
+    const db = await getDb();
+
+    const facilitiesResults = await db
+      .collection(scenariosCollectionId)
+      .doc(scenario.id)
       .collection(facilitiesCollectionId)
       .orderBy("name")
       .get();
@@ -279,42 +247,13 @@ export const getFacilities = async (): Promise<Array<Facility> | null> => {
     const facilities = facilitiesResults.docs.map((doc) => {
       const facility = doc.data() as Facility;
       facility.id = doc.id;
+      facility.scenarioId = scenario.id;
       return facility;
     });
 
     return facilities;
   } catch (error) {
     console.error("Encountered error while attempting to retrieve facilities:");
-
-    console.error(error);
-
-    return null;
-  }
-};
-
-export const getFacility = async (
-  facilityId: string,
-): Promise<Facility | null> => {
-  try {
-    // Cheating for launch expediency.
-    // See: https://github.com/Recidiviz/covid19-dashboard/issues/129
-    const baselineScenarioRef = await getBaselineScenarioRef();
-
-    if (!baselineScenarioRef) return null;
-
-    const facilityResult = await baselineScenarioRef
-      .collection(facilitiesCollectionId)
-      .doc(facilityId)
-      .get();
-
-    const facility = facilityResult.data() as Facility;
-    facility.id = facilityResult.id;
-
-    return facility;
-  } catch (error) {
-    console.error(
-      `Encountered error while attempting to retrieve the facility (${facilityId}):`,
-    );
 
     console.error(error);
 
@@ -331,6 +270,7 @@ export const getFacility = async (
  * affecting any other fields:
  *
  * saveFacility({
+     "scenarioId": "<The Scenario's ID>",
  *   "id": "<The Faciliy's ID>",
  *   "name": "Updated Facility Name",
  * });
@@ -342,6 +282,7 @@ export const getFacility = async (
  * // Don't do this, it will erase all other model input aside from the
  * // ageUnknownCases:
  * saveFacility({
+     "scenarioId": "<The Scenario's ID>",
  *   "id": "<The Faciliy's ID>",
  *   "modelInput": {
  *     "ageUnknownCases": 4
@@ -359,15 +300,14 @@ export const getFacility = async (
  * Note: It is fine to leave model input values out of modelInputs field
  * if the desired behavior is that those fields are deleted from Firestore.
  */
-export const saveFacility = async (facility: any): Promise<void> => {
+export const saveFacility = async (
+  scenarioId: string,
+  facility: any,
+): Promise<void> => {
   try {
-    // We're cheating here because for the launch we know there is only a
-    // baseline scenario. In subsequent launches, we'll need to pass in
-    // the ID of the specific scenario that we want to save the facility to.
-    // See: https://github.com/Recidiviz/covid19-dashboard/issues/129
-    const baselineScenarioRef = await getBaselineScenarioRef();
+    const scenarioRef = await getScenarioRef(scenarioId);
 
-    if (!baselineScenarioRef) return;
+    if (!scenarioRef) return;
 
     if (facility.modelInputs) {
       // Ensures we don't store any attributres that our model does not
@@ -388,9 +328,7 @@ export const saveFacility = async (facility: any): Promise<void> => {
     const db = await getDb();
     const batch = db.batch();
 
-    const facilitiesCollection = baselineScenarioRef.collection(
-      facilitiesCollectionId,
-    );
+    const facilitiesCollection = scenarioRef.collection(facilitiesCollectionId);
 
     let facilityDoc;
 
@@ -425,13 +363,14 @@ export const saveFacility = async (facility: any): Promise<void> => {
   }
 };
 
-export const deleteFacility = async (facilityId: string): Promise<void> => {
+export const deleteFacility = async (
+  scenarioId: string,
+  facilityId: string,
+): Promise<void> => {
   try {
-    // Cheating for launch expediency.
-    // See: https://github.com/Recidiviz/covid19-dashboard/issues/129
-    const baselineScenarioRef = await getBaselineScenarioRef();
+    const scenarioRef = await getScenarioRef(scenarioId);
 
-    if (!baselineScenarioRef) return;
+    if (!scenarioRef) return;
 
     // Delete all of the modelVersions associated with a facility.  Technically,
     // this is not the recommended approach for the web*, but we should be ok
@@ -440,7 +379,7 @@ export const deleteFacility = async (facilityId: string): Promise<void> => {
     //
     // * https://firebase.google.com/docs/firestore/manage-data/delete-data#web_2
     // ** https://github.com/Recidiviz/covid19-dashboard/issues/191
-    const facilityDocRef = await baselineScenarioRef
+    const facilityDocRef = await scenarioRef
       .collection(facilitiesCollectionId)
       .doc(facilityId);
 

--- a/src/entry-point-client/App.tsx
+++ b/src/entry-point-client/App.tsx
@@ -5,6 +5,7 @@ import { Route, Switch } from "react-router-dom";
 import AuthWall from "../auth/AuthWall";
 import { LocaleDataProvider } from "../locale-data-context";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
+import { ScenarioProvider } from "../scenario-context";
 import { GlobalStyles } from "../styles";
 import PageList from "./PageList";
 import WindowTitle from "./WindowTitle";
@@ -14,30 +15,32 @@ const App: React.FC = () => {
 
   return (
     <LocaleDataProvider>
-      <FacilityContext.Provider value={{ facility, setFacility }}>
-        <GlobalStyles />
-        <Switch>
-          {PageList.map(({ path, title, isPrivate, contents }) => {
-            if (!isPrivate) {
-              return (
-                <Route key={path} path={path} exact>
-                  <WindowTitle>{title}</WindowTitle>
-                  {contents}
-                </Route>
-              );
-            } else {
-              return (
-                <Route key={path} path={path} exact>
-                  <AuthWall>
+      <ScenarioProvider>
+        <FacilityContext.Provider value={{ facility, setFacility }}>
+          <GlobalStyles />
+          <Switch>
+            {PageList.map(({ path, title, isPrivate, contents }) => {
+              if (!isPrivate) {
+                return (
+                  <Route key={path} path={path} exact>
                     <WindowTitle>{title}</WindowTitle>
                     {contents}
-                  </AuthWall>
-                </Route>
-              );
-            }
-          })}
-        </Switch>
-      </FacilityContext.Provider>
+                  </Route>
+                );
+              } else {
+                return (
+                  <Route key={path} path={path} exact>
+                    <AuthWall>
+                      <WindowTitle>{title}</WindowTitle>
+                      {contents}
+                    </AuthWall>
+                  </Route>
+                );
+              }
+            })}
+          </Switch>
+        </FacilityContext.Provider>
+      </ScenarioProvider>
     </LocaleDataProvider>
   );
 };

--- a/src/page-multi-facility/CreateBaselineScenarioPage.tsx
+++ b/src/page-multi-facility/CreateBaselineScenarioPage.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
-import { createBaselineScenario } from "../database";
+import { saveScenario } from "../database";
 import Colors from "../design-system/Colors";
 import InputButton from "../design-system/InputButton";
 import ModalDialog from "../design-system/ModalDialog";
+import useScenario from "../scenario-context/useScenario";
 
 const CreateBaselineScenarioPageContainer = styled.div``;
 
@@ -33,11 +34,29 @@ const ModalContent = styled.div`
 `;
 
 const CreateBaselineScenarioPage: React.FC = () => {
+  // eslint-disable-next-line no-unused-vars
+  const [_, dispatchScenarioUpdate] = useScenario();
   const history = useHistory();
+
   const handleOnClick = async () => {
-    const baselineScenarioRef = await createBaselineScenario();
-    if (baselineScenarioRef) {
-      // Redirect to new facility page after exiting welcome modal
+    const baselineScenarioDefaults = {
+      name: "Baseline Scenario",
+      baseline: true,
+      dataSharing: false,
+      dailyReports: false,
+      promoStatuses: {
+        dataSharing: true,
+        dailyReports: true,
+        addFacilities: true,
+      },
+      description:
+        "Welcome to your new scenario. To get started, add in facility data on the right-hand side of the page. Your initial scenario is also your 'Baseline' - meaning this is where you should keep real-world numbers about the current state of your facilities, their cases, and mitigation steps.",
+    };
+
+    const scenario = await saveScenario(baselineScenarioDefaults);
+
+    if (scenario) {
+      dispatchScenarioUpdate(scenario);
       history.push("/facility");
     }
   };

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -31,7 +31,11 @@ const ButtonSection = styled.div`
   margin-top: 30px;
 `;
 
-const FacilityInputForm: React.FC = () => {
+interface Props {
+  scenarioId: string;
+}
+
+const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   const { facility } = useContext(FacilityContext);
   const history = useHistory();
   const [facilityName, setFacilityName] = useState(facility?.name || undefined);
@@ -44,7 +48,7 @@ const FacilityInputForm: React.FC = () => {
   const model = useModel();
 
   const save = () => {
-    saveFacility({
+    saveFacility(scenarioId, {
       id: facility?.id,
       name: facilityName || null,
       description: description || null,

--- a/src/page-multi-facility/FacilityPage.tsx
+++ b/src/page-multi-facility/FacilityPage.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
 
+import Loading from "../design-system/Loading";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
+import useScenario from "../scenario-context/useScenario";
 import SiteHeader from "../site-header/SiteHeader";
 import { FacilityContext } from "./FacilityContext";
 import FacilityInputForm from "./FacilityInputForm";
@@ -14,21 +16,28 @@ const FacilityPageDiv = styled.div``;
 const FacilityPage: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const { facility } = useContext(FacilityContext);
+  const [scenario] = useScenario();
 
   return (
-    <EpidemicModelProvider
-      facilityModel={facility?.modelInputs}
-      localeDataSource={localeDataSource}
-    >
-      <FacilityPageDiv>
-        <div className="font-body text-green min-h-screen tracking-normal w-full">
-          <div className="max-w-screen-xl px-4 mx-auto">
-            <SiteHeader />
-            <FacilityInputForm />
-          </div>
-        </div>
-      </FacilityPageDiv>
-    </EpidemicModelProvider>
+    <>
+      {scenario.loading || !scenario?.data?.id ? (
+        <Loading />
+      ) : (
+        <EpidemicModelProvider
+          facilityModel={facility?.modelInputs}
+          localeDataSource={localeDataSource}
+        >
+          <FacilityPageDiv>
+            <div className="font-body text-green min-h-screen tracking-normal w-full">
+              <div className="max-w-screen-xl px-4 mx-auto">
+                <SiteHeader />
+                <FacilityInputForm scenarioId={scenario.data.id} />
+              </div>
+            </div>
+          </FacilityPageDiv>
+        </EpidemicModelProvider>
+      )}
+    </>
   );
 };
 

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -101,13 +101,15 @@ const handleSubClick = (fn?: Function, ...args: any[]) => {
 };
 
 interface Props {
-  deleteFn: (id: string) => void;
+  deleteFn: (scenarioId: string, facilityId: string) => void;
   facility: Facility;
+  scenarioId: string;
 }
 
 const FacilityRow: React.FC<Props> = ({
   deleteFn,
   facility: initialFacility,
+  scenarioId: scenarioId,
 }) => {
   const confirmedCases = totalConfirmedCases(useEpidemicModelState());
   const history = useHistory();
@@ -128,11 +130,7 @@ const FacilityRow: React.FC<Props> = ({
   const closeDeleteModal = handleSubClick(updateShowDeleteModal, false);
 
   const removeFacility = handleSubClick(async () => {
-    // In this context id should always be present, but TypeScript
-    // is complaining so I'm adding this check to appease it.
-    if (id) {
-      await deleteFn(id);
-    }
+    await deleteFn(scenarioId, id);
     updateShowDeleteModal(false);
   });
 
@@ -155,7 +153,7 @@ const FacilityRow: React.FC<Props> = ({
                   // this updates the local state
                   updateFacility({ ...facility, name: newName });
                   // this persists the changes to the database
-                  saveFacility({
+                  saveFacility(scenarioId, {
                     id,
                     name: newName,
                   });

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -2,23 +2,18 @@ import React, { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
-import {
-  deleteFacility,
-  getBaselineScenario,
-  getFacilities,
-  saveScenario,
-} from "../database";
+import { deleteFacility, getFacilities } from "../database";
 import Colors from "../design-system/Colors";
 import iconAddSrc from "../design-system/icons/ic_add.svg";
 import Loading from "../design-system/Loading";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
+import useScenario from "../scenario-context/useScenario";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
-import { BaselineScenarioRef } from "./MultiFacilityPage";
 import ProjectionsHeader from "./ProjectionsHeader";
 import ScenarioSidebar from "./ScenarioSidebar";
-import { Facilities, Scenario } from "./types";
+import { Facilities } from "./types";
 
 const MultiFacilityImpactDashboardContainer = styled.main.attrs({
   className: `
@@ -26,10 +21,6 @@ const MultiFacilityImpactDashboardContainer = styled.main.attrs({
     mt-8
   `,
 })``;
-
-interface Props {
-  baselineScenarioRef?: BaselineScenarioRef;
-}
 
 const AddFacilityButton = styled.button`
   color: ${Colors.forest};
@@ -51,10 +42,10 @@ const AddFacilityButtonText = styled.span`
   vertical-align: middle;
 `;
 
-const MultiFacilityImpactDashboard: React.FC<Props> = ({
-  baselineScenarioRef,
-}) => {
+const MultiFacilityImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
+  const [scenario] = useScenario();
+
   const history = useHistory();
   const { setFacility } = useContext(FacilityContext);
 
@@ -63,32 +54,10 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
     loading: true,
   });
 
-  const [scenario, setScenario] = useState<{
-    data: Scenario | null;
-    loading: boolean;
-  }>({
-    data: null,
-    loading: true,
-  });
-
-  const updateScenario = async (scenario: Scenario) => {
-    await saveScenario(scenario);
-    setScenario({ data: scenario, loading: false });
-  };
-
-  useEffect(() => {
-    async function fetchScenario() {
-      const scenario = await getBaselineScenario(baselineScenarioRef?.data);
-      setScenario({
-        data: scenario,
-        loading: false,
-      });
-    }
-    fetchScenario();
-  }, []);
-
   async function fetchFacilities() {
-    const facilitiesData = await getFacilities();
+    if (!scenario?.data?.id) return;
+
+    const facilitiesData = await getFacilities(scenario.data.id);
 
     if (facilitiesData) {
       setFacilities({
@@ -100,15 +69,15 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
 
   useEffect(() => {
     fetchFacilities();
-  }, []);
+  }, [scenario.data?.id]);
 
   const openAddFacilityPage = () => {
     setFacility(null);
     history.push("/facility");
   };
 
-  const deleteFn = async (id: string) => {
-    await deleteFacility(id);
+  const deleteFn = async (scenarioId: string, facilityId: string) => {
+    await deleteFacility(scenarioId, facilityId);
     fetchFacilities();
   };
 
@@ -117,11 +86,7 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
       {scenario.loading ? (
         <Loading />
       ) : (
-        <ScenarioSidebar
-          numFacilities={facilities?.data.length}
-          scenario={scenario.data}
-          updateScenario={updateScenario}
-        />
+        <ScenarioSidebar numFacilities={facilities?.data.length} />
       )}
       <div className="flex flex-col flex-1 pb-6 pl-8">
         <AddFacilityButton onClick={openAddFacilityPage}>
@@ -139,7 +104,11 @@ const MultiFacilityImpactDashboard: React.FC<Props> = ({
                 facilityModel={facility.modelInputs}
                 localeDataSource={localeDataSource}
               >
-                <FacilityRow deleteFn={deleteFn} facility={facility} />
+                <FacilityRow
+                  deleteFn={deleteFn}
+                  facility={facility}
+                  scenarioId={facility.scenarioId}
+                />
               </EpidemicModelProvider>
             );
           })

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -1,43 +1,18 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
-import { getBaselineScenarioRef } from "../database";
 import Loading from "../design-system/Loading";
 import { useLocaleDataState } from "../locale-data-context";
+import useScenario from "../scenario-context/useScenario";
 import SiteHeader from "../site-header/SiteHeader";
 import CreateBaselineScenarioPage from "./CreateBaselineScenarioPage";
 import MultiFacilityImpactDashboard from "./MultiFacilityImpactDashboard";
 
 const MultiFacilityPageDiv = styled.div``;
 
-export type BaselineScenarioRef = {
-  // TODO: Confine uses of Firestore APIs (document references, etc.) to the `database` module and make this type
-  //       more specific.
-  data?: any;
-  loading: boolean;
-};
-
 const MultiFacilityPage: React.FC = () => {
-  const [baselineScenarioRef, setBaselineScenarioRef] = useState<
-    BaselineScenarioRef
-  >({
-    data: null,
-    loading: true,
-  });
-
   const localeState = useLocaleDataState();
-
-  useEffect(() => {
-    async function fetchBaselineScenarioRef() {
-      const baselineScenarioRef = await getBaselineScenarioRef();
-
-      setBaselineScenarioRef({
-        data: baselineScenarioRef,
-        loading: false,
-      });
-    }
-    fetchBaselineScenarioRef();
-  }, []);
+  const [scenario] = useScenario();
 
   return (
     <MultiFacilityPageDiv>
@@ -50,12 +25,10 @@ const MultiFacilityPage: React.FC = () => {
               Unable to load state and county data. Please try refreshing the
               page.
             </div>
-          ) : baselineScenarioRef.loading || localeState.loading ? (
+          ) : localeState.loading || scenario.loading ? (
             <Loading />
-          ) : baselineScenarioRef.data ? (
-            <MultiFacilityImpactDashboard
-              baselineScenarioRef={baselineScenarioRef}
-            />
+          ) : scenario.data ? (
+            <MultiFacilityImpactDashboard />
           ) : (
             <CreateBaselineScenarioPage />
           )}

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -1,16 +1,16 @@
 import { format } from "date-fns";
 import React, { useState } from "react";
 
+import { saveScenario } from "../database";
 import InputDescription from "../design-system/InputDescription";
 import InputNameWithIcon from "../design-system/InputNameWithIcon";
 import PromoBoxWithButton from "../design-system/PromoBoxWithButton";
+import useScenario from "../scenario-context/useScenario";
 import ToggleRow from "./ToggleRow";
 import { Scenario } from "./types";
 
 interface Props {
   numFacilities?: number | null;
-  scenario?: Scenario | null;
-  updateScenario: (scenario: Scenario) => void;
 }
 
 export function getEnabledPromoType(
@@ -45,11 +45,16 @@ export function getPromoText(promoType: string | null) {
 }
 
 const ScenarioSidebar: React.FC<Props> = (props) => {
-  const { scenario, updateScenario, numFacilities } = props;
+  const [scenarioState, dispatchScenarioUpdate] = useScenario();
+  const scenario = scenarioState.data;
+  const { numFacilities } = props;
   const updatedAtDate = Number(scenario?.updatedAt.toDate());
 
   const handleScenarioChange = (scenarioChange: object) => {
-    updateScenario(Object.assign({}, scenario, scenarioChange));
+    const changes = Object.assign({}, scenario, scenarioChange);
+    saveScenario(changes).then((_) => {
+      dispatchScenarioUpdate(changes);
+    });
   };
   const [name, setName] = useState(scenario?.name);
   const [promoDismissed, setPromoDismissed] = useState(false);

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -1,7 +1,8 @@
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
 
 export type Facility = {
-  id?: string;
+  id: string;
+  scenarioId: string;
   name: string;
   description?: string;
   systemType?: string;
@@ -19,6 +20,7 @@ type Timestamp = {
 export type Facilities = Facility[];
 
 export type Scenario = {
+  id: string;
   name: string;
   baseline: boolean;
   dataSharing: boolean;

--- a/src/scenario-context/ScenarioContext.tsx
+++ b/src/scenario-context/ScenarioContext.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from "react";
+
+import { getBaselineScenario } from "../database";
+import { Scenario } from "../page-multi-facility/types";
+
+export type ScenarioUpdate = {
+  loading?: boolean;
+  failed?: boolean;
+  data?: Scenario | null;
+};
+
+interface ScenarioState {
+  loading: boolean;
+  failed: boolean;
+  data: Scenario | null;
+}
+
+type Action = { type: "update"; payload: ScenarioUpdate };
+type Dispatch = (action: Action) => void;
+
+const StateContext = React.createContext<ScenarioState | undefined>(undefined);
+const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+
+function scenarioReducer(state: ScenarioState, action: Action): ScenarioState {
+  switch (action.type) {
+    case "update":
+      return Object.assign({}, state, action.payload);
+  }
+}
+
+export const ScenarioProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, dispatch] = React.useReducer(scenarioReducer, {
+    loading: true,
+    failed: false,
+    data: null,
+  });
+
+  useEffect(() => {
+    async function fetchBaselineScenario() {
+      const baselineScenario = await getBaselineScenario();
+      dispatch({
+        type: "update",
+        payload: {
+          data: baselineScenario,
+          loading: false,
+        },
+      });
+    }
+    fetchBaselineScenario();
+  }, []);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+};
+
+export function useScenarioState() {
+  const context = React.useContext(StateContext);
+
+  if (context === undefined) {
+    throw new Error("useScenarioState must be used within an ScenarioProvider");
+  }
+
+  return context;
+}
+
+export function useScenarioDispatch() {
+  const context = React.useContext(DispatchContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useScenarioDispatch must be used within a ScenarioProvider",
+    );
+  }
+
+  return context;
+}

--- a/src/scenario-context/index.tsx
+++ b/src/scenario-context/index.tsx
@@ -1,0 +1,1 @@
+export * from "./ScenarioContext";

--- a/src/scenario-context/useScenario.tsx
+++ b/src/scenario-context/useScenario.tsx
@@ -1,0 +1,22 @@
+import { Scenario } from "../page-multi-facility/types";
+import { useScenarioDispatch, useScenarioState } from "./ScenarioContext";
+
+export default function useScenario() {
+  const dispatch = useScenarioDispatch();
+  const scenario = useScenarioState();
+
+  function dispatchScenarioUpdate(scenario: Scenario) {
+    dispatch({
+      type: "update",
+      payload: {
+        data: scenario,
+        loading: false,
+      },
+    });
+  }
+
+  return [scenario, dispatchScenarioUpdate] as [
+    typeof scenario,
+    typeof dispatchScenarioUpdate,
+  ];
+}


### PR DESCRIPTION
## Description of the change

This work was done to unwind the assumption that there is only ever a single scenario (i.e. the Baseline) that we can hang all of our other data off of.  Instead, the work here will allow additional features to be created in the context of a multiple scenarios world.

Note:  This PR does not add any new functionality.  It simply lays the foundation for the mutli-scenario work as outlined by #168 which will additionally require more persistence changes for things like listing all scenarios, duplicating a scenario, deleting a scenario, etc.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #129 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
