### PR TITLE
Update Model Persistence to Support Accessing Multiple Named Scenarios

### DIFF
--- a/src/database/__tests__/testcases.tsx
+++ b/src/database/__tests__/testcases.tsx
@@ -6,7 +6,7 @@
  * (If/when ported to Jest, remove this directory from testPathIgnorePatterns
  * in Jest config.)
  */
-import { deleteFacility, saveFacility } from "../index";
+import { deleteFacility, saveFacility, saveScenario } from "../index";
 
 const scenarioId = "someScenarioId";
 
@@ -205,3 +205,17 @@ saveFacility(scenarioId, {
 deleteFacility(scenarioId, "NON-EXISTENT ID");
 
 // Firestore treats this as a no-op ✅
+
+// Scenario Saving
+
+saveScenario({
+  name: "High Release Scenario",
+  description:
+    "Modeling what the COVID-19 impact would be in a high release scenario",
+});
+
+saveScenario({
+  name: "Low Release Scenario",
+  description:
+    "Modeling what the COVID-19 impact would be in a low release scenario",
+});


### PR DESCRIPTION
## Description of the change

Updating the persistence layer to support accessing all of the Scenarios created by a user such that they can create a "model library" to test multiple scenarios at their facilities.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #255 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
