### PR TITLE
Curve functions accept numeric rate of spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "tailwindcss": "^1.3.5",
     "typescript": "^3.8.3",
     "us-zcta-counties": "^0.0.2",
+    "utility-types": "^3.10.0",
     "whatwg-fetch": "^3.0.0"
   },
   "husky": {

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -4,7 +4,11 @@ import React from "react";
 import { useEffect, useState } from "react";
 
 import Loading from "../design-system/Loading";
-import { calculateCurves, CurveData } from "../infection-model";
+import {
+  calculateCurves,
+  CurveData,
+  curveInputsFromUserInputs,
+} from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
 import { seirIndex } from "../infection-model/seir";
 import { MarkColors } from "./ChartArea";
@@ -41,7 +45,9 @@ const CurveChartContainer: React.FC<Props> = ({
 
   useEffect(() => {
     // TODO: could this be stored on the context instead for reuse?
-    const projectionData = calculateCurves(modelData);
+    const projectionData = calculateCurves(
+      curveInputsFromUserInputs(modelData),
+    );
     // merge and filter the curve data to only what we need for the chart
     updateCurveData({
       exposed: combinePopulations(projectionData, seirIndex.exposed),

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -4,7 +4,10 @@ import styled from "styled-components";
 
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import TextLabel from "../design-system/TextLabel";
-import { getAdjustedTotalPopulation } from "../infection-model";
+import {
+  curveInputsFromUserInputs,
+  getAdjustedTotalPopulation,
+} from "../infection-model";
 import Description from "./Description";
 import { EpidemicModelUpdate } from "./EpidemicModelContext";
 import { FormGrid, FormGridCell, FormGridRow } from "./FormGrid";
@@ -190,7 +193,11 @@ const FacilityInformation: React.FC = () => {
                 {model.populationTurnover !== 0 && (
                   <InputNote>
                     Your updated total population impacted is{" "}
-                    {numeral(getAdjustedTotalPopulation(model)).format("0,0")}
+                    {numeral(
+                      getAdjustedTotalPopulation(
+                        curveInputsFromUserInputs(model),
+                      ),
+                    ).format("0,0")}
                   </InputNote>
                 )}
               </>,

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -2,7 +2,7 @@ import { sum } from "d3-array";
 import ndarray from "ndarray";
 import React from "react";
 
-import { calculateCurves } from "../infection-model";
+import { calculateCurves, curveInputsFromUserInputs } from "../infection-model";
 import {
   getAllValues,
   getColView,
@@ -105,7 +105,9 @@ const ImpactProjectionTableContainer: React.FC = () => {
   const modelData = useEpidemicModelState();
   const { hospitalBeds } = modelData;
   // TODO: could this be stored on the context instead for reuse?
-  const { incarcerated, staff } = calculateCurves(modelData);
+  const { incarcerated, staff } = calculateCurves(
+    curveInputsFromUserInputs(modelData),
+  );
   const incarceratedData: TableRow[] = [
     buildTableRowFromCurves(incarcerated, "Cases", countCasesForDay),
   ];

--- a/src/infection-model/__tests__/curves.test.tsx
+++ b/src/infection-model/__tests__/curves.test.tsx
@@ -1,11 +1,6 @@
 import { range } from "d3-array";
 
-import { RateOfSpread } from "../../impact-dashboard/EpidemicModelContext";
-import {
-  calculateAllCurves,
-  CurveFunctionInputs,
-  getR0FromSize,
-} from "../index";
+import { calculateAllCurves, CurveFunctionInputs } from "../index";
 import { ageGroupIndex, seirIndex } from "../seir";
 
 describe("calculateAllCurves function", () => {
@@ -31,7 +26,8 @@ describe("calculateAllCurves function", () => {
       facilityDormitoryPct: 0.3,
       facilityOccupancyPct: 1.15,
       populationTurnover: 0,
-      rateOfSpreadFactor: RateOfSpread.low,
+      rateOfSpreadCells: 1.8,
+      rateOfSpreadDorms: 2.4,
       staffCases: 7,
       staffPopulation: 23,
       usePopulationSubsets: true,
@@ -76,54 +72,6 @@ describe("calculateAllCurves function", () => {
       );
       expect(totalPop).not.toBe(0);
       expect(totalPop).toBeCloseTo(sumOfCompartments, 5);
-    });
-  });
-
-  test("should accept explicit rate of spread numbers", () => {
-    const rateOfSpreadCells = 1.8;
-    const rateOfSpreadDorms = 2.4;
-    const rateOfSpreadDefaults = getR0FromSize(inputs.rateOfSpreadFactor);
-    // sanity check that these values are actually different from the defaults
-    expect({ rateOfSpreadCells, rateOfSpreadDorms }).not.toEqual(
-      rateOfSpreadDefaults,
-    );
-
-    const { projectionGrid: projectionGridDefault } = calculateAllCurves(
-      inputs,
-    );
-    const { projectionGrid: projectionGridExplicit } = calculateAllCurves({
-      ...inputs,
-      rateOfSpreadCells,
-      rateOfSpreadDorms,
-    });
-
-    // helper to get daily totals for a single compartment
-    function getCurveValues(
-      grid: typeof projectionGridDefault,
-      compartment: number,
-    ) {
-      return range(grid.shape[1]).map((day) =>
-        range(grid.shape[2]).reduce(
-          (sumOfCompartments, bracket) =>
-            (sumOfCompartments += grid.get(compartment, day, bracket)),
-          0,
-        ),
-      );
-    }
-
-    // we can't predict the exact effect but the curves should be different
-    range(projectionGridDefault.shape[0]).map((compartment) => {
-      const defaultCurve: number[] = getCurveValues(
-        projectionGridDefault,
-        compartment,
-      );
-      const explicitCurve: number[] = getCurveValues(
-        projectionGridExplicit,
-        compartment,
-      );
-
-      expect(defaultCurve.length).toEqual(explicitCurve.length);
-      expect(defaultCurve).not.toEqual(explicitCurve);
     });
   });
 });

--- a/src/infection-model/__tests__/curves.test.tsx
+++ b/src/infection-model/__tests__/curves.test.tsx
@@ -1,0 +1,129 @@
+import { range } from "d3-array";
+
+import { RateOfSpread } from "../../impact-dashboard/EpidemicModelContext";
+import {
+  calculateAllCurves,
+  CurveFunctionInputs,
+  getR0FromSize,
+} from "../index";
+import { ageGroupIndex, seirIndex } from "../seir";
+
+describe("calculateAllCurves function", () => {
+  let inputs = {} as CurveFunctionInputs;
+  beforeEach(() => {
+    inputs = {
+      age0Cases: 10,
+      age0Population: 123,
+      age20Cases: 20,
+      age20Population: 456,
+      age45Cases: 25,
+      age45Population: 789,
+      age55Cases: 14,
+      age55Population: 1012,
+      age65Cases: 40,
+      age65Population: 1345,
+      age75Cases: 100,
+      age75Population: 1678,
+      age85Cases: 25,
+      age85Population: 1901,
+      ageUnknownCases: 0,
+      ageUnknownPopulation: 0,
+      facilityDormitoryPct: 0.3,
+      facilityOccupancyPct: 1.15,
+      populationTurnover: 0,
+      rateOfSpreadFactor: RateOfSpread.low,
+      staffCases: 7,
+      staffPopulation: 23,
+      usePopulationSubsets: true,
+    };
+  });
+
+  test("we should have 90 days of data", () => {
+    const {
+      totalPopulationByDay,
+      projectionGrid,
+      expectedPopulationChanges,
+    } = calculateAllCurves(inputs);
+
+    expect(totalPopulationByDay.length).toBe(90);
+    expect(expectedPopulationChanges.length).toBe(90);
+    expect(projectionGrid.shape[1]).toBe(90);
+  });
+
+  test("3D projection array should have the right shape", () => {
+    const { projectionGrid } = calculateAllCurves(inputs);
+    expect(projectionGrid.shape).toEqual([
+      seirIndex.__length,
+      90,
+      ageGroupIndex.__length,
+    ]);
+  });
+
+  test("each day's compartments should equal total population", () => {
+    const { totalPopulationByDay, projectionGrid } = calculateAllCurves(inputs);
+    totalPopulationByDay.forEach((totalPop, day) => {
+      let sumOfCompartments = 0;
+
+      range(projectionGrid.shape[0]).map((compartment) =>
+        range(projectionGrid.shape[2]).map(
+          (bracket) =>
+            (sumOfCompartments += projectionGrid.get(
+              compartment,
+              day,
+              bracket,
+            )),
+        ),
+      );
+      expect(totalPop).not.toBe(0);
+      expect(totalPop).toBeCloseTo(sumOfCompartments, 5);
+    });
+  });
+
+  test("should accept explicit rate of spread numbers", () => {
+    const rateOfSpreadCells = 1.8;
+    const rateOfSpreadDorms = 2.4;
+    const rateOfSpreadDefaults = getR0FromSize(inputs.rateOfSpreadFactor);
+    // sanity check that these values are actually different from the defaults
+    expect({ rateOfSpreadCells, rateOfSpreadDorms }).not.toEqual(
+      rateOfSpreadDefaults,
+    );
+
+    const { projectionGrid: projectionGridDefault } = calculateAllCurves(
+      inputs,
+    );
+    const { projectionGrid: projectionGridExplicit } = calculateAllCurves({
+      ...inputs,
+      rateOfSpreadCells,
+      rateOfSpreadDorms,
+    });
+
+    // helper to get daily totals for a single compartment
+    function getCurveValues(
+      grid: typeof projectionGridDefault,
+      compartment: number,
+    ) {
+      return range(grid.shape[1]).map((day) =>
+        range(grid.shape[2]).reduce(
+          (sumOfCompartments, bracket) =>
+            (sumOfCompartments += grid.get(compartment, day, bracket)),
+          0,
+        ),
+      );
+    }
+
+    // we can't predict the exact effect but the curves should be different
+    range(projectionGridDefault.shape[0]).map((compartment) => {
+      const defaultCurve: number[] = getCurveValues(
+        projectionGridDefault,
+        compartment,
+      );
+      const explicitCurve: number[] = getCurveValues(
+        projectionGridExplicit,
+        compartment,
+      );
+
+      expect(defaultCurve.length).toEqual(explicitCurve.length);
+      expect(defaultCurve).not.toEqual(explicitCurve);
+    });
+  });
+});

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -2,10 +2,7 @@ import { range, sum, zip } from "d3-array";
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import ndarray from "ndarray";
 
-import {
-  PlannedReleases,
-  RateOfSpread,
-} from "../impact-dashboard/EpidemicModelContext";
+import { PlannedReleases } from "../impact-dashboard/EpidemicModelContext";
 import {
   getAllValues,
   getColView,
@@ -22,9 +19,10 @@ export interface CurveProjectionInputs extends SimulationInputs {
   numDays: number;
   ageGroupInitiallyInfected: number[];
   facilityOccupancyPct: number;
-  rateOfSpreadFactor: RateOfSpread;
   plannedReleases?: PlannedReleases;
   populationTurnover: number;
+  rateOfSpreadCells: number;
+  rateOfSpreadDorms: number;
 }
 
 interface SingleDayInputs {
@@ -203,18 +201,6 @@ function simulateOneDay(inputs: SimulationInputs & SingleDayInputs) {
   ];
 }
 
-enum R0Cells {
-  low = 2.4,
-  moderate = 3,
-  high = 3.7,
-}
-
-enum R0Dorms {
-  low = 3,
-  moderate = 5,
-  high = 7,
-}
-
 export const adjustPopulations = ({
   ageGroupPopulations,
   populationTurnover,
@@ -238,7 +224,8 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     numDays,
     plannedReleases,
     populationTurnover,
-    rateOfSpreadFactor,
+    rateOfSpreadCells,
+    rateOfSpreadDorms,
   } = inputs;
 
   // 3d array. D1 = SEIR compartment. D2 = day. D3 = age bracket
@@ -272,15 +259,13 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ageGroupFatalityRates[ageGroupIndex.staff] = 0.026;
 
   // calculate R0 adjusted for housing type and capacity
-  let rateOfSpreadCells = R0Cells[rateOfSpreadFactor];
   const rateOfSpreadCellsAdjustment = 0.8; // magic constant
-  rateOfSpreadCells =
+  const rateOfSpreadCellsAdjusted =
     rateOfSpreadCells -
     (1 - facilityOccupancyPct) *
       (rateOfSpreadCells - rateOfSpreadCellsAdjustment);
-  let rateOfSpreadDorms = R0Dorms[rateOfSpreadFactor];
   const rateOfSpreadDormsAdjustment = 1.7; // magic constant
-  rateOfSpreadDorms =
+  const rateOfSpreadDormsAdjusted =
     rateOfSpreadDorms -
     (1 - facilityOccupancyPct) *
       (rateOfSpreadDorms - rateOfSpreadDormsAdjustment);
@@ -371,8 +356,8 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
         priorSimulation: getAllValues(getRowView(singleDayState, ageGroup)),
         totalPopulation,
         totalInfectious,
-        rateOfSpreadCells,
-        rateOfSpreadDorms,
+        rateOfSpreadCells: rateOfSpreadCellsAdjusted,
+        rateOfSpreadDorms: rateOfSpreadDormsAdjusted,
         pFatalityRate: rate,
         facilityDormitoryPct,
         simulateStaff: ageGroup === ageGroupIndex.staff,

--- a/src/page-model-inspection/ModelInspectionTableContainer.tsx
+++ b/src/page-model-inspection/ModelInspectionTableContainer.tsx
@@ -3,7 +3,10 @@ import flatten from "lodash/flatten";
 import React from "react";
 
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
-import { calculateAllCurves } from "../infection-model";
+import {
+  calculateAllCurves,
+  curveInputsFromUserInputs,
+} from "../infection-model";
 import { ageGroupIndex, seirIndex } from "../infection-model/seir";
 import ModelInspectionTable from "./ModelInspectionTable";
 
@@ -13,7 +16,7 @@ const ModelInspectionTableContainer: React.FC = () => {
     expectedPopulationChanges,
     projectionGrid,
     totalPopulationByDay,
-  } = calculateAllCurves(modelData);
+  } = calculateAllCurves(curveInputsFromUserInputs(modelData));
 
   const dataRows = flatten(
     range(projectionGrid.shape[0]).map((compartment) =>

--- a/src/page-model-inspection/ModelOutputChartContainer.tsx
+++ b/src/page-model-inspection/ModelOutputChartContainer.tsx
@@ -2,7 +2,11 @@ import { sum, zip } from "d3-array";
 import React from "react";
 
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
-import { calculateCurves, CurveData } from "../infection-model";
+import {
+  calculateCurves,
+  CurveData,
+  curveInputsFromUserInputs,
+} from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
 import { seirIndex, seirIndexList } from "../infection-model/seir";
 import ModelOutputChart from "./ModelOutputChart";
@@ -18,7 +22,7 @@ function combinePopulations(data: CurveData, compartment: seirIndex) {
 const ModelOutputChartContainer: React.FC = () => {
   const modelData = useEpidemicModelState();
   // TODO: could this be stored on the context instead for reuse?
-  const projectionData = calculateCurves(modelData);
+  const projectionData = calculateCurves(curveInputsFromUserInputs(modelData));
   // merge and filter the curve data to only what we need for the chart
   const curveData: { [key: string]: number[] } = {};
   seirIndexList.forEach((i) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15579,6 +15579,11 @@ utila@^0.4.0, utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
+utility-types@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"


### PR DESCRIPTION
## Description of the change

Both the R(t) feature and Excalibur are going to need to generate curves based on arbitrary rate of spread factors that aren't captured by our existing low/med/high enums. This PR changes the interface for our curve functions to just require numeric inputs. 

There was existing logic in the curve function to translate the enum key into numeric values; that has been factored out into a separate function. Components that were dumping the `EpidemicModelContext` directly into curve functions now need to use this new function to transform the context data structure first. Future components for the features mentioned above may provide these values by other means, which may or may not depend on the enum value selected by the user. There may come a point where we deprecate and remove that enum entirely, but we're not there yet, so for now this new function bridges the gap.

Also added some tests for the curve function to help me make this change with confidence. They mainly just replicate the manual sanity checks we have been doing on model inspection page (inspecting table structure, computing checksums).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #62 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
