### PR TITLE
Make FacilityRow text input behavior match Scenario Details section

### DIFF
--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -14,7 +14,6 @@ const inputTextAreaStyle = {
 const DescriptionDiv = styled.div`
   min-height: 100px;
   width: 100%;
-  padding: 20px 0;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -44,7 +44,7 @@ interface Props {
   description?: string | undefined;
   setDescription: (description?: string) => void;
   placeholderValue?: string | undefined;
-  persistChanges?: (changes: object) => void;
+  persistChanges?: (changes: { description: string | undefined }) => void;
 }
 
 const InputDescription: React.FC<Props> = ({

--- a/src/design-system/PopUpMenu.tsx
+++ b/src/design-system/PopUpMenu.tsx
@@ -29,7 +29,6 @@ const PopUpMenuIcon = styled.div`
   font-size: 24px;
   font-weight: 600;
   color: ${Colors.forest};
-  padding: 8px;
 `;
 
 const PopUpMenuContents = styled.div`

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -29,10 +29,6 @@ const DescRow = styled.div`
   justify-content: space-between;
 `;
 
-const PopUpMenuWrapper = styled.div`
-  padding-top: 12px;
-`;
-
 // Delete Modal elements
 const ModalContents = styled.div`
   align-items: center;
@@ -143,15 +139,15 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           setName={setFacilityName}
           placeholderValue="Unnamed Facility"
         />
+        <div className="mt-5" />
         <DescRow>
           <InputDescription
             description={description}
             setDescription={setDescription}
             placeholderValue="Enter a description (optional)"
           />
-          <PopUpMenuWrapper>
-            <PopUpMenu items={popupItems} />
-          </PopUpMenuWrapper>
+          <div className="mr-5" />
+          <PopUpMenu items={popupItems} />
         </DescRow>
         <div className="mt-5 mb-5 border-b border-gray-300" />
 

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -5,8 +5,7 @@ import styled from "styled-components";
 import { saveFacility } from "../database/index";
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
-import iconEditSrc from "../design-system/icons/ic_edit.svg";
-import InputTextArea from "../design-system/InputTextArea";
+import InputDescription from "../design-system/InputDescription";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import {
   totalConfirmedCases,
@@ -29,18 +28,6 @@ const FacilityNameLabel = styled.label`
   height: 100%;
   padding-right: 25px;
   width: 75%;
-`;
-
-const IconEdit = styled.img`
-  align-self: flex-start;
-  flex: 0 0 auto;
-  height: 10px;
-  margin-left: 10px;
-  visibility: hidden;
-  width: 10px;
-  ${FacilityNameLabel}:hover & {
-    visibility: visible;
-  }
 `;
 
 const DataContainer = styled.div`
@@ -89,15 +76,10 @@ const FacilityRow: React.FC<Props> = ({
           <div className="flex flex-row h-full">
             <CaseText className="w-1/4 font-bold">{confirmedCases}</CaseText>
             <FacilityNameLabel onClick={handleSubClick()}>
-              <InputTextArea
-                inline={true}
-                fillVertical={true}
-                value={name}
-                onChange={(event) => {
-                  const newName = (event.target.value || "").replace(
-                    /(\r\n|\n|\r)/gm,
-                    "",
-                  );
+              <InputDescription
+                description={name}
+                setDescription={(name) => {
+                  const newName = (name || "").replace(/(\r\n|\n|\r)/gm, "");
                   // this updates the local state
                   updateFacility({ ...facility, name: newName });
                   // this persists the changes to the database
@@ -106,8 +88,8 @@ const FacilityRow: React.FC<Props> = ({
                     name: newName,
                   });
                 }}
+                placeholderValue="Unnamed Facility"
               />
-              <IconEdit alt="Edit facility name" src={iconEditSrc} />
             </FacilityNameLabel>
           </div>
           <div className="text-xs text-gray-500 pb-4">

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -70,12 +70,14 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           placeholderValue={scenario?.name}
           persistChanges={handleScenarioChange}
         />
+        <div className="mt-5" />
         <InputDescription
           description={description}
           setDescription={setDescription}
           placeholderValue={scenario?.description}
           persistChanges={handleScenarioChange}
         />
+        <div className="mb-5" />
         <div>
           <p className="text-xs text-gray-500">
             Last Update:{" "}


### PR DESCRIPTION
## Description of the change

* Use InputDescription instead of InputTextArea in FacilityRow
* Make persistChanges more specific
* Remove padding from component level 
  * Correspondingly, re-implement spacing in page, with margin (cause between elements)

WAS:
![inputtext5](https://user-images.githubusercontent.com/1372946/80772596-21bb1a80-8b0c-11ea-8495-09513da501e6.gif)

IS: only visual change to facility row, not elsewhere
![inputtext4](https://user-images.githubusercontent.com/1372946/80772536-f9332080-8b0b-11ea-82e8-9154bb3e66d2.gif)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes https://github.com/Recidiviz/covid19-dashboard/issues/196

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant

---

Let me know if should make any changes!

Thanks @szhu for your help! 💯

---

From talking to szhu and @cawarren, next tasks could be these things, lmk if any preferences:

**Follow-ons I can do:**
- Fix InputNameWithIcon to not have the text size jump
- [x] Use `Spacer` component instead of `div className="mt-5"`...rn this give me an error because it outputs `height: 20` instead of `height: 20px` (or rem, see both) https://github.com/Recidiviz/covid19-dashboard/pull/277
- Rename InputDescription to something like InputTextAreaEditable since we are using it for name and description now
- If a single word in the FacilityRow is longer than the textarea box, it breaks the layout, can account for with some sort of `text-overflow: ellipsis` but wanted to get eyes on this first...since seems like an edge case

**New ticket I can do:**
- https://github.com/Recidiviz/covid19-dashboard/issues/176