### PR TITLE
Do real Rt calculation in the python cloud function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .history/
 .idea/
 .vscode/
+.mypy_cache
 
 # Common OS files
 .DS_Store

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,4 +3,3 @@ firebase-debug.log
 # Python
 venv
 __pycache__
-.mypy_cache

--- a/backend/python-functions/main.py
+++ b/backend/python-functions/main.py
@@ -3,6 +3,7 @@ from flask import json
 
 from helpers import cloudfunction
 from schemas import rt_input, rt_output
+from realtime_rt import compute_r_t
 
 @cloudfunction(
     in_schema=rt_input,
@@ -16,10 +17,12 @@ def calculate_rt(request_json):
     """
     resp = defaultdict(list)
 
-    # TODO: real calculation
-    for date in request_json['dates']:
-        resp['Rt'].append({'date': date, 'value': 1.8})
-        resp['low90'].append({'date': date, 'value': 0.6})
-        resp['high90'].append({'date': date, 'value': 3.7})
+    result_df = compute_r_t(request_json)
+
+    for day in result_df.index:
+        date_str = day.strftime("%Y-%m-%d")
+        resp['Rt'].append({'date': date_str, 'value': result_df.loc[day, 'ML']})
+        resp['low90'].append({'date': date_str, 'value': result_df.loc[day, 'Low_90']})
+        resp['high90'].append({'date': date_str, 'value': result_df.loc[day, 'High_90']})
 
     return resp

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -51,7 +51,6 @@ def get_posteriors(sr, sigma=0.15):
     process_matrix /= process_matrix.sum(axis=0)
 
     # (4) Calculate the initial prior
-    #prior0 = sps.gamma(a=4).pdf(r_t_range)
     prior0 = np.ones_like(r_t_range)/len(r_t_range)
     prior0 /= prior0.sum()
 
@@ -76,7 +75,7 @@ def get_posteriors(sr, sigma=0.15):
         #(5b) Calculate the numerator of Bayes' Rule: P(k|R_t)P(R_t)
         numerator = likelihoods[current_day] * current_prior
 
-        #(5c) Calcluate the denominator of Bayes' Rule P(k)
+        #(5c) Calculate the denominator of Bayes' Rule P(k)
         denominator = np.sum(numerator)
 
         # Execute full Bayes' Rule

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -1,0 +1,143 @@
+# Adapted from https://github.com/k-sys/covid-19/blob/master/Realtime%20R0.ipynb
+
+# Libraries required for the web version
+import pandas as pd
+import numpy as np
+from scipy import stats as sps
+from scipy.interpolate import interp1d
+
+def prepare_cases(cases, cutoff=25):
+    new_cases = cases.diff()
+
+    smoothed = new_cases.rolling(7,
+        win_type='gaussian',
+        min_periods=1,
+        center=True).mean(std=2).round()
+
+    idx_start = np.searchsorted(smoothed, cutoff)
+
+    smoothed = smoothed.iloc[idx_start:]
+    original = new_cases.loc[smoothed.index]
+
+    return original, smoothed
+
+def get_posteriors(sr, sigma=0.15):
+
+    # We create an array for every possible value of Rt
+    R_T_MAX = 12
+    r_t_range = np.linspace(0, R_T_MAX, R_T_MAX*100+1)
+
+    # Gamma is 1/serial interval
+    # https://wwwnc.cdc.gov/eid/article/26/7/20-0282_article
+    # https://www.nejm.org/doi/full/10.1056/NEJMoa2001316
+    GAMMA = 1/7
+
+    # (1) Calculate Lambda
+    lam = sr[:-1].values * np.exp(GAMMA * (r_t_range[:, None] - 1))
+
+
+    # (2) Calculate each day's likelihood
+    likelihoods = pd.DataFrame(
+        data = sps.poisson.pmf(sr[1:].values, lam),
+        index = r_t_range,
+        columns = sr.index[1:])
+
+    # (3) Create the Gaussian Matrix
+    process_matrix = sps.norm(loc=r_t_range,
+                              scale=sigma
+                             ).pdf(r_t_range[:, None])
+
+    # (3a) Normalize all rows to sum to 1
+    process_matrix /= process_matrix.sum(axis=0)
+
+    # (4) Calculate the initial prior
+    #prior0 = sps.gamma(a=4).pdf(r_t_range)
+    prior0 = np.ones_like(r_t_range)/len(r_t_range)
+    prior0 /= prior0.sum()
+
+    # Create a DataFrame that will hold our posteriors for each day
+    # Insert our prior as the first posterior.
+    posteriors = pd.DataFrame(
+        index=r_t_range,
+        columns=sr.index,
+        data={sr.index[0]: prior0}
+    )
+
+    # We said we'd keep track of the sum of the log of the probability
+    # of the data for maximum likelihood calculation.
+    log_likelihood = 0.0
+
+    # (5) Iteratively apply Bayes' rule
+    for previous_day, current_day in zip(sr.index[:-1], sr.index[1:]):
+
+        #(5a) Calculate the new prior
+        current_prior = process_matrix @ posteriors[previous_day]
+
+        #(5b) Calculate the numerator of Bayes' Rule: P(k|R_t)P(R_t)
+        numerator = likelihoods[current_day] * current_prior
+
+        #(5c) Calcluate the denominator of Bayes' Rule P(k)
+        denominator = np.sum(numerator)
+
+        # Execute full Bayes' Rule
+        posteriors[current_day] = numerator/denominator
+
+        # Add to the running sum of log likelihoods
+        log_likelihood += np.log(denominator)
+
+    return posteriors, log_likelihood
+
+def highest_density_interval(pmf, p=.9, debug=False):
+    # If we pass a DataFrame, just call this recursively on the columns
+    if(isinstance(pmf, pd.DataFrame)):
+        return pd.DataFrame([highest_density_interval(pmf[col], p=p) for col in pmf],
+                            index=pmf.columns)
+
+    cumsum = np.cumsum(pmf.values)
+
+    # N x N matrix of total probability mass for each low, high
+    total_p = cumsum - cumsum[:, None]
+
+    # Return all indices with total_p > p
+    lows, highs = (total_p > p).nonzero()
+
+    # Find the smallest range (highest density)
+    best = (highs - lows).argmin()
+
+    low = pmf.index[lows[best]]
+    high = pmf.index[highs[best]]
+
+    return pd.Series([low, high],
+                     index=[f'Low_{p*100:.0f}',
+                            f'High_{p*100:.0f}'])
+
+# High level method for computing the rate of spread over time
+def compute_r_t(historical_case_counts):
+
+    # Check required columns are included in the provided input
+    for required_column in ['cases', 'dates']:
+        if required_column not in historical_case_counts:
+            raise ValueError(f'Input is missing required column {required_column}')
+
+    case_df = pd.Series(historical_case_counts['cases'], index=historical_case_counts['dates'])
+    case_df.index = pd.to_datetime(case_df.index)
+    case_df.index.name = 'date'
+
+    _, smoothed = prepare_cases(case_df, cutoff=25)
+
+    # Raise an error if there are no valid cases to use
+    if len(smoothed) == 0:
+        raise ValueError('Input has too few cases to compute R(t)')
+
+    # Note that we're fixing sigma to a value just for the example
+    posteriors, _ = get_posteriors(smoothed, sigma=.25)
+
+    # Note that this takes a while to execute - it's not the most efficient algorithm
+    try:
+        hdis = highest_density_interval(posteriors, p=.9)
+    except:
+        raise ValueError('Unable to compute R(t) with the provided data')
+
+    most_likely = posteriors.idxmax().rename('ML')
+    result = pd.concat([most_likely, hdis], axis=1)
+    return result

--- a/backend/python-functions/requirements.txt
+++ b/backend/python-functions/requirements.txt
@@ -1,2 +1,5 @@
 Flask==1.0.2
 jsonschema==3.2.0
+numpy==1.18.3
+pandas==1.0.3
+scipy==1.4.1

--- a/backend/python-functions/schemas.py
+++ b/backend/python-functions/schemas.py
@@ -8,7 +8,13 @@ number_array = {
 rt_input = {
     "type": "object",
     "properties": {
-        "dates": number_array,
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "format": "date",
+            },
+        },
         "cases": number_array,
     },
 }
@@ -18,8 +24,11 @@ rt_records = {
   "items": {
     "type": "object",
     "properties": {
-      "date": {"type": "number"},
-      "value": {"type": "number"},
+        "date": {
+            "type": "string",
+            "format": "date",
+        },
+        "value": {"type": "number"},
     },
   },
 }

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -14,8 +14,8 @@ class TestCalculateRt(TestCase):
 
     def test_happy_path(self):
         data = {
-        'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
-        'cases': [30, 50, 90, 150]
+            'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
+            'cases': [30, 50, 90, 150]
         }
         self.req.get_json.return_value = data
 
@@ -41,8 +41,8 @@ class TestCalculateRt(TestCase):
 
     def test_empty_input(self):
         data = {
-        'dates': [],
-        'cases': []
+            'dates': [],
+            'cases': []
         }
         self.req.get_json.return_value = data
 

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -14,16 +14,13 @@ class TestCalculateRt(TestCase):
 
     def test_happy_path(self):
         data = {
-        'dates': [1587422775, 1587509175, 1587595575, 1587681975],
-        'cases': [5, 3, 0, 12]
+        'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
+        'cases': [30, 50, 90, 150]
         }
         self.req.get_json.return_value = data
 
         resp = self.get_response_json()
 
-        # TODO: this is really just a placeholder test.
-        # is 1:1 correspondence between input and output dates
-        # actually what we want? probably not
         for date in data['dates']:
             rt = next(x for x in resp['Rt'] if x['date'] == date)
             self.assertIsInstance(rt['value'], float)
@@ -40,4 +37,24 @@ class TestCalculateRt(TestCase):
 
         resp = self.get_response_json()
 
+        self.assertIn('error', resp)
+
+    def test_empty_input(self):
+        data = {
+        'dates': [],
+        'cases': []
+        }
+        self.req.get_json.return_value = data
+
+        resp = self.get_response_json()
+        self.assertIn('error', resp)
+
+    def test_too_few_cases(self):
+        data = {
+        'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
+        'cases': [5, 7, 15, 22]
+        }
+        self.req.get_json.return_value = data
+
+        resp = self.get_response_json()
         self.assertIn('error', resp)


### PR DESCRIPTION
## Description of the change

Replaces the placeholder `calculate_rt` function with real computation. Credit where due: everything in `realtime_rt` is the handiwork of @justkunz; all I really did was construct the response object and write tests. 

I also changed the API to pass the dates as strings instead of timestamps. This conforms better to what the compute function expects, but it also has the benefit of being more explicit and able to be validated as a proper date by the schema, so it's better all around IMO.

I tested this end-to-end on top of #250 and verified it works! (The fetches generally took ~2-3 seconds with just two days of data, FWIW.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #62 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
