### PR TITLE
Tweak Spacer component, then use it

### DIFF
--- a/src/design-system/Spacer.tsx
+++ b/src/design-system/Spacer.tsx
@@ -6,6 +6,6 @@ interface Props {
 }
 
 export const Spacer = styled.div<Props>`
-  width: ${(props) => (props.x == null ? 0 : props.x)};
-  height: ${(props) => (props.y == null ? 0 : props.y)};
+  width: ${(props) => (props.x == null ? 0 : props.x + "rem")};
+  height: ${(props) => (props.y == null ? 0 : props.y + "rem")};
 `;

--- a/src/design-system/Spacer.tsx
+++ b/src/design-system/Spacer.tsx
@@ -6,6 +6,6 @@ interface Props {
 }
 
 export const Spacer = styled.div<Props>`
-  width: ${(props) => (props.x == null ? 0 : props.x + "rem")};
-  height: ${(props) => (props.y == null ? 0 : props.y + "rem")};
+  width: ${(props) => (props.x == null ? 0 : props.x + "px")};
+  height: ${(props) => (props.y == null ? 0 : props.y + "px")};
 `;

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -139,14 +139,14 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           setName={setFacilityName}
           placeholderValue="Unnamed Facility"
         />
-        <Spacer y={1.25} />
+        <Spacer y={20} />
         <DescRow>
           <InputDescription
             description={description}
             setDescription={setDescription}
             placeholderValue="Enter a description (optional)"
           />
-          <Spacer x={1.25} />
+          <Spacer x={20} />
           <PopUpMenu items={popupItems} />
         </DescRow>
         <div className="mt-5 mb-5 border-b border-gray-300" />

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -10,6 +10,7 @@ import InputNameWithIcon from "../design-system/InputNameWithIcon";
 import ModalDialog from "../design-system/ModalDialog";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import PopUpMenu from "../design-system/PopUpMenu";
+import { Spacer } from "../design-system/Spacer";
 import { Flag } from "../feature-flags";
 import FacilityInformation from "../impact-dashboard/FacilityInformation";
 import MitigationInformation from "../impact-dashboard/MitigationInformation";
@@ -138,14 +139,14 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           setName={setFacilityName}
           placeholderValue="Unnamed Facility"
         />
-        <div className="mt-5" />
+        <Spacer y={1.25} />
         <DescRow>
           <InputDescription
             description={description}
             setDescription={setDescription}
             placeholderValue="Enter a description (optional)"
           />
-          <div className="mr-5" />
+          <Spacer x={1.25} />
           <PopUpMenu items={popupItems} />
         </DescRow>
         <div className="mt-5 mb-5 border-b border-gray-300" />

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -100,7 +100,7 @@ const FacilityRow: React.FC<Props> = ({
             <div>
               Last Update: <DateMMMMdyyyy date={updatedAt} />
             </div>
-            <Spacer x={2} />
+            <Spacer x={32} />
           </div>
         </div>
         <div className="w-3/5">

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -6,6 +6,7 @@ import { saveFacility } from "../database/index";
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import InputDescription from "../design-system/InputDescription";
+import { Spacer } from "../design-system/Spacer";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import {
   totalConfirmedCases,
@@ -99,7 +100,7 @@ const FacilityRow: React.FC<Props> = ({
             <div>
               Last Update: <DateMMMMdyyyy date={updatedAt} />
             </div>
-            <div className="mr-8" />
+            <Spacer x={2} />
           </div>
         </div>
         <div className="w-3/5">

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -71,14 +71,14 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           placeholderValue={scenario?.name}
           persistChanges={handleScenarioChange}
         />
-        <Spacer y={1.25} />
+        <Spacer y={20} />
         <InputDescription
           description={description}
           setDescription={setDescription}
           placeholderValue={scenario?.description}
           persistChanges={handleScenarioChange}
         />
-        <Spacer y={1.25} />
+        <Spacer y={20} />
         <div>
           <p className="text-xs text-gray-500">
             Last Update:{" "}

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -5,6 +5,7 @@ import { saveScenario } from "../database";
 import InputDescription from "../design-system/InputDescription";
 import InputNameWithIcon from "../design-system/InputNameWithIcon";
 import PromoBoxWithButton from "../design-system/PromoBoxWithButton";
+import { Spacer } from "../design-system/Spacer";
 import useScenario from "../scenario-context/useScenario";
 import ToggleRow from "./ToggleRow";
 import { Scenario } from "./types";
@@ -70,14 +71,14 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           placeholderValue={scenario?.name}
           persistChanges={handleScenarioChange}
         />
-        <div className="mt-5" />
+        <Spacer y={1.25} />
         <InputDescription
           description={description}
           setDescription={setDescription}
           placeholderValue={scenario?.description}
           persistChanges={handleScenarioChange}
         />
-        <div className="mb-5" />
+        <Spacer y={1.25} />
         <div>
           <p className="text-xs text-gray-500">
             Last Update:{" "}


### PR DESCRIPTION
## Description of the change

* Fix Spacer component by adding rem suffix
  * Used rem based off of https://tailwindcss.com/docs/margin/
* Refactor to use Spacer instead of a blank div 
  * Based off changes made in #274

IS (no visual change):
![image](https://user-images.githubusercontent.com/1372946/80776727-e1619980-8b17-11ea-8311-598f767b774b.png)

## Type of change

N/A, refactor

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

N/A, should I make one? 

Follow-on to https://github.com/Recidiviz/covid19-dashboard/pull/274

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant