### PR TITLE
Add validation for Scenario name & description and Facility name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,9 @@
     // `any`s are also easy to check for after the fact with a search.
     "@typescript-eslint/no-explicit-any": "off",
 
+    // Allow unused variables that start with "_"
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+
     // Ensure default exports have the same name as the file.
     "filenames/match-exported": "error",
 

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -67,6 +67,10 @@ const InputDescription: React.FC<Props> = ({
 
   const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
     if (event.key !== "Enter") return;
+    else if (event.key === "Enter" && requiredFlag && !value?.trim()) {
+      event.preventDefault();
+      return;
+    }
     onEnter();
   };
 

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -9,6 +9,7 @@ const inputTextAreaStyle = {
   fontFamily: "Helvetica Neue",
   fontSize: "13px",
   color: Colors.forest,
+  outline: "none"
 };
 
 const DescriptionDiv = styled.div`
@@ -60,6 +61,10 @@ const InputDescription: React.FC<Props> = ({
 }) => {
   const [editingDescription, setEditingDescription] = useState(false);
   const [value, setValue] = useState(description);
+
+  // Reset Description field border
+  if (!editingDescription) inputTextAreaStyle.outline = "none";
+
   const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
     if (event.key !== "Enter") return;
     onEnter();
@@ -78,6 +83,12 @@ const InputDescription: React.FC<Props> = ({
       if (persistChanges) {
         persistChanges({ description: '' });
       }
+    }
+
+    if (requiredFlag && !value?.trim()) {
+      inputTextAreaStyle.outline = `1px solid ${ Colors.red }`;
+    } else {
+      inputTextAreaStyle.outline = "none";
     }
   };
 

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -43,6 +43,9 @@ interface Props {
   description?: string | undefined;
   setDescription: (description?: string) => void;
   placeholderValue?: string | undefined;
+  placeholderText?: string | undefined;
+  maxLengthValue?: number | undefined;
+  requiredFlag?: boolean;
   persistChanges?: (changes: { description: string | undefined }) => void;
 }
 
@@ -50,7 +53,10 @@ const InputDescription: React.FC<Props> = ({
   description,
   setDescription,
   placeholderValue,
-  persistChanges,
+  placeholderText,
+  maxLengthValue,
+  requiredFlag,
+  persistChanges
 }) => {
   const [editingDescription, setEditingDescription] = useState(false);
   const [value, setValue] = useState(description);
@@ -60,16 +66,24 @@ const InputDescription: React.FC<Props> = ({
   };
 
   const updateDescription = () => {
-    setEditingDescription(false);
-    setDescription(value);
-    if (persistChanges) {
-      persistChanges({ description: value });
+    if (requiredFlag && value?.trim() || !requiredFlag) {
+      setEditingDescription(false);
+      setDescription(value);
+      if (persistChanges) {
+        persistChanges({ description: value });
+      }
+    } else {
+      setEditingDescription(true);
+      setDescription('');
+      if (persistChanges) {
+        persistChanges({ description: '' });
+      }
     }
   };
 
   return (
     <DescriptionDiv>
-      {!editingDescription ? (
+      {!editingDescription && ((requiredFlag && value) || !requiredFlag) ? (
         <Description onClick={() => setEditingDescription(true)}>
           <span>{value || placeholderValue}</span>
         </Description>
@@ -80,7 +94,9 @@ const InputDescription: React.FC<Props> = ({
             style={inputTextAreaStyle}
             autoResizeVertically
             value={value}
-            placeholder={""}
+            placeholder={placeholderText || ""}
+            maxLength={maxLengthValue}
+            required={requiredFlag}
             onBlur={updateDescription}
             onChange={(event) => setValue(event.target.value)}
             onKeyDown={(event) => {

--- a/src/design-system/InputNameWithIcon.tsx
+++ b/src/design-system/InputNameWithIcon.tsx
@@ -52,6 +52,9 @@ interface Props {
   name?: string | undefined;
   setName: (name?: string) => void;
   placeholderValue?: string | undefined;
+  placeholderText?: string | undefined;
+  maxLengthValue?: number | undefined;
+  requiredFlag?: boolean;
   persistChanges?: (changes: object) => void;
 }
 
@@ -59,7 +62,10 @@ const InputNameWithIcon: React.FC<Props> = ({
   name,
   setName,
   placeholderValue,
-  persistChanges,
+  placeholderText,
+  maxLengthValue,
+  requiredFlag,
+  persistChanges
 }) => {
   const [editingName, setEditingName] = useState(false);
   const [value, setValue] = useState(name);
@@ -69,16 +75,24 @@ const InputNameWithIcon: React.FC<Props> = ({
   };
 
   const updateName = () => {
-    setEditingName(false);
-    setName(value);
-    if (persistChanges) {
-      persistChanges({ name: value });
+    if (requiredFlag && value?.trim() || !requiredFlag) {
+      setEditingName(false);
+      setName(value);
+      if (persistChanges) {
+        persistChanges({ name: value });
+      }
+    } else {
+      setEditingName(true);
+      setName('');
+      if (persistChanges) {
+        persistChanges({ name: '' });
+      }
     }
   };
 
   return (
     <NameLabelDiv>
-      {!editingName ? (
+      {!editingName && ((requiredFlag && name) || !requiredFlag) ? (
         <Heading onClick={() => setEditingName(true)}>
           <IconFolder alt="folder" src={iconFolderSrc} />
           <span>{value || placeholderValue}</span>
@@ -92,6 +106,9 @@ const InputNameWithIcon: React.FC<Props> = ({
           onValueChange={(value) => setValue(value)}
           onBlur={() => updateName()}
           onKeyDown={(event) => onEnterPress(event, updateName)}
+          maxLength={maxLengthValue}
+          placeholder={placeholderText || ""}
+          required={requiredFlag}
         />
       )}
       <IconEdit alt="Name" src={iconEditSrc} />

--- a/src/design-system/InputNameWithIcon.tsx
+++ b/src/design-system/InputNameWithIcon.tsx
@@ -6,6 +6,10 @@ import iconEditSrc from "./icons/ic_edit.svg";
 import iconFolderSrc from "./icons/ic_folder.svg";
 import InputText from "./InputText";
 
+const requiredInputStyle = {
+  outline: "none"
+};
+
 const borderStyle = `1px solid ${Colors.paleGreen}`;
 
 const NameLabelDiv = styled.label`
@@ -69,6 +73,10 @@ const InputNameWithIcon: React.FC<Props> = ({
 }) => {
   const [editingName, setEditingName] = useState(false);
   const [value, setValue] = useState(name);
+
+  // Reset Name field border
+  if (!editingName) requiredInputStyle.outline = "none";
+
   const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
     if (event.key !== "Enter") return;
     onEnter();
@@ -87,6 +95,12 @@ const InputNameWithIcon: React.FC<Props> = ({
       if (persistChanges) {
         persistChanges({ name: '' });
       }
+    }
+
+    if (requiredFlag && !value?.trim()) {
+      requiredInputStyle.outline = `1px solid ${ Colors.red }`;
+    } else {
+      requiredInputStyle.outline = "none";
     }
   };
 
@@ -109,6 +123,7 @@ const InputNameWithIcon: React.FC<Props> = ({
           maxLength={maxLengthValue}
           placeholder={placeholderText || ""}
           required={requiredFlag}
+          style={requiredInputStyle}
         />
       )}
       <IconEdit alt="Name" src={iconEditSrc} />

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -26,6 +26,20 @@ const WrappedInput = styled(StyledInput)`
   */
   width: 0;
   color: ${Colors.green};
+  
+  // make placeholder font size smaller than the input's
+  &::-webkit-input-placeholder {
+    font-size: 18px;
+  }
+  &::-moz-placeholder {
+    font-size: 18px;
+  }
+  &:-ms-input-placeholder {
+    font-size: 18px;
+  }
+  &:-moz-placeholder {
+    font-size: 18px;
+  }
 `;
 
 interface Props extends InputBaseProps<string> {
@@ -34,6 +48,9 @@ interface Props extends InputBaseProps<string> {
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   focus?: boolean;
+  maxLength?: number;
+  placeholder?: string;
+  required?: boolean;
 }
 
 const InputText: React.FC<Props> = (props) => {
@@ -56,7 +73,9 @@ const InputText: React.FC<Props> = (props) => {
           ref={nameInput}
           value={inputValue ?? ""}
           headerStyle={!!props.headerStyle}
-          placeholder={props.valuePlaceholder ?? props.labelPlaceholder}
+          placeholder={props.placeholder ?? props.labelPlaceholder}
+          maxLength={props.maxLength}
+          required={props.required}
           onChange={(e) => props.onValueChange(e.target.value)}
           onBlur={props.onBlur}
           onKeyDown={props.onKeyDown}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -51,6 +51,7 @@ interface Props extends InputBaseProps<string> {
   maxLength?: number;
   placeholder?: string;
   required?: boolean;
+  style?: object;
 }
 
 const InputText: React.FC<Props> = (props) => {
@@ -67,7 +68,7 @@ const InputText: React.FC<Props> = (props) => {
   return (
     <TextInputContainer>
       <InputLabelAndHelp label={props.labelAbove} labelHelp={props.labelHelp} />
-      <InputWrapper as="div">
+      <InputWrapper as="div" style={props.style}>
         <WrappedInput
           type={props.type}
           ref={nameInput}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -29,16 +29,16 @@ const WrappedInput = styled(StyledInput)`
   
   // make placeholder font size smaller than the input's
   &::-webkit-input-placeholder {
-    font-size: 18px;
+    ${props => props.headerStyle ? "font-size: 18px" : ""}
   }
   &::-moz-placeholder {
-    font-size: 18px;
+    ${props => props.headerStyle ? "font-size: 18px" : ""}
   }
   &:-ms-input-placeholder {
-    font-size: 18px;
+    ${props => props.headerStyle ? "font-size: 18px" : ""}
   }
   &:-moz-placeholder {
-    font-size: 18px;
+    ${props => props.headerStyle ? "font-size: 18px" : ""}
   }
 `;
 
@@ -56,7 +56,7 @@ interface Props extends InputBaseProps<string> {
 
 const InputText: React.FC<Props> = (props) => {
   let inputValue = useInputValue(props);
-
+  const placeholder = props.valuePlaceholder ?? props.labelPlaceholder;
   const nameInput = useRef() as React.MutableRefObject<HTMLInputElement>;
 
   useEffect(() => {
@@ -74,7 +74,7 @@ const InputText: React.FC<Props> = (props) => {
           ref={nameInput}
           value={inputValue ?? ""}
           headerStyle={!!props.headerStyle}
-          placeholder={props.placeholder ?? props.labelPlaceholder}
+          placeholder={props.placeholder ?? placeholder}
           maxLength={props.maxLength}
           required={props.required}
           onChange={(e) => props.onValueChange(e.target.value)}

--- a/src/design-system/InputTextArea.tsx
+++ b/src/design-system/InputTextArea.tsx
@@ -15,6 +15,8 @@ interface Props {
   inline?: boolean;
   fillVertical?: boolean;
   style?: object;
+  maxLength?: number;
+  required?: boolean;
 }
 
 interface InputProps {
@@ -50,6 +52,20 @@ const TextAreaInput = styled.textarea<InputProps>`
     css`
       height: 100%;
     `};
+
+  // make placeholder font size smaller than the textarea's
+  &::-webkit-input-placeholder {
+    font-size: 18px;
+  }
+  &::-moz-placeholder {
+    font-size: 18px;
+  }
+  &:-ms-input-placeholder {
+    font-size: 18px;
+  }
+  &:-moz-placeholder {
+    font-size: 18px;
+  }
 `;
 
 interface TextAreaContainer {
@@ -95,6 +111,8 @@ const InputTextArea: React.FC<Props> = (props) => {
         onBlur={props.onBlur}
         value={props.value}
         placeholder={props.placeholder}
+        maxLength={props.maxLength}
+        required={props.required}
         name={props.label}
         onKeyDown={props.onKeyDown}
         {...props.style}

--- a/src/design-system/InputTextArea.tsx
+++ b/src/design-system/InputTextArea.tsx
@@ -25,12 +25,13 @@ interface InputProps {
   fontFamily?: string;
   fontSize?: string;
   color?: string;
+  outline?: string;
 }
 
 const TextAreaInput = styled.textarea<InputProps>`
   margin-top: 8px;
   border: none;
-  outline: none;
+  outline: ${(props) => props.outline || "none"};
   padding: 16px;
   background: #e0e4e4;
   border-radius: 2px;

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -100,15 +100,19 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   const model = useModel();
 
   const save = () => {
-    saveFacility(scenarioId, {
-      id: facility?.id,
-      name: facilityName || null,
-      description: description || null,
-      systemType: systemType || null,
-      modelInputs: model[0],
-    }).then(() => {
-      navigate("/");
-    });
+    if (facilityName) {
+      saveFacility(scenarioId, {
+        id: facility?.id,
+        name: facilityName || null,
+        description: description || null,
+        systemType: systemType || null,
+        modelInputs: model[0],
+      }).then(() => {
+        navigate("/");
+      });
+    } else {
+      window.scroll({ top: 0, left: 0, behavior: 'smooth' });
+    }
   };
 
   // delete modal stuff
@@ -144,6 +148,9 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           name={facilityName}
           setName={setFacilityName}
           placeholderValue="Unnamed Facility"
+          placeholderText="Facility name is required"
+          maxLengthValue={124}
+          requiredFlag={true}
         />
         <Spacer y={20} />
         <DescRow>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -191,6 +191,9 @@ const FacilityRow: React.FC<Props> = ({
                     });
                   }}
                   placeholderValue="Unnamed Facility"
+                  placeholderText="Facility name is required"
+                  maxLengthValue={124}
+                  requiredFlag={true}
                 />
               </FacilityNameLabel>
             </div>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -181,14 +181,16 @@ const FacilityRow: React.FC<Props> = ({
                 <InputDescription
                   description={name}
                   setDescription={(name) => {
-                    const newName = (name || "").replace(/(\r\n|\n|\r)/gm, "");
-                    // this updates the local state
-                    updateFacility({ ...facility, name: newName });
-                    // this persists the changes to the database
-                    saveFacility(scenarioId, {
-                      id,
-                      name: newName,
-                    });
+                    if (name) {
+                      const newName = (name || "").replace(/(\r\n|\n|\r)/gm, "");
+                      // this updates the local state
+                      updateFacility({ ...facility, name: newName });
+                      // this persists the changes to the database
+                      saveFacility(scenarioId, {
+                        id,
+                        name: newName,
+                      });
+                    }
                   }}
                   placeholderValue="Unnamed Facility"
                   placeholderText="Facility name is required"

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -51,11 +51,13 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const { numFacilities } = props;
   const updatedAtDate = Number(scenario?.updatedAt);
 
-  const handleScenarioChange = (scenarioChange: object) => {
-    const changes = Object.assign({}, scenario, scenarioChange);
-    saveScenario(changes).then((_) => {
-      dispatchScenarioUpdate(changes);
-    });
+  const handleScenarioChange = (scenarioChange: any) => {
+    if (scenarioChange.name || scenarioChange.description) {
+      const changes = Object.assign({}, scenario, scenarioChange);
+      saveScenario(changes).then((_) => {
+        dispatchScenarioUpdate(changes);
+      });
+    }
   };
   const [name, setName] = useState(scenario?.name);
   const [promoDismissed, setPromoDismissed] = useState(false);
@@ -69,6 +71,9 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           name={name}
           setName={setName}
           placeholderValue={scenario?.name}
+          placeholderText="Scenario name is required"
+          maxLengthValue={124}
+          requiredFlag={true}
           persistChanges={handleScenarioChange}
         />
         <Spacer y={20} />
@@ -76,6 +81,9 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           description={description}
           setDescription={setDescription}
           placeholderValue={scenario?.description}
+          placeholderText="Scenario description is required"
+          maxLengthValue={500}
+          requiredFlag={true}
           persistChanges={handleScenarioChange}
         />
         <Spacer y={20} />

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -54,6 +54,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const handleScenarioChange = (scenarioChange: any) => {
     if (scenarioChange.name || scenarioChange.description) {
       const changes = Object.assign({}, scenario, scenarioChange);
+      /*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
       saveScenario(changes).then((_) => {
         dispatchScenarioUpdate(changes);
       });

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -54,7 +54,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const handleScenarioChange = (scenarioChange: any) => {
     if (scenarioChange.name || scenarioChange.description) {
       const changes = Object.assign({}, scenario, scenarioChange);
-      /*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
+
       saveScenario(changes).then((_) => {
         dispatchScenarioUpdate(changes);
       });


### PR DESCRIPTION
## Description of the change

Add validation for Scenario name & description and Facility name
- Scenario name & description: keep showing the input field if empty
- Facility name:
   - Set focus on the input field on page load
   - Keep showing the input field on blur/mouse out
   - If facility name is empty, Scroll top on "Save" clicked

Before:
![Before](https://user-images.githubusercontent.com/1066069/80945372-87bfd000-8da0-11ea-967b-328be4f8201f.png)

After:
![After](https://user-images.githubusercontent.com/1066069/80945377-8d1d1a80-8da0-11ea-9549-43a1512be026.png)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #197

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
