### PR TITLE
Adding Support for Duplicating Scenarios

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -19,7 +19,7 @@ service cloud.firestore {
       allow read, write: if userCanAccess(resource);
 
       match /{documents=**} {
-        allow read, write: if userCanAccess(get(/databases/$(database)/documents/scenarios/$(scenario)));
+        allow read, write: if userCanAccess(getAfter(/databases/$(database)/documents/scenarios/$(scenario)));
       }
     }
   }

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -1,0 +1,3 @@
+// Date Format Constants
+export const MMMD = "MMM d";
+export const MMMMdyyyy = "MMMM d, yyyy";

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -258,14 +258,11 @@ export const saveScenario = async (scenario: any): Promise<Scenario | null> => {
 
 export const getFacilities = async (
   scenarioId: string,
-): Promise<Facility[]> => {
+): Promise<Array<Facility> | null> => {
   try {
     const scenario = await getScenario(scenarioId);
 
-    if (!scenario) {
-      console.error(`No scenario found for scenario: ${scenarioId}`);
-      return [];
-    }
+    if (!scenario) return null;
 
     const db = await getDb();
 
@@ -286,7 +283,7 @@ export const getFacilities = async (
 
     console.error(error);
 
-    return [];
+    return null;
   }
 };
 
@@ -524,7 +521,7 @@ export const duplicateScenario = async (
 
     // Duplicate and save all of the Facilities
     const facilities = await getFacilities(scenarioId);
-    for (const facility of facilities) {
+    for (const facility of facilities || []) {
       const facilityCopy = Object.assign({}, facility);
       delete facilityCopy.id;
       delete facilityCopy.scenarioId;
@@ -550,7 +547,6 @@ export const duplicateScenario = async (
 
     batch.commit();
   } catch (error) {
-    debugger;
     console.error(
       `Encountered error while attempting to duplicate scenario: ${scenarioId}`,
     );

--- a/src/design-system/DateFormats.tsx
+++ b/src/design-system/DateFormats.tsx
@@ -1,15 +1,17 @@
 import { format } from "date-fns";
 import React from "react";
 
+import { MMMD, MMMMdyyyy } from "../constants";
+
 interface Props {
   date: Date;
   children?: undefined;
 }
 
 export const DateMMMD: React.FC<Props> = (props) => {
-  return <>{format(props.date, "MMM d")}</>;
+  return <>{format(props.date, MMMD)}</>;
 };
 
 export const DateMMMMdyyyy: React.FC<Props> = (props) => {
-  return <>{format(props.date, "MMMM d, yyyy")}</>;
+  return <>{format(props.date, MMMMdyyyy)}</>;
 };


### PR DESCRIPTION
## Description of the change

Adding the persistence layer code to allow for duplicating scenarios

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #175 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

Upon duplication a scenario I confirmed that:
1.  A new scenario was created with the requested name and description copy ✅ 
2.  All existing facilities and their modelInput versions were copied over ✅ 

Additional Cases:

1.  Tested that copying a Scenario without any facilities worked ✅ 
2.  Throwing an exception within the batch performs a rollback on the commit ✅ 

Performance:

I "performance tested" this by duplicating a Scenario that had 10 facilities and each of those facilities had 8 versions of modelInputs.  The duplication ran in about 2-3 seconds.  I think this should be fine for most cases, but we'll need to keep an eye on this if we expect users to add a significantly higher number of facilities and to be creating a lot of new versions (i.e. entering new case information frequently).

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
