### PR TITLE
Add promo message for Rt

### DIFF
--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -69,5 +69,15 @@ export const buildScenario = (
   scenario.createdAt = timestampToDate(documentData.createdAt);
   scenario.updatedAt = timestampToDate(documentData.updatedAt);
 
+  // Runtime migration: make sure a default value is set for
+  // promo status flags added since the last data shakeup
+  // TODO: Remove this once automated migration is in place per #186
+  const newPromoStatuses = ["rtChart"];
+  newPromoStatuses.forEach((flagName) => {
+    if (scenario.promoStatuses[flagName] === undefined) {
+      scenario.promoStatuses[flagName] = true;
+    }
+  });
+
   return scenario;
 };

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -22,7 +22,9 @@ export function getEnabledPromoType(
 
   const { dailyReports, dataSharing, promoStatuses } = scenario;
 
-  return !dailyReports && promoStatuses?.dailyReports
+  return promoStatuses.rtChart
+    ? "rtChart"
+    : !dailyReports && promoStatuses?.dailyReports
     ? "dailyReports"
     : !dataSharing && promoStatuses?.dataSharing
     ? "dataSharing"
@@ -38,6 +40,11 @@ const promoTexts: { [promoType: string]: string } = {
     "Turn on 'Data Sharing' to provide your baseline data to public researchers, to help improve models of disease spread in prisons in the future.",
   addFacilities:
     "Add additional facilities to see the impact across your entire system.",
+  rtChart: `New! View the chart of Rt (the rate of spread over time) for any
+    facility by selecting it. This is based on the number of cases over time
+    for that facility. To get an accurate Rt, enter case counts for previous
+    days by clicking the number of cases on the right (in red) to update case
+    numbers.)`,
 };
 
 export function getPromoText(promoType: string | null) {

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -24,7 +24,7 @@ export type Scenario = {
   baseline: boolean;
   dataSharing: boolean;
   dailyReports: boolean;
-  promoStatuses?: PromoStatuses | undefined;
+  promoStatuses: PromoStatuses;
   description: string;
   roles: object;
   createdAt: Date;


### PR DESCRIPTION
## Description of the change

Adds a new scenario promo to highlight new Rt charts and puts it at the top of the priority queue. Requires a runtime migration/monkeypatch for users who have not yet saved the new flag to their database.

![Screen Shot 2020-05-04 at 2 06 24 PM](https://user-images.githubusercontent.com/5385319/81014403-a3af8a00-8e11-11ea-8e27-87e70a20a057.png)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #303 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
