### PR TITLE
"Add cases" button on the Facility page

### DIFF
--- a/src/design-system/Modal.tsx
+++ b/src/design-system/Modal.tsx
@@ -1,39 +1,33 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
-import Colors from "./Colors";
 import ModalDialog from "./ModalDialog";
 import { TitleProps } from "./ModalTitle";
 
 const ModalContainer = styled.div``;
 
-const ModalTrigger = styled.button`
-  color: ${Colors.green};
-  cursor: pointer;
-  font-family: "Libre Baskerville", serif;
-  font-size: 32px;
-  line-height: 32px;
-  letter-spacing: -0.03em;
-`;
-
-interface Props {
+export interface Props {
   modalTitle?: TitleProps["title"];
+  onClose?: () => void;
+  open: boolean;
+  setOpen: (open: boolean) => void;
   trigger?: string | React.ReactElement<any>;
-  children?: any;
 }
 
 const Modal: React.FC<Props> = (props) => {
-  const [open, setOpen] = useState(false);
-  const { trigger, modalTitle, children } = props;
+  const { trigger, modalTitle, children, open, setOpen } = props;
+
+  const closeModal = () => {
+    if (props.onClose) {
+      props.onClose();
+    }
+    setOpen(false);
+  };
 
   return (
     <ModalContainer>
-      <ModalTrigger onClick={() => setOpen(true)}>{trigger}</ModalTrigger>
-      <ModalDialog
-        title={modalTitle}
-        open={open}
-        closeModal={() => setOpen(false)}
-      >
+      <div onClick={() => setOpen(true)}> {trigger}</div>
+      <ModalDialog title={modalTitle} open={open} closeModal={closeModal}>
         {children}
       </ModalDialog>
     </ModalContainer>

--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -34,7 +34,6 @@ interface Props {
   title?: TitleProps["title"];
   open?: boolean;
   closeModal?: (e: React.MouseEvent<HTMLElement>) => void | null;
-  children?: React.ReactElement<any>;
 }
 
 const isOutsideModal = (

--- a/src/design-system/icons/ic_duplicate.svg
+++ b/src/design-system/icons/ic_duplicate.svg
@@ -1,0 +1,13 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M0.5 6.5V0.5H6.5V6.5H0.5Z"
+    stroke="#005450"
+    stroke-linecap="round"
+    stroke-linejoin="round" />
+  <mask id="path-3-inside-1" fill="white">
+    <path d="M8 3H10V10H3V8"/>
+  </mask>
+  <path d="M10 3H11C11 2.44772 10.5523 2 10 2V3ZM10 10V11C10.5523 11 11 10.5523 11 10H10ZM3 10H2C2 10.5523 2.44772 11 3 11V10ZM8 4H10V2H8V4ZM9 3V10H11V3H9ZM10 9H3V11H10V9ZM4 10V8H2V10H4Z"
+    fill="#005450"
+    mask="url(#path-3-inside-1)" />
+</svg>

--- a/src/page-multi-facility/AddCasesModal.tsx
+++ b/src/page-multi-facility/AddCasesModal.tsx
@@ -1,0 +1,125 @@
+import { startOfDay, startOfToday } from "date-fns";
+import { pick } from "lodash";
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { saveFacility } from "../database";
+import Colors from "../design-system/Colors";
+import InputButton from "../design-system/InputButton";
+import InputDate from "../design-system/InputDate";
+import Modal, { Props as ModalProps } from "../design-system/Modal";
+import {
+  EpidemicModelUpdate,
+  persistedKeys,
+} from "../impact-dashboard/EpidemicModelContext";
+import { AgeGroupGrid } from "../impact-dashboard/FacilityInformation";
+import useModel from "../impact-dashboard/useModel";
+import { Facility } from "./types";
+
+type Props = Pick<ModalProps, "trigger"> & {
+  facility: Facility;
+  updateFacility: Function;
+};
+
+const ModalContents = styled.div`
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  font-weight: normal;
+  justify-content: flex-start;
+  margin-top: 30px;
+`;
+
+const HorizRule = styled.div`
+  border-bottom: 0.5px solid ${Colors.darkGray};
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+  width: 100%;
+`;
+
+// Create a diff of the model to store changes in the update cases modal.
+// This is necessary so that we don't update the current modal if the modal is thrown away w/o saving or
+// if the date added in the modal is prior to the current date (backfill)
+const useModelDiff = (): [
+  EpidemicModelUpdate,
+  (update: EpidemicModelUpdate) => void,
+  () => void,
+] => {
+  const [diff, setDiff] = useState({});
+  const mergeDiff = (update: EpidemicModelUpdate) => {
+    setDiff({ ...diff, ...update });
+  };
+  const resetDiff = () => {
+    setDiff({});
+  };
+  return [diff, mergeDiff, resetDiff];
+};
+
+const AddCasesModal: React.FC<Props> = ({
+  facility,
+  trigger,
+  updateFacility,
+}) => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const [model, updateModel] = useModel();
+  let [modelDiff, fakeUpdateModel, resetModelDiff] = useModelDiff();
+  const newModel = { ...model, ...modelDiff };
+
+  const save = () => {
+    // Ensure that we don't insert keys (like `localeDataSource`) that is in model but not in the facility modelInputs
+    const modelInputs = {
+      ...facility.modelInputs,
+      ...pick(newModel, persistedKeys),
+    };
+    // Update the local state iff
+    // The observedAt date in the modal is more recent than the observedAt date in the current modelInputs.
+    // This needs to happen so that facility data will show the most updated data w/o requiring a hard reload.
+    if (
+      newModel.observedAt &&
+      model.observedAt &&
+      startOfDay(newModel.observedAt) >= startOfDay(model.observedAt)
+    ) {
+      updateFacility({ ...facility, modelInputs });
+      updateModel(modelDiff);
+    }
+    // Save to DB with model changes
+    saveFacility(facility.scenarioId, {
+      id: facility.id,
+      modelInputs,
+    });
+    setModalOpen(false);
+  };
+
+  return (
+    <Modal
+      modalTitle="Add Cases"
+      onClose={resetModelDiff}
+      open={modalOpen}
+      setOpen={setModalOpen}
+      trigger={trigger}
+    >
+      <ModalContents>
+        <InputDate
+          labelAbove={"Date observed"}
+          onValueChange={(date) => {
+            if (date) {
+              fakeUpdateModel({ observedAt: date });
+            }
+          }}
+          valueEntered={newModel.observedAt || startOfToday()}
+        />
+        <HorizRule />
+        <AgeGroupGrid
+          model={newModel}
+          updateModel={fakeUpdateModel}
+          collapsible={true}
+        />
+        <HorizRule />
+        <InputButton label="Save" onClick={save} />
+      </ModalContents>
+    </Modal>
+  );
+};
+
+export default AddCasesModal;

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { deleteFacility, saveFacility } from "../database/index";
 import Colors from "../design-system/Colors";
+import iconDuplicatePath from "../design-system/icons/ic_duplicate.svg";
 import InputButton, { StyledButton } from "../design-system/InputButton";
 import InputDescription from "../design-system/InputDescription";
 import InputNameWithIcon from "../design-system/InputNameWithIcon";
@@ -11,11 +12,13 @@ import ModalDialog from "../design-system/ModalDialog";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import PopUpMenu from "../design-system/PopUpMenu";
 import { Spacer } from "../design-system/Spacer";
+import Tooltip from "../design-system/Tooltip";
 import { Flag } from "../feature-flags";
 import FacilityInformation from "../impact-dashboard/FacilityInformation";
 import MitigationInformation from "../impact-dashboard/MitigationInformation";
 import useModel from "../impact-dashboard/useModel";
 import RtTimeseries from "../rt-timeseries";
+import AddCasesModal from "./AddCasesModal";
 import { FacilityContext } from "./FacilityContext";
 import FacilityProjections from "./FacilityProjections";
 import LocaleInformationSection from "./LocaleInformationSection";
@@ -80,16 +83,32 @@ export const SectionHeader = styled.header`
 
 const RtChartContainer = styled.div``;
 
-interface Props {
-  scenarioId: string;
-}
+const AddCasesRow = styled.div`
+  margin-bottom: 16px;
+`;
+
+const ImgDuplicate = styled.img`
+  display: inline-block;
+  height: 10px;
+  margin-right: 1em;
+  width: 10px;
+  vertical-align: baseline;
+`;
+
+const AddCasesButton = styled.button`
+  color: ${Colors.green};
+  font-family: "Poppins", sans-serif;
+  font-size: 12px;
+  line-height: 1.3;
+`;
 
 interface Props {
   scenarioId: string;
 }
 
 const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
-  const { facility, rtData } = useContext(FacilityContext);
+  const { facility: initialFacility, rtData } = useContext(FacilityContext);
+  const [facility, updateFacility] = useState(initialFacility);
   const [facilityName, setFacilityName] = useState(facility?.name || undefined);
   const [description, setDescription] = useState(
     facility?.description || undefined,
@@ -153,6 +172,22 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           requiredFlag={true}
         />
         <Spacer y={20} />
+        {facility && (
+          <AddCasesRow>
+            <AddCasesModal
+              facility={facility}
+              trigger={
+                <Tooltip content="Click to add new or previous day cases">
+                  <AddCasesButton>
+                    <ImgDuplicate alt="" src={iconDuplicatePath} />
+                    Add or update cases
+                  </AddCasesButton>
+                </Tooltip>
+              }
+              updateFacility={updateFacility}
+            />
+          </AddCasesRow>
+        )}
         <DescRow>
           <InputDescription
             description={description}

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -1,26 +1,17 @@
-import { startOfDay, startOfToday } from "date-fns";
 import { navigate } from "gatsby";
-import { pick } from "lodash";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
 import { saveFacility } from "../database/index";
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
-import InputButton from "../design-system/InputButton";
-import InputDate from "../design-system/InputDate";
 import InputDescription from "../design-system/InputDescription";
-import ModalDialog from "../design-system/ModalDialog";
 import { Spacer } from "../design-system/Spacer";
 import { useFlag } from "../feature-flags";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
-import {
-  EpidemicModelUpdate,
-  persistedKeys as facilityModelKeys,
-  totalConfirmedCases,
-} from "../impact-dashboard/EpidemicModelContext";
-import { AgeGroupGrid } from "../impact-dashboard/FacilityInformation";
+import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
 import useModel from "../impact-dashboard/useModel";
+import AddCasesModal from "./AddCasesModal";
 import { FacilityContext } from "./FacilityContext";
 import {
   useChartDataFromProjectionData,
@@ -52,22 +43,6 @@ const CaseText = styled.div`
   color: ${Colors.darkRed};
 `;
 
-const ModalContents = styled.div`
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
-  font-weight: normal;
-  justify-content: flex-start;
-  margin-top: 30px;
-`;
-
-const HorizRule = styled.div`
-  border-bottom: 0.5px solid ${Colors.darkGray};
-  padding-bottom: 20px;
-  margin-bottom: 20px;
-  width: 100%;
-`;
-
 // TODO: validate the arguments?
 const handleSubClick = (fn?: Function, ...args: any[]) => {
   return (event: React.MouseEvent<Element>) => {
@@ -84,29 +59,11 @@ interface Props {
   scenarioId: string;
 }
 
-// Create a diff of the model to store changes in the update cases modal.
-// This is necessary so that we don't update the current modal if the modal is thrown away w/o saving or
-// if the date added in the modal is prior to the current date (backfill)
-const useModelDiff = (): [
-  EpidemicModelUpdate,
-  (update: EpidemicModelUpdate) => void,
-  () => void,
-] => {
-  const [diff, setDiff] = useState({});
-  const mergeDiff = (update: EpidemicModelUpdate) => {
-    setDiff({ ...diff, ...update });
-  };
-  const resetDiff = () => {
-    setDiff({});
-  };
-  return [diff, mergeDiff, resetDiff];
-};
-
 const FacilityRow: React.FC<Props> = ({
   facility: initialFacility,
   scenarioId: scenarioId,
 }) => {
-  const [model, updateModel] = useModel();
+  const [model] = useModel();
 
   const { rtData, setFacility } = useContext(FacilityContext);
   const [facility, updateFacility] = useState(initialFacility);
@@ -127,56 +84,22 @@ const FacilityRow: React.FC<Props> = ({
     navigate("/facility");
   };
 
-  let [modelDiff, fakeUpdateModel, resetModelDiff] = useModelDiff();
-  const newModel = { ...model, ...modelDiff };
-
-  // Open/close update case counts modal. Saves data on clicking the save button, discards otherwise
-  const [caseCountsModal, updateCaseCountsModal] = useState(false);
-  const openCaseCountsModal = () => {
-    updateCaseCountsModal(true);
-  };
-  const closeCaseCountsModal = () => {
-    resetModelDiff();
-    updateCaseCountsModal(false);
-  };
-
-  const save = () => {
-    // Ensure that we don't insert keys (like `localeDataSource`) that is in model but not in the facility modelInputs
-    const modelInputs = {
-      ...facility.modelInputs,
-      ...pick(newModel, facilityModelKeys),
-    };
-    // Update the local state iff
-    // The observedAt date in the modal is more recent than the observedAt date in the current modelInputs.
-    // This needs to happen so that facility data will show the most updated data w/o requiring a hard reload.
-    if (
-      newModel.observedAt &&
-      model.observedAt &&
-      startOfDay(newModel.observedAt) >= startOfDay(model.observedAt)
-    ) {
-      updateFacility({ ...facility, modelInputs });
-      updateModel(modelDiff);
-    }
-    // Save to DB with model changes
-    saveFacility(scenarioId, {
-      id,
-      modelInputs,
-    });
-    closeCaseCountsModal();
-  };
-
   return (
     <>
       <div onClick={openFacilityPage} className="cursor-pointer">
         <DataContainer className="flex flex-row mb-8 border-b">
           <div className="w-2/5 flex flex-col justify-between">
             <div className="flex flex-row h-full">
-              <CaseText
+              <div
                 className="w-1/4 font-bold"
-                onClick={handleSubClick(openCaseCountsModal)}
+                onClick={(e) => e.stopPropagation()}
               >
-                {confirmedCases}
-              </CaseText>
+                <AddCasesModal
+                  facility={facility}
+                  trigger={<CaseText>{confirmedCases}</CaseText>}
+                  updateFacility={updateFacility}
+                />
+              </div>
               <FacilityNameLabel onClick={handleSubClick()}>
                 <InputDescription
                   description={name}
@@ -220,31 +143,6 @@ const FacilityRow: React.FC<Props> = ({
           </div>
         </DataContainer>
       </div>
-      <ModalDialog
-        closeModal={closeCaseCountsModal}
-        open={caseCountsModal}
-        title="Add Cases"
-      >
-        <ModalContents>
-          <InputDate
-            labelAbove={"Date observed"}
-            onValueChange={(date) => {
-              if (date) {
-                fakeUpdateModel({ observedAt: date });
-              }
-            }}
-            valueEntered={newModel.observedAt || startOfToday()}
-          />
-          <HorizRule />
-          <AgeGroupGrid
-            model={newModel}
-            updateModel={fakeUpdateModel}
-            collapsible={true}
-          />
-          <HorizRule />
-          <InputButton label="Save" onClick={save} />
-        </ModalContents>
-      </ModalDialog>
     </>
   );
 };


### PR DESCRIPTION
## Description of the change

Refactors the add cases modal into a separate component for reuse, and then reuses it on the facility page. (Some of the modal state management boilerplate I was able to delegate to a `Modal` component that we already had but weren't using for anything.)

![Screen Shot 2020-05-04 at 5 20 27 PM](https://user-images.githubusercontent.com/5385319/81025501-b2a33600-8e2b-11ea-9657-587c95f5a078.png)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #304 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
