### PR TITLE
[Excalibur] Refactor ProjectionCharts into its own component

### DIFF
--- a/src/page-response-impact/ProjectionCharts.tsx
+++ b/src/page-response-impact/ProjectionCharts.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled from "styled-components";
+
+import Colors, { MarkColors } from "../design-system/Colors";
+import CurveChart from "../impact-dashboard/CurveChart";
+import { CurveFunctionInputs } from "../infection-model";
+import ProjectionsLegend from "../page-multi-facility/ProjectionsLegend";
+import { getCurveChartData, SystemWideData } from "./responseChartData";
+import { ChartHeader } from "./styles";
+
+const CurveChartContainer = styled.div`
+  margin-bottom: 50px;
+`;
+
+interface Props {
+  systemWideData: SystemWideData;
+  originalCurveInputs: CurveFunctionInputs[];
+  currentCurveInputs: CurveFunctionInputs[];
+}
+
+const ProjectionCharts: React.FC<Props> = ({
+  systemWideData,
+  originalCurveInputs,
+  currentCurveInputs,
+}) => {
+  return (
+    <>
+      <CurveChartContainer>
+        <ChartHeader>
+          Original Projection
+          <ProjectionsLegend />
+        </ChartHeader>
+        <CurveChart
+          chartHeight={250}
+          hideAxes={false}
+          hospitalBeds={systemWideData.hospitalBeds}
+          markColors={MarkColors}
+          curveData={getCurveChartData(originalCurveInputs)}
+        />
+      </CurveChartContainer>
+      <CurveChartContainer>
+        <ChartHeader color={Colors.teal}>
+          Current Projection
+          <ProjectionsLegend />
+        </ChartHeader>
+        <CurveChart
+          chartHeight={250}
+          hideAxes={false}
+          hospitalBeds={systemWideData.hospitalBeds}
+          markColors={MarkColors}
+          curveData={getCurveChartData(currentCurveInputs)}
+        />
+      </CurveChartContainer>
+    </>
+  );
+};
+
+export default ProjectionCharts;

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -1,115 +1,34 @@
 import React, { useEffect, useState } from "react";
-import styled from "styled-components";
 
 import { getFacilities } from "../database";
-import Colors, { MarkColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
 import { Column, PageContainer } from "../design-system/PageColumn";
-import CurveChart from "../impact-dashboard/CurveChart";
 import {
   EpidemicModelState,
   getLocaleDefaults,
 } from "../impact-dashboard/EpidemicModelContext";
-import {
-  CurveFunctionInputs,
-  curveInputsFromUserInputs,
-} from "../infection-model";
-import { LocaleData, useLocaleDataState } from "../locale-data-context";
-import ProjectionsLegend from "../page-multi-facility/ProjectionsLegend";
+import { CurveFunctionInputs } from "../infection-model";
+import { useLocaleDataState } from "../locale-data-context";
 import { Facilities } from "../page-multi-facility/types";
 import useScenario from "../scenario-context/useScenario";
 import PopulationImpactMetrics from "./PopulationImpactMetrics";
+import ProjectionCharts from "./ProjectionCharts";
 import ReducingR0ImpactMetrics from "./ReducingR0ImpactMetrics";
 import {
-  getCurveChartData,
+  getCurveInputs,
+  getModelInputs,
   getSystemWideSums,
   originalProjection,
 } from "./responseChartData";
-
-const ResponseImpactDashboardContainer = styled.div``;
-const ScenarioName = styled.div`
-  font-family: Poppins;
-  font-size: 10px;
-  font-weight: normal;
-  line-height: 150%;
-  letter-spacing: 0.15em;
-  text-transform: uppercase;
-  color: ${Colors.green};
-  padding: 10px 0;
-`;
-const PageHeader = styled.h1`
-  color: ${Colors.forest};
-  font-family: "Libre Baskerville";
-  font-weight: normal;
-  font-size: 24px;
-  line-height: 24px;
-  letter-spacing: -0.06em;
-  padding: 24px 0;
-`;
-const SectionHeader = styled.h1`
-  color: ${Colors.forest};
-  border-top: 1px solid ${Colors.opacityGray};
-  font-family: "Libre Baskerville";
-  font-weight: normal;
-  font-size: 19px;
-  line-height: 24px;
-  letter-spacing: -0.06em;
-  padding: 32px 0 24px;
-`;
-const PlaceholderSpace = styled.div`
-  border: 1px solid ${Colors.gray};
-  background-color: ${Colors.darkGray};
-  height: 200px;
-  margin: 20px 0;
-  width: 100%;
-`;
-const ChartHeader = styled.h3<{ color?: string }>`
-  border-top: 1px solid ${Colors.opacityGray};
-  border-bottom: 1px solid ${Colors.opacityGray};
-  color: ${(props) => props.color || Colors.opacityForest};
-  display: flex;
-  font-family: "Poppins";
-  font-style: normal;
-  font-weight: 600;
-  font-size: 9px;
-  justify-content: space-between;
-  line-height: 16px;
-  margin-bottom: 15px;
-  padding: 5px 0;
-`;
-const SectionSubheader = styled.h2`
-  color: ${Colors.darkForest};
-  font-family: "Poppins";
-  font-weight: normal;
-  font-size: 10px;
-  line-height: 150%;
-  letter-spacing: 0.15em;
-  padding: 32px 0 24px;
-  text-transform: uppercase;
-`;
-const CurveChartContainer = styled.div`
-  margin-bottom: 50px;
-`;
-
-function getModelInputs(facilities: Facilities, localeDataSource: LocaleData) {
-  return facilities.map((facility) => {
-    const modelInputs = facility.modelInputs;
-    return {
-      ...modelInputs,
-      ...getLocaleDefaults(
-        localeDataSource,
-        modelInputs.stateCode,
-        modelInputs.countyName,
-      ),
-    };
-  });
-}
-
-function getCurveInputs(modelInputs: EpidemicModelState[]) {
-  return modelInputs.map((modelInput) => {
-    return curveInputsFromUserInputs(modelInput);
-  });
-}
+import {
+  ChartHeader,
+  PageHeader,
+  PlaceholderSpace,
+  ResponseImpactDashboardContainer,
+  ScenarioName,
+  SectionHeader,
+  SectionSubheader,
+} from "./styles";
 
 const ResponseImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
@@ -174,8 +93,6 @@ const ResponseImpactDashboard: React.FC = () => {
     });
   }, [modelInputs, localeDataSource]);
 
-  // NOTE: Replace with CurveChart with CurveChartContainer
-  // after it's modified to take curve data as prop
   return (
     <ResponseImpactDashboardContainer>
       {scenarioState.loading ? (
@@ -204,32 +121,11 @@ const ResponseImpactDashboard: React.FC = () => {
             <ReducingR0ImpactMetrics />
           </Column>
           <Column>
-            <CurveChartContainer>
-              <ChartHeader>
-                Original Projection
-                <ProjectionsLegend />
-              </ChartHeader>
-              <CurveChart
-                chartHeight={144}
-                hideAxes={true}
-                hospitalBeds={systemWideData.hospitalBeds}
-                markColors={MarkColors}
-                curveData={getCurveChartData(originalCurveInputs)}
-              />
-            </CurveChartContainer>
-            <CurveChartContainer>
-              <ChartHeader color={Colors.teal}>
-                Current Projection
-                <ProjectionsLegend />
-              </ChartHeader>
-              <CurveChart
-                chartHeight={144}
-                hideAxes={true}
-                hospitalBeds={systemWideData.hospitalBeds}
-                markColors={MarkColors}
-                curveData={getCurveChartData(currentCurveInputs)}
-              />
-            </CurveChartContainer>
+            <ProjectionCharts
+              systemWideData={systemWideData}
+              originalCurveInputs={originalCurveInputs}
+              currentCurveInputs={currentCurveInputs}
+            />
           </Column>
         </PageContainer>
       )}

--- a/src/page-response-impact/responseChartData.tsx
+++ b/src/page-response-impact/responseChartData.tsx
@@ -1,24 +1,52 @@
 import { zip } from "d3-array";
 import ndarray from "ndarray";
 
-import { EpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
+import {
+  EpidemicModelState,
+  getLocaleDefaults,
+} from "../impact-dashboard/EpidemicModelContext";
 import { RateOfSpread } from "../impact-dashboard/EpidemicModelContext";
 import {
   calculateCurves,
   CurveData,
   CurveFunctionInputs,
+  curveInputsFromUserInputs,
 } from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
 import { seirIndex } from "../infection-model/seir";
+import { LocaleData } from "../locale-data-context";
 import { Facilities } from "../page-multi-facility/types";
 
 const NUM_DAYS = 90;
 const NUM_SEIR_CATEGORIES = 9;
 
-interface SystemWideData {
+export type SystemWideData = {
   staffPopulation: number;
   prisonPopulation: number;
   hospitalBeds: number;
+};
+
+export function getModelInputs(
+  facilities: Facilities,
+  localeDataSource: LocaleData,
+) {
+  return facilities.map((facility) => {
+    const modelInputs = facility.modelInputs;
+    return {
+      ...modelInputs,
+      ...getLocaleDefaults(
+        localeDataSource,
+        modelInputs.stateCode,
+        modelInputs.countyName,
+      ),
+    };
+  });
+}
+
+export function getCurveInputs(modelInputs: EpidemicModelState[]) {
+  return modelInputs.map((modelInput) => {
+    return curveInputsFromUserInputs(modelInput);
+  });
 }
 
 function originalEpidemicModelInputs(systemWideData: SystemWideData) {

--- a/src/page-response-impact/styles.tsx
+++ b/src/page-response-impact/styles.tsx
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+
+export const ResponseImpactDashboardContainer = styled.div``;
+
+export const ScenarioName = styled.div`
+  font-family: Poppins;
+  font-size: 10px;
+  font-weight: normal;
+  line-height: 150%;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: ${Colors.green};
+  padding: 10px 0;
+`;
+export const PageHeader = styled.h1`
+  color: ${Colors.forest};
+  font-family: "Libre Baskerville";
+  font-weight: normal;
+  font-size: 24px;
+  line-height: 24px;
+  letter-spacing: -0.06em;
+  padding: 24px 0;
+`;
+export const SectionHeader = styled.h1`
+  color: ${Colors.forest};
+  border-top: 1px solid ${Colors.opacityGray};
+  font-family: "Libre Baskerville";
+  font-weight: normal;
+  font-size: 19px;
+  line-height: 24px;
+  letter-spacing: -0.06em;
+  padding: 32px 0 24px;
+`;
+export const PlaceholderSpace = styled.div`
+  border: 1px solid ${Colors.gray};
+  background-color: ${Colors.darkGray};
+  height: 200px;
+  margin: 20px 0;
+  width: 100%;
+`;
+export const ChartHeader = styled.h3<{ color?: string }>`
+  border-top: 1px solid ${Colors.opacityGray};
+  border-bottom: 1px solid ${Colors.opacityGray};
+  color: ${(props) => props.color || Colors.opacityForest};
+  display: flex;
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 600;
+  font-size: 9px;
+  justify-content: space-between;
+  line-height: 16px;
+  margin-bottom: 15px;
+  padding: 5px 0;
+`;
+export const SectionSubheader = styled.h2`
+  color: ${Colors.darkForest};
+  font-family: "Poppins";
+  font-weight: normal;
+  font-size: 10px;
+  line-height: 150%;
+  letter-spacing: 0.15em;
+  padding: 32px 0 24px;
+  text-transform: uppercase;
+`;


### PR DESCRIPTION
While we wait for more information about the populations for current and original, this PR does some light refactoring for the dashboard component:
 
- Move charts to a ProjectionCharts component
- Move styled components to a styles.tsx file
- Move helper get functions to the responseChartData file

I'm not sure what type of change to select for a refactor/cleanup

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
