### PR TITLE
Use R(t) value in projection model

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -124,8 +124,9 @@ def compute_r_t(historical_case_counts):
 
     _, smoothed = prepare_cases(case_df, cutoff=25)
 
-    # Raise an error if there are no valid cases to use
-    if len(smoothed) == 0:
+    # Raise an error if there are not enough valid cases to use
+    # we need at least two days to represent change over time
+    if len(smoothed) < 2:
         raise ValueError('Input has too few cases to compute R(t)')
 
     # Note that we're fixing sigma to a value just for the example

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -122,7 +122,7 @@ def compute_r_t(historical_case_counts):
     case_df.index = pd.to_datetime(case_df.index)
     case_df.index.name = 'date'
 
-    _, smoothed = prepare_cases(case_df, cutoff=25)
+    _, smoothed = prepare_cases(case_df, cutoff=10)
 
     # Raise an error if there are not enough valid cases to use
     # we need at least two days to represent change over time

--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -30,7 +30,7 @@ const LegendContainer = styled.div`
 `;
 
 const ChartArea: React.FC<{
-  projectionData: CurveData;
+  projectionData?: CurveData;
 }> = ({ projectionData }) => {
   const [groupStatus, setGroupStatus] = useState({
     exposed: true,

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -68,7 +68,7 @@ const Tooltip: React.FC<TooltipProps> = ({
 };
 
 export interface ChartData {
-  [key: string]: number[];
+  [key: string]: number[] | undefined;
 }
 
 interface CurveChartProps {

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -12,7 +12,7 @@ interface Props {
   groupStatus: Record<string, any>;
   hideAxes?: boolean;
   markColors: MarkColors;
-  curveData: ChartData;
+  curveData?: ChartData;
 }
 
 const CurveChartContainer: React.FC<Props> = ({
@@ -26,6 +26,8 @@ const CurveChartContainer: React.FC<Props> = ({
   const [curveDataFiltered, setCurveDataFiltered] = useState(curveData);
 
   useEffect(() => {
+    if (!curveData) return;
+
     if (isEmpty(curveData)) {
       setCurveDataFiltered({});
       return;

--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -2,6 +2,7 @@ import { sum } from "d3-array";
 import ndarray from "ndarray";
 import React from "react";
 
+import Loading from "../design-system/Loading";
 import { CurveData } from "../infection-model";
 import {
   getAllValues,
@@ -102,9 +103,11 @@ function buildHospitalizedRow(data: ndarray): TableRow {
 }
 
 const ImpactProjectionTableContainer: React.FC<{
-  projectionData: CurveData;
+  projectionData?: CurveData;
 }> = ({ projectionData }) => {
   const { hospitalBeds } = useEpidemicModelState();
+
+  if (!projectionData) return <Loading />;
 
   const { incarcerated, staff } = projectionData;
   const incarceratedData: TableRow[] = [

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -15,6 +15,10 @@ export type CurveData = {
   staff: ndarray;
 };
 
+export const isCurveData = (arg: CurveData | undefined): arg is CurveData => {
+  return arg !== undefined;
+};
+
 export type CurveFunctionInputs = Omit<
   EpidemicModelInputs,
   "rateOfSpreadFactor"

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -79,6 +79,23 @@ export function curveInputsFromUserInputs(
   return curveInputs;
 }
 
+export function curveInputsWithRt(
+  userInputs: EpidemicModelInputs,
+  rt?: number,
+): CurveFunctionInputs | undefined {
+  if (rt === undefined) {
+    return;
+  }
+  // with Rt there is no distinction between these rates
+  const rateOfSpreadValues = {
+    rateOfSpreadCells: rt,
+    rateOfSpreadDorms: rt,
+  };
+  const curveInputs = { ...userInputs, ...rateOfSpreadValues };
+  delete curveInputs.rateOfSpreadFactor;
+  return curveInputs;
+}
+
 function prepareCurveData(inputs: CurveFunctionInputs): CurveProjectionInputs {
   const {
     age0Cases,
@@ -132,7 +149,11 @@ function prepareCurveData(inputs: CurveFunctionInputs): CurveProjectionInputs {
   };
 }
 
-export function calculateCurves(inputs: CurveFunctionInputs): CurveData {
+export function calculateCurves(
+  inputs?: CurveFunctionInputs,
+): CurveData | undefined {
+  if (!inputs) return;
+
   const { projectionGrid } = getAllBracketCurves(prepareCurveData(inputs));
 
   // these will each produce a matrix with row = day and col = SEIR bucket,

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -69,12 +69,28 @@ enum R0Dorms {
 export function curveInputsFromUserInputs(
   userInputs: EpidemicModelInputs,
 ): CurveFunctionInputs {
+  const { facilityOccupancyPct, rateOfSpreadFactor } = userInputs;
   // translate qualitative rate of spread factor into numbers
-  const rateOfSpreadDefaults = {
-    rateOfSpreadCells: R0Cells[userInputs.rateOfSpreadFactor],
-    rateOfSpreadDorms: R0Dorms[userInputs.rateOfSpreadFactor],
+  let rateOfSpreadCells = R0Cells[rateOfSpreadFactor];
+  let rateOfSpreadDorms = R0Dorms[rateOfSpreadFactor];
+
+  // adjust rate of spread for housing type and capacity
+  const rateOfSpreadCellsAdjustment = 0.8; // magic constant
+  rateOfSpreadCells =
+    rateOfSpreadCells -
+    (1 - facilityOccupancyPct) *
+      (rateOfSpreadCells - rateOfSpreadCellsAdjustment);
+
+  const rateOfSpreadDormsAdjustment = 1.7; // magic constant
+  rateOfSpreadDorms =
+    rateOfSpreadDorms -
+    (1 - facilityOccupancyPct) *
+      (rateOfSpreadDorms - rateOfSpreadDormsAdjustment);
+
+  const curveInputs = {
+    ...userInputs,
+    ...{ rateOfSpreadCells, rateOfSpreadDorms },
   };
-  const curveInputs = { ...userInputs, ...rateOfSpreadDefaults };
   delete curveInputs.rateOfSpreadFactor;
   return curveInputs;
 }

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -220,7 +220,6 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     ageGroupInitiallyInfected,
     ageGroupPopulations,
     facilityDormitoryPct,
-    facilityOccupancyPct,
     numDays,
     plannedReleases,
     populationTurnover,
@@ -257,18 +256,6 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ageGroupFatalityRates[ageGroupIndex.age75] = 0.074;
   ageGroupFatalityRates[ageGroupIndex.age85] = 0.1885;
   ageGroupFatalityRates[ageGroupIndex.staff] = 0.026;
-
-  // calculate R0 adjusted for housing type and capacity
-  const rateOfSpreadCellsAdjustment = 0.8; // magic constant
-  const rateOfSpreadCellsAdjusted =
-    rateOfSpreadCells -
-    (1 - facilityOccupancyPct) *
-      (rateOfSpreadCells - rateOfSpreadCellsAdjustment);
-  const rateOfSpreadDormsAdjustment = 1.7; // magic constant
-  const rateOfSpreadDormsAdjusted =
-    rateOfSpreadDorms -
-    (1 - facilityOccupancyPct) *
-      (rateOfSpreadDorms - rateOfSpreadDormsAdjustment);
 
   // adjust population figures based on expected turnover
   ageGroupPopulations = adjustPopulations({
@@ -356,8 +343,8 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
         priorSimulation: getAllValues(getRowView(singleDayState, ageGroup)),
         totalPopulation,
         totalInfectious,
-        rateOfSpreadCells: rateOfSpreadCellsAdjusted,
-        rateOfSpreadDorms: rateOfSpreadDormsAdjusted,
+        rateOfSpreadCells,
+        rateOfSpreadDorms,
         pFatalityRate: rate,
         facilityDormitoryPct,
         simulateStaff: ageGroup === ageGroupIndex.staff,

--- a/src/page-model-inspection/ModelOutputChartContainer.tsx
+++ b/src/page-model-inspection/ModelOutputChartContainer.tsx
@@ -1,6 +1,7 @@
 import { sum, zip } from "d3-array";
 import React from "react";
 
+import Loading from "../design-system/Loading";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import {
   calculateCurves,
@@ -23,6 +24,7 @@ const ModelOutputChartContainer: React.FC = () => {
   const modelData = useEpidemicModelState();
   // TODO: could this be stored on the context instead for reuse?
   const projectionData = calculateCurves(curveInputsFromUserInputs(modelData));
+  if (!projectionData) return <Loading />;
   // merge and filter the curve data to only what we need for the chart
   const curveData: { [key: string]: number[] } = {};
   seirIndexList.forEach((i) => {

--- a/src/page-multi-facility/FacilityContext.tsx
+++ b/src/page-multi-facility/FacilityContext.tsx
@@ -4,7 +4,7 @@ import { RtData } from "../infection-model/rt";
 import { Facility } from "./types";
 
 export type RtDataMapping = {
-  [key in Facility["id"]]: RtData;
+  [key in Facility["id"]]: RtData | null;
 };
 
 interface FacilityContextProps {

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -132,7 +132,13 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
     updateShowDeleteModal(false);
   };
 
-  const rtTimeseriesData = rtData && facility ? rtData[facility.id] : undefined;
+  const rtTimeseriesData = facility
+    ? rtData
+      ? rtData[facility.id]
+      : undefined
+    : // when creating a new facility, there will never be Rt data;
+      // setting this value to null will suppress the chart
+      null;
 
   return (
     <PageContainer>

--- a/src/page-multi-facility/FacilityProjections.tsx
+++ b/src/page-multi-facility/FacilityProjections.tsx
@@ -1,12 +1,24 @@
-import React from "react";
+import React, { useContext } from "react";
 
+import { useFlag } from "../feature-flags";
 import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import ImpactProjectionTableContainer from "../impact-dashboard/ImpactProjectionTableContainer";
-import { useProjectionFromUserInput } from "./projectionCurveHooks";
+import { FacilityContext } from "./FacilityContext";
+import { useProjectionData } from "./projectionCurveHooks";
 
-const FacilityProjections = () => {
-  const projectionData = useProjectionFromUserInput(useEpidemicModelState());
+const FacilityProjections: React.FC = () => {
+  const { facility, rtData } = useContext(FacilityContext);
+  let useRt, facilityRtData;
+  if (useFlag(["useRt"])) {
+    useRt = true;
+    facilityRtData = rtData && facility ? rtData[facility.id] : undefined;
+  }
+  const projectionData = useProjectionData(
+    useEpidemicModelState(),
+    useRt,
+    facilityRtData,
+  );
   return (
     <>
       <ChartArea projectionData={projectionData} />

--- a/src/page-multi-facility/FacilityProjections.tsx
+++ b/src/page-multi-facility/FacilityProjections.tsx
@@ -10,9 +10,11 @@ import { useProjectionData } from "./projectionCurveHooks";
 const FacilityProjections: React.FC = () => {
   const { facility, rtData } = useContext(FacilityContext);
   let useRt, facilityRtData;
-  if (useFlag(["useRt"])) {
+  // when creating a new facility, we'll never have Rt,
+  // so fall back to unflagged behavior
+  if (useFlag(["useRt"]) && facility) {
     useRt = true;
-    facilityRtData = rtData && facility ? rtData[facility.id] : undefined;
+    facilityRtData = rtData ? rtData[facility.id] : undefined;
   }
   const projectionData = useProjectionData(
     useEpidemicModelState(),

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -7,13 +7,17 @@ import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import iconEditSrc from "../design-system/icons/ic_edit.svg";
 import InputTextArea from "../design-system/InputTextArea";
+import { useFlag } from "../feature-flags";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import {
   totalConfirmedCases,
   useEpidemicModelState,
 } from "../impact-dashboard/EpidemicModelContext";
 import { FacilityContext } from "./FacilityContext";
-import { useChartDataFromUserInput } from "./projectionCurveHooks";
+import {
+  useChartDataFromProjectionData,
+  useProjectionData,
+} from "./projectionCurveHooks";
 import { Facility } from "./types";
 
 const groupStatus = {
@@ -73,9 +77,17 @@ const FacilityRow: React.FC<Props> = ({
   scenarioId: scenarioId,
 }) => {
   const modelData = useEpidemicModelState();
-  const { setFacility } = useContext(FacilityContext);
+  const { setFacility, rtData } = useContext(FacilityContext);
   const [facility, updateFacility] = useState(initialFacility);
-  const chartData = useChartDataFromUserInput(modelData);
+
+  let useRt, facilityRtData;
+  if (useFlag(["useRt"])) {
+    useRt = true;
+    facilityRtData = rtData ? rtData[facility.id] : undefined;
+  }
+  const chartData = useChartDataFromProjectionData(
+    useProjectionData(modelData, useRt, facilityRtData),
+  );
 
   const { id, name, updatedAt } = facility;
   const confirmedCases = totalConfirmedCases(modelData);

--- a/src/page-multi-facility/__tests__/projectionCurveHooks.test.tsx
+++ b/src/page-multi-facility/__tests__/projectionCurveHooks.test.tsx
@@ -1,88 +1,101 @@
 import { render } from "@testing-library/react";
 import React from "react";
 
-import { RateOfSpread } from "../../impact-dashboard/EpidemicModelContext";
-import {
-  useChartDataFromUserInput,
-  useProjectionFromUserInput,
-} from "../projectionCurveHooks";
+import { EpidemicModelInputs } from "../../impact-dashboard/EpidemicModelContext";
+import { RtData } from "../../infection-model/rt";
+import { useProjectionData } from "../projectionCurveHooks";
 
-describe("useProjectionFromUserInput", () => {
+describe("useProjectionData", () => {
   let input: any;
   let returnVal: any;
+  let rtData: any;
+  let useRt: boolean;
 
-  function TestComponent({ input }: { input: any }) {
-    returnVal = useProjectionFromUserInput(input);
+  function TestComponent({
+    input,
+    rtData,
+    useRt,
+  }: {
+    input: EpidemicModelInputs;
+    rtData?: RtData;
+    useRt?: boolean;
+  }) {
+    returnVal = useProjectionData(input, useRt, rtData);
     return null;
   }
 
   beforeEach(() => {
+    returnVal = undefined;
+    useRt = true;
     input = {
       ageUnknownCases: 1500,
       ageUnknownPopulation: 6543,
       facilityDormitoryPct: 0.3,
       facilityOccupancyPct: 1.15,
       populationTurnover: 0,
-      rateOfSpreadFactor: RateOfSpread.high,
       staffCases: 7,
       staffPopulation: 23,
       usePopulationSubsets: true,
     };
-  });
-
-  test("reference remains stable with same input", () => {
-    const { rerender } = render(<TestComponent input={input} />);
-    const firstReturnVal = returnVal;
-
-    rerender(<TestComponent input={input} />);
-    expect(firstReturnVal).toBe(returnVal);
-  });
-
-  test("reference changes with new input", () => {
-    const { rerender } = render(<TestComponent input={input} />);
-    const firstReturnVal = returnVal;
-
-    rerender(<TestComponent input={{ ...input }} />);
-    expect(firstReturnVal).not.toBe(returnVal);
-  });
-});
-
-describe("useChartDataFromUserInput", () => {
-  let input: any;
-  let returnVal: any;
-
-  function TestComponent({ input }: { input: any }) {
-    returnVal = useChartDataFromUserInput(input);
-    return null;
-  }
-
-  beforeEach(() => {
-    input = {
-      ageUnknownCases: 1500,
-      ageUnknownPopulation: 6543,
-      facilityDormitoryPct: 0.3,
-      facilityOccupancyPct: 1.15,
-      populationTurnover: 0,
-      rateOfSpreadFactor: RateOfSpread.high,
-      staffCases: 7,
-      staffPopulation: 23,
-      usePopulationSubsets: true,
+    rtData = {
+      Rt: [{ date: new Date(), value: 2.2 }],
+      low90: [{ date: new Date(), value: 1.2 }],
+      high90: [{ date: new Date(), value: 3.2 }],
     };
   });
 
   test("reference remains stable with same input", () => {
-    const { rerender } = render(<TestComponent input={input} />);
+    const { rerender } = render(
+      <TestComponent useRt={useRt} input={input} rtData={rtData} />,
+    );
     const firstReturnVal = returnVal;
 
-    rerender(<TestComponent input={input} />);
+    rerender(<TestComponent useRt={useRt} input={input} rtData={rtData} />);
+    expect(firstReturnVal).toBe(returnVal);
+
+    rerender(
+      <TestComponent useRt={useRt} input={input} rtData={{ ...rtData }} />,
+    );
+    // this should still be the same because the last value of Rt hasn't changed
     expect(firstReturnVal).toBe(returnVal);
   });
 
   test("reference changes with new input", () => {
-    const { rerender } = render(<TestComponent input={input} />);
-    const firstReturnVal = returnVal;
+    const { rerender } = render(
+      <TestComponent useRt={useRt} input={input} rtData={rtData} />,
+    );
+    let prevReturnVal = returnVal;
 
-    rerender(<TestComponent input={{ ...input }} />);
-    expect(firstReturnVal).not.toBe(returnVal);
+    rerender(
+      <TestComponent
+        useRt={useRt}
+        input={input}
+        rtData={{ ...rtData, Rt: [{ date: new Date(), value: 2.1 }] }}
+      />,
+    );
+    expect(prevReturnVal).not.toBe(returnVal);
+
+    prevReturnVal = returnVal;
+
+    rerender(
+      <TestComponent
+        useRt={useRt}
+        input={{ ...input }}
+        rtData={{ ...rtData }}
+      />,
+    );
+    expect(prevReturnVal).not.toBe(returnVal);
+  });
+
+  test("Rt is optional", () => {
+    useRt = false;
+
+    render(<TestComponent useRt={useRt} input={input} rtData={rtData} />);
+    expect(returnVal).toBeDefined();
+
+    returnVal = undefined;
+
+    render(<TestComponent input={input} />);
+    expect(returnVal).toBeDefined();
   });
 });

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -1,7 +1,6 @@
 import { zip } from "d3-array";
 import { useEffect, useState } from "react";
 
-import { ChartData } from "../impact-dashboard/CurveChart";
 import { EpidemicModelInputs } from "../impact-dashboard/EpidemicModelContext";
 import {
   calculateCurves,
@@ -70,15 +69,6 @@ export const useChartDataFromProjectionData = (projectionData?: CurveData) => {
   useEffect(() => {
     updateCurveData(buildCurves(projectionData));
   }, [projectionData]);
-
-  return curveData;
-};
-
-export const useChartDataFromUserInput = (
-  input: EpidemicModelInputs,
-): ChartData => {
-  const projectionData = useProjectionFromUserInput(input);
-  const curveData = useChartDataFromProjectionData(projectionData);
 
   return curveData;
 };

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -53,7 +53,7 @@ function combinePopulations(data: CurveData, columnIndex: number) {
 }
 
 function buildCurves(projectionData?: CurveData) {
-  if (!projectionData) return {};
+  if (!projectionData) return undefined;
 
   // merge and filter the curve data to only what we need for the chart
   return {

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -27,12 +27,17 @@ function getCurves(
 export const useProjectionData = (
   input: EpidemicModelInputs,
   useRt?: boolean,
-  rtData?: RtData,
+  rtData?: RtData | null,
 ): CurveData | undefined => {
   let latestRt: number | undefined;
 
   if (useRt) {
-    latestRt = rtData?.Rt[rtData.Rt.length - 1].value;
+    // a null value indicates Rt fetching failed
+    if (rtData === null) {
+      useRt = false;
+    } else {
+      latestRt = rtData?.Rt[rtData.Rt.length - 1].value;
+    }
   }
 
   const [curves, updateCurves] = useState(getCurves(input, useRt, latestRt));

--- a/src/page-response-impact/responseChartData.tsx
+++ b/src/page-response-impact/responseChartData.tsx
@@ -5,6 +5,7 @@ import {
   calculateCurves,
   CurveData,
   CurveFunctionInputs,
+  isCurveData,
 } from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
 import { seirIndex } from "../infection-model/seir";
@@ -47,7 +48,7 @@ export function getCurveChartData(facilitiesInputs: CurveFunctionInputs[]) {
     };
   const facilitiesProjectionData = calculateCurveData(facilitiesInputs);
   const combinedData: ndarray = combineFacilitiesProjectionData(
-    facilitiesProjectionData,
+    facilitiesProjectionData.filter(isCurveData),
   );
   return {
     exposed: getAllValues(getColView(combinedData, seirIndex.exposed)),

--- a/src/rt-timeseries/RtTimeseries.tsx
+++ b/src/rt-timeseries/RtTimeseries.tsx
@@ -1,5 +1,6 @@
 import { scaleTime, timeFormat } from "d3";
 import hexAlpha from "hex-alpha";
+import numeral from "numeral";
 // no type defs for Semiotic
 const ResponsiveXYFrame = require("semiotic/lib/ResponsiveXYFrame") as any;
 import React from "react";
@@ -68,7 +69,7 @@ const Tooltip: React.FC<{
   return (
     <ChartTooltip>
       <TooltipContents>
-        <TooltipValue>{value}</TooltipValue>
+        <TooltipValue>{numeral(value).format("0.0")}</TooltipValue>
         <TooltipLabel>
           {title} {formatDate(date)}
         </TooltipLabel>

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -5,7 +5,7 @@ import { RtData } from "../infection-model/rt";
 import RtTimeseries from "./RtTimeseries";
 
 interface Props {
-  data?: RtData;
+  data?: RtData | null;
 }
 
 const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {


### PR DESCRIPTION
## Description of the change

When enabled by feature flag, this uses the latest fetched R(t) value as the "rate of spread" input to the projection model. (When not enabled, there should be no change in functionality.)

A few things had to happen to enable this:

- I ran into trouble with the new curve function hooks I just wrote, because I forgot you can't use hooks conditionally (they have to run in the same order on every render), so now there is just one hook for getting the curve that takes optional Rt input, and decides what data transformations to apply based on that.
- Based on advice from @justkunz I also lifted more logic related to the qualitiative R0 user input out of the curve function and into the related data transformation, to make sure it was not erroneously applied to Rt input.
- All the projection visualizations need to be in a loading state while they are waiting for Rt data. The most straighforward way to accomplish this seemed to be to let the curve data be `undefined` while it's waiting for inputs, and let that `undefined` flow all the way through the data pipeline to be handled by the chart and table components (they already mostly handled it, I just had to clean up the legend toggle logic a bit). 
- Because of that change, I had to add a type guard on top of @daschi 's recently merged changes to filter these undefined values out of the Excalibur chart data pipeline.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #62 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
