### PR TITLE
don't let initial exposed estimate exceed total population

### DIFF
--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -276,15 +276,19 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   // assign people to initial states
   zip(ageGroupPopulations, ageGroupInitiallyInfected).forEach(
     ([pop, cases], index) => {
-      const exposed = cases * ratioExposedToInfected;
-      singleDayState.set(index, seirIndex.exposed, exposed);
-      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
       // distribute cases across compartments proportionally
-      singleDayState.set(
-        index,
-        seirIndex.infectious,
-        cases * pInitiallyInfectious,
+
+      const infectious = cases * pInitiallyInfectious;
+      // exposed is related to the number of infectious
+      // but it can't be more than the total uninfected population
+      const exposed = Math.min(
+        infectious * ratioExposedToInfected,
+        pop - cases,
       );
+
+      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+      singleDayState.set(index, seirIndex.exposed, exposed);
+      singleDayState.set(index, seirIndex.infectious, infectious);
       singleDayState.set(index, seirIndex.mild, cases * pInitiallyMild);
       singleDayState.set(index, seirIndex.severe, cases * pInitiallySevere);
       singleDayState.set(


### PR DESCRIPTION
## Description of the change

We were extrapolating the number of initially exposed people from the number of initial cases, but failed to clamp the maximum value at the total population size, which could lead to negative values in the "susceptible" curve. This fixes that! Really it just ports over the fix from Python, where @justkunz had already implemented it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #272 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
