### PR TITLE
[Excalibur] response impact - reduction card data

### DIFF
--- a/src/impact-dashboard/ImpactProjectionTableContainer.tsx
+++ b/src/impact-dashboard/ImpactProjectionTableContainer.tsx
@@ -33,7 +33,7 @@ function buildTableRowFromCurves(
   };
 }
 
-function countEverHospitalizedForDay(data: ndarray, day: number) {
+export function countEverHospitalizedForDay(data: ndarray, day: number) {
   // includes people who are currently hospitalized or were previously
   const everHospitalized = [
     seirIndex.hospitalized,
@@ -51,11 +51,11 @@ function countCasesForDay(data: ndarray, day: number): number {
   return Math.round(sum(row.filter((d, i) => !notCases.includes(i))));
 }
 
-function getHospitalizedForDay(data: ndarray, day: number): number {
+export function getHospitalizedForDay(data: ndarray, day: number): number {
   return Math.round(data.get(day, seirIndex.hospitalized));
 }
 
-function getFatalitiesForDay(data: ndarray, day: number): number {
+export function getFatalitiesForDay(data: ndarray, day: number): number {
   return Math.round(data.get(day, seirIndex.fatalities));
 }
 

--- a/src/page-response-impact/PopulationImpactMetrics.tsx
+++ b/src/page-response-impact/PopulationImpactMetrics.tsx
@@ -6,6 +6,7 @@ import ambulanceIcon from "./icons/ic_ambulance.svg";
 import heartIcon from "./icons/ic_heart.svg";
 import ImpactMetricCard from "./ImpactMetricCard";
 import ImpactMetricsContainer from "./ImpactMetricsContainer";
+import { reductionCardDataType } from "./utils/ResponseImpactCardStateUtils";
 
 const TitleSpan = styled.span`
   color: ${Colors.teal};
@@ -19,35 +20,56 @@ const Title = ({ title }: { [title: string]: string }) => {
   );
 };
 
-const PopulationImpactMetrics: React.FC = () => {
-  // TODO: Replace with actual data
+interface Props {
+  reductionData: reductionCardDataType | undefined;
+  staffPopulation: number;
+  incarceratedPopulation: number;
+}
+
+function round(percent: number): number {
+  return Math.round(percent * 100);
+}
+
+const PopulationImpactMetrics: React.FC<Props> = ({
+  reductionData,
+  staffPopulation,
+  incarceratedPopulation,
+}) => {
+  if (!reductionData || !staffPopulation || !incarceratedPopulation) {
+    return null;
+  }
+  const { incarcerated, staff } = reductionData;
   return (
     <>
       <ImpactMetricsContainer>
         <ImpactMetricCard
           title={<Title title="Staff fatalities" />}
-          value={12}
-          subtitle="12% of staff"
+          value={staff.fatalities}
+          subtitle={`${round(staff.fatalities / staffPopulation)}% of staff`}
           icon={heartIcon}
         />
         <ImpactMetricCard
           title={<Title title="Incarcerated fatalities" />}
-          value={42}
-          subtitle="12% of incarcerated"
+          value={incarcerated.fatalities}
+          subtitle={`${round(
+            incarcerated.fatalities / incarceratedPopulation,
+          )}% of incarcerated`}
           icon={heartIcon}
         />
       </ImpactMetricsContainer>
       <ImpactMetricsContainer>
         <ImpactMetricCard
           title={<Title title="Staff hospitalization" />}
-          value={7}
-          subtitle="12% of staff"
+          value={staff.hospitalized}
+          subtitle={`${round(staff.hospitalized / staffPopulation)}% of staff`}
           icon={ambulanceIcon}
         />
         <ImpactMetricCard
           title={<Title title="Incarcerated hospitalization" />}
-          value={138}
-          subtitle="12% of incarcerated"
+          value={incarcerated.hospitalized}
+          subtitle={`${round(
+            incarcerated.hospitalized / incarceratedPopulation,
+          )}% of incarcerated`}
           icon={ambulanceIcon}
         />
       </ImpactMetricsContainer>

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -134,6 +134,9 @@ const ResponseImpactDashboard: React.FC = () => {
   const [releaseCardData, setReleaseCardData] = useState<
     releaseCardDataType | undefined
   >();
+  const [statePrisonPopulation, setStatePrisonPopulation] = useState<
+    number | undefined
+  >();
   const scenario = scenarioState.data;
   const [, setFacilities] = useState({
     data: [] as Facilities,
@@ -160,9 +163,22 @@ const ResponseImpactDashboard: React.FC = () => {
   useEffect(() => {
     const curveDataPerFacility = calculateCurveData(currentCurveInputs);
     const releaseCardObj = buildResponseImpactCardData(curveDataPerFacility);
-    console.log("releaseCardObj", releaseCardObj);
+
     setReleaseCardData(releaseCardObj);
   }, [currentCurveInputs]);
+
+  // calculate state prison population
+  useEffect(() => {
+    // get state total prison population
+    if (modelInputs.length) {
+      const state = modelInputs[0].stateCode;
+      const statePrisonPop: number | undefined = localeDataSource
+        .get(state)
+        ?.get("Total")?.totalPrisonPopulation;
+
+      setStatePrisonPopulation(statePrisonPop);
+    }
+  }, [modelInputs, localeDataSource]);
 
   useEffect(() => {
     fetchFacilities();

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -91,6 +91,12 @@ const CurveChartContainer = styled.div`
   margin-bottom: 50px;
 `;
 
+function getCurveInputs(modelInputs: EpidemicModelState[]) {
+  return modelInputs.map((modelInput) => {
+    return curveInputsFromUserInputs(modelInput);
+  });
+}
+
 function getModelInputs(facilities: Facilities, localeDataSource: LocaleData) {
   return facilities.map((facility) => {
     const modelInputs = facility.modelInputs;
@@ -102,12 +108,6 @@ function getModelInputs(facilities: Facilities, localeDataSource: LocaleData) {
         modelInputs.countyName,
       ),
     };
-  });
-}
-
-function getCurveInputs(modelInputs: EpidemicModelState[]) {
-  return modelInputs.map((modelInput) => {
-    return curveInputsFromUserInputs(modelInput);
   });
 }
 

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -120,6 +120,7 @@ function getModelInputs(facilities: Facilities, localeDataSource: LocaleData) {
 const ResponseImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const [scenarioState] = useScenario();
+  const scenarioId = scenarioState?.data?.id;
   const scenario = scenarioState.data;
   const [currentCurveInputs, setCurrentCurveInputs] = useState(
     [] as CurveFunctionInputs[],
@@ -159,7 +160,7 @@ const ResponseImpactDashboard: React.FC = () => {
 
   useEffect(() => {
     fetchFacilities();
-  }, [scenarioState?.data?.id]);
+  }, [scenarioId, fetchFacilities]);
 
   // calculate data for cards
   useEffect(() => {

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -121,6 +121,7 @@ const ResponseImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const [scenarioState] = useScenario();
   const scenario = scenarioState.data;
+  const scenarioId = scenarioState?.data?.id; // hooks wants this to be its own var
   const [currentCurveInputs, setCurrentCurveInputs] = useState(
     [] as CurveFunctionInputs[],
   );
@@ -157,9 +158,13 @@ const ResponseImpactDashboard: React.FC = () => {
     }
   }
 
-  useEffect(() => {
-    fetchFacilities();
-  }, [scenarioState?.data?.id]);
+  useEffect(
+    () => {
+      fetchFacilities();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [scenarioId],
+  );
 
   // calculate data for cards
   useEffect(() => {

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -121,7 +121,7 @@ const ResponseImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const [scenarioState] = useScenario();
   const scenario = scenarioState.data;
-  const scenarioId = scenarioState?.data?.id; // hooks wants this to be its own var
+  const scenarioId = scenarioState?.data?.id; // linter wants this to be its own var since it is a useEffect dep
   const [currentCurveInputs, setCurrentCurveInputs] = useState(
     [] as CurveFunctionInputs[],
   );
@@ -142,29 +142,25 @@ const ResponseImpactDashboard: React.FC = () => {
     loading: true,
   });
 
-  async function fetchFacilities() {
-    if (!scenarioState?.data?.id) return;
-    const facilitiesData = await getFacilities(scenarioState.data.id);
-    if (facilitiesData) {
-      setFacilities({
-        data: facilitiesData,
-        loading: false,
-      });
+  useEffect(() => {
+    async function fetchFacilities() {
+      if (!scenarioId) return;
+      const facilitiesData = await getFacilities(scenarioId);
+      if (facilitiesData) {
+        setFacilities({
+          data: facilitiesData,
+          loading: false,
+        });
 
-      const modelInputs = getModelInputs(facilitiesData, localeDataSource);
-      const currentCurveInputs = getCurveInputs(modelInputs);
-      setModelInputs(modelInputs);
-      setCurrentCurveInputs(currentCurveInputs);
+        const modelInputs = getModelInputs(facilitiesData, localeDataSource);
+        const currentCurveInputs = getCurveInputs(modelInputs);
+        setModelInputs(modelInputs);
+        setCurrentCurveInputs(currentCurveInputs);
+      }
     }
-  }
 
-  useEffect(
-    () => {
-      fetchFacilities();
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [scenarioId],
-  );
+    fetchFacilities();
+  }, [scenarioId, localeDataSource]);
 
   // calculate data for cards
   useEffect(() => {

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -29,7 +29,7 @@ import {
 import {
   buildReductionData,
   buildResponseImpactCardData,
-  releaseCardDataType,
+  reductionCardDataType,
 } from "./utils/ResponseImpactCardStateUtils";
 
 const ResponseImpactDashboardContainer = styled.div``;
@@ -133,8 +133,8 @@ const ResponseImpactDashboard: React.FC = () => {
     staffPopulation: 0,
     prisonPopulation: 0,
   });
-  const [releaseCardData, setReleaseCardData] = useState<
-    releaseCardDataType | undefined
+  const [reductionCardData, setreductionCardData] = useState<
+    reductionCardDataType | undefined
   >();
   const [, setFacilities] = useState({
     data: [] as Facilities,
@@ -173,7 +173,7 @@ const ResponseImpactDashboard: React.FC = () => {
     // positive value is a reduction
     const reduction = buildReductionData(origData, currData);
 
-    setReleaseCardData(reduction);
+    setreductionCardData(reduction);
   }, [originalCurveInputs, currentCurveInputs]);
 
   // calculate original and current curves
@@ -218,7 +218,11 @@ const ResponseImpactDashboard: React.FC = () => {
             <SectionSubheader>
               Positive impact of releasing [X] incarcerated individuals
             </SectionSubheader>
-            <PopulationImpactMetrics />
+            <PopulationImpactMetrics
+              reductionData={reductionCardData}
+              staffPopulation={systemWideData.staffPopulation}
+              incarceratedPopulation={systemWideData.prisonPopulation}
+            />
             <SectionHeader>Community Resources Saved</SectionHeader>
             <ChartHeader>Change in rate of transmission R(0)</ChartHeader>
             <PlaceholderSpace />

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -174,8 +174,6 @@ const ResponseImpactDashboard: React.FC = () => {
     });
   }, [modelInputs, localeDataSource]);
 
-  // NOTE: Replace with CurveChart with CurveChartContainer
-  // after it's modified to take curve data as prop
   return (
     <ResponseImpactDashboardContainer>
       {scenarioState.loading ? (

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -120,7 +120,6 @@ function getModelInputs(facilities: Facilities, localeDataSource: LocaleData) {
 const ResponseImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const [scenarioState] = useScenario();
-  const scenarioId = scenarioState?.data?.id;
   const scenario = scenarioState.data;
   const [currentCurveInputs, setCurrentCurveInputs] = useState(
     [] as CurveFunctionInputs[],
@@ -160,7 +159,7 @@ const ResponseImpactDashboard: React.FC = () => {
 
   useEffect(() => {
     fetchFacilities();
-  }, [scenarioId, fetchFacilities]);
+  }, [scenarioState?.data?.id]);
 
   // calculate data for cards
   useEffect(() => {

--- a/src/page-response-impact/responseChartData.tsx
+++ b/src/page-response-impact/responseChartData.tsx
@@ -65,7 +65,7 @@ export function getSystemWideSums(modelInputs: EpidemicModelState[]) {
   return sums;
 }
 
-function calculateCurveData(facilitiesInputs: CurveFunctionInputs[]) {
+export function calculateCurveData(facilitiesInputs: CurveFunctionInputs[]) {
   return facilitiesInputs.map((facilityInput) => {
     return calculateCurves(facilityInput);
   });

--- a/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
+++ b/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
@@ -1,0 +1,95 @@
+import {
+  countEverHospitalizedForDay,
+  getFatalitiesForDay,
+} from "../../impact-dashboard/ImpactProjectionTableContainer";
+import { CurveData } from "../../infection-model";
+
+export type releaseCardDataType = {
+  original: {
+    incarcerated: {
+      hospitalized: number;
+      fatalities: number;
+    };
+    staff: {
+      hospitalized: number;
+      fatalities: number;
+    };
+  };
+  current: {
+    incarcerated: {
+      hospitalized: number;
+      fatalities: number;
+    };
+    staff: {
+      hospitalized: number;
+      fatalities: number;
+    };
+  };
+};
+
+export function buildResponseImpactCardData(
+  curveDataArr: CurveData[],
+): releaseCardDataType {
+  // will need to loop over original scenario AND current scenario
+  let incarceratedHospitalizedSum = 0;
+  let incarceratedFatalitiesSum = 0;
+  let staffHospitalizedSum = 0;
+  let staffFatalitiesSum = 0;
+
+  curveDataArr.forEach((data) => {
+    const incarceratedData = data.incarcerated;
+    const staffData = data.staff;
+
+    const incarceratedHospitalized = countEverHospitalizedForDay(
+      incarceratedData,
+      incarceratedData.shape[0] - 1,
+    );
+    const incarceratedFatalities = getFatalitiesForDay(
+      incarceratedData,
+      incarceratedData.shape[0] - 1,
+    );
+    // console.log("incarceratedHospitalized", incarceratedHospitalized);
+    // console.log("incarceratedFatalities", incarceratedFatalities);
+    incarceratedHospitalizedSum += incarceratedHospitalized;
+    incarceratedFatalitiesSum += incarceratedFatalities;
+
+    const staffHospitalized = countEverHospitalizedForDay(
+      staffData,
+      staffData.shape[0] - 1,
+    );
+    const staffFatalities = getFatalitiesForDay(
+      staffData,
+      staffData.shape[0] - 1,
+    );
+    // console.log("staffHospitalized", staffHospitalized);
+    // console.log("staffFatalities", staffFatalities);
+    console.log("---");
+    staffHospitalizedSum += staffHospitalized;
+    staffFatalitiesSum += staffFatalities;
+  });
+
+  // after calculating Original scenario and Current scenario, populate data obj
+  const releaseCardObj: releaseCardDataType = {
+    original: {
+      incarcerated: {
+        hospitalized: 0,
+        fatalities: 0,
+      },
+      staff: {
+        hospitalized: 0,
+        fatalities: 0,
+      },
+    },
+    current: {
+      incarcerated: {
+        hospitalized: incarceratedHospitalizedSum,
+        fatalities: incarceratedFatalitiesSum,
+      },
+      staff: {
+        hospitalized: staffHospitalizedSum,
+        fatalities: staffFatalitiesSum,
+      },
+    },
+  };
+  return releaseCardObj;
+}

--- a/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
+++ b/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
@@ -5,32 +5,43 @@ import {
 import { CurveData } from "../../infection-model";
 
 export type releaseCardDataType = {
-  original: {
-    incarcerated: {
-      hospitalized: number;
-      fatalities: number;
-    };
-    staff: {
-      hospitalized: number;
-      fatalities: number;
-    };
+  incarcerated: {
+    hospitalized: number;
+    fatalities: number;
   };
-  current: {
-    incarcerated: {
-      hospitalized: number;
-      fatalities: number;
-    };
-    staff: {
-      hospitalized: number;
-      fatalities: number;
-    };
+  staff: {
+    hospitalized: number;
+    fatalities: number;
   };
 };
+
+export function buildReductionData(
+  origData: releaseCardDataType,
+  currData: releaseCardDataType,
+): releaseCardDataType {
+  // positive value is a reduction
+  return {
+    incarcerated: {
+      hospitalized:
+        -1 *
+        (currData.incarcerated.hospitalized -
+          origData.incarcerated.hospitalized),
+      fatalities:
+        -1 *
+        (currData.incarcerated.fatalities - origData.incarcerated.fatalities),
+    },
+    staff: {
+      hospitalized:
+        -1 * (currData.staff.hospitalized - origData.staff.hospitalized),
+      fatalities: -1 * (currData.staff.fatalities - origData.staff.fatalities),
+    },
+  };
+}
 
 export function buildResponseImpactCardData(
   curveDataArr: CurveData[],
 ): releaseCardDataType {
-  // will need to loop over original scenario AND current scenario
+  // for a given scenario, iterate over facilities and produce data for staff/inc. - hosp./fat.
   let incarceratedHospitalizedSum = 0;
   let incarceratedFatalitiesSum = 0;
   let staffHospitalizedSum = 0;
@@ -48,8 +59,6 @@ export function buildResponseImpactCardData(
       incarceratedData,
       incarceratedData.shape[0] - 1,
     );
-    // console.log("incarceratedHospitalized", incarceratedHospitalized);
-    // console.log("incarceratedFatalities", incarceratedFatalities);
     incarceratedHospitalizedSum += incarceratedHospitalized;
     incarceratedFatalitiesSum += incarceratedFatalities;
 
@@ -61,35 +70,19 @@ export function buildResponseImpactCardData(
       staffData,
       staffData.shape[0] - 1,
     );
-    // console.log("staffHospitalized", staffHospitalized);
-    // console.log("staffFatalities", staffFatalities);
-    // console.log("---");
     staffHospitalizedSum += staffHospitalized;
     staffFatalitiesSum += staffFatalities;
   });
 
-  // after calculating Original scenario and Current scenario, populate data obj
-  const releaseCardObj: releaseCardDataType = {
-    original: {
-      incarcerated: {
-        hospitalized: 0,
-        fatalities: 0,
-      },
-      staff: {
-        hospitalized: 0,
-        fatalities: 0,
-      },
+  const scenarioSum: releaseCardDataType = {
+    incarcerated: {
+      hospitalized: incarceratedHospitalizedSum,
+      fatalities: incarceratedFatalitiesSum,
     },
-    current: {
-      incarcerated: {
-        hospitalized: incarceratedHospitalizedSum,
-        fatalities: incarceratedFatalitiesSum,
-      },
-      staff: {
-        hospitalized: staffHospitalizedSum,
-        fatalities: staffFatalitiesSum,
-      },
+    staff: {
+      hospitalized: staffHospitalizedSum,
+      fatalities: staffFatalitiesSum,
     },
   };
-  return releaseCardObj;
+  return scenarioSum;
 }

--- a/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
+++ b/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
@@ -63,7 +63,7 @@ export function buildResponseImpactCardData(
     );
     // console.log("staffHospitalized", staffHospitalized);
     // console.log("staffFatalities", staffFatalities);
-    console.log("---");
+    // console.log("---");
     staffHospitalizedSum += staffHospitalized;
     staffFatalitiesSum += staffFatalities;
   });

--- a/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
+++ b/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
@@ -4,7 +4,7 @@ import {
 } from "../../impact-dashboard/ImpactProjectionTableContainer";
 import { CurveData } from "../../infection-model";
 
-export type releaseCardDataType = {
+export type reductionCardDataType = {
   incarcerated: {
     hospitalized: number;
     fatalities: number;
@@ -16,9 +16,9 @@ export type releaseCardDataType = {
 };
 
 export function buildReductionData(
-  origData: releaseCardDataType,
-  currData: releaseCardDataType,
-): releaseCardDataType {
+  origData: reductionCardDataType,
+  currData: reductionCardDataType,
+): reductionCardDataType {
   // positive value is a reduction
   return {
     incarcerated: {
@@ -40,7 +40,7 @@ export function buildReductionData(
 
 export function buildResponseImpactCardData(
   curveDataArr: CurveData[],
-): releaseCardDataType {
+): reductionCardDataType {
   // for a given scenario, iterate over facilities and produce data for staff/inc. - hosp./fat.
   let incarceratedHospitalizedSum = 0;
   let incarceratedFatalitiesSum = 0;
@@ -74,7 +74,7 @@ export function buildResponseImpactCardData(
     staffFatalitiesSum += staffFatalities;
   });
 
-  const scenarioSum: releaseCardDataType = {
+  const scenarioSum: reductionCardDataType = {
     incarcerated: {
       hospitalized: incarceratedHospitalizedSum,
       fatalities: incarceratedFatalitiesSum,


### PR DESCRIPTION
## Description of the change

1. Calculate hospitalizations and fatalities across all facilities for current scenario for both staff and incarcerated.
2. repeat for original scenario
3. pass data into cards

Most of the heavy lifting is in the `ResponseImpactCardStateUtils` file. `ResponseImpactDashboard` assembles and maintains the state for the data object. A couple other files I just needed to export some functions, and then the card container I needed to pass those props down and hook the data up.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #281 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
