### PR TITLE
[nit] Add vertical padding for the loading indicator when loading

### DIFF
--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -26,7 +26,9 @@ const MultiFacilityPage: React.FC = () => {
               page.
             </div>
           ) : localeState.loading || scenario.loading ? (
-            <Loading />
+            <div className="mt-16">
+              <Loading />
+            </div>
           ) : scenario.data ? (
             <MultiFacilityImpactDashboard />
           ) : (


### PR DESCRIPTION
<img width="1325" alt="Screen Shot 2020-05-02 at 2 48 01 PM" src="https://user-images.githubusercontent.com/1332366/80873318-a2e9ed00-8c85-11ea-92dc-0b8661329f5b.png">

Add vertical padding for the loading indicator when loading on MultiFacilityPage.

Currently this loading indicator is attached to the header border and looks broken.

## Description of the change

> Description here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

None

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
