### PR TITLE
Add collapsible age rows for case count update modal.

### DIFF
--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -76,7 +76,7 @@ interface AgeGroupGridProps {
 }
 
 export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
-  collapsible = true,
+  collapsible = false,
   ...props
 }) => {
   const [collapsed, setCollapsed] = useState(collapsible);

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -1,5 +1,5 @@
 import numeral from "numeral";
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import InputTextNumeric from "../design-system/InputTextNumeric";
@@ -20,6 +20,10 @@ const FacilityInformationDiv = styled.div``;
 
 const LabelRow = styled(FormGridRow)`
   margin-bottom: 0;
+`;
+
+const CollapseIcon = styled.span`
+  font-size: xx-small;
 `;
 
 const LabelCell: React.FC = (props) => (
@@ -68,71 +72,95 @@ const FormHeaderRow: React.FC<FormHeaderRowProps> = (props) => (
 interface AgeGroupGridProps {
   model: EpidemicModelState;
   updateModel: (update: EpidemicModelUpdate) => void;
+  collapsible?: boolean;
 }
 
-export const AgeGroupGrid: React.FC<AgeGroupGridProps> = (props) => (
-  <FormGrid>
-    <FormGridRow />
-    <FormHeaderRow label="Staff Population" />
-    <AgeGroupRow
-      label="Facility Staff"
-      leftKey="staffCases"
-      rightKey="staffPopulation"
-      {...props}
-    />
-    {/* empty row for spacing */}
-    <FormGridRow />
-    <FormHeaderRow label="Total Population" />
-    <AgeGroupRow
-      label="Ages Unknown"
-      leftKey="ageUnknownCases"
-      rightKey="ageUnknownPopulation"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 0-19"
-      leftKey="age0Cases"
-      rightKey="age0Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 20-44"
-      leftKey="age20Cases"
-      rightKey="age20Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 45-54"
-      leftKey="age45Cases"
-      rightKey="age45Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 55-64"
-      leftKey="age55Cases"
-      rightKey="age55Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 65-74"
-      leftKey="age65Cases"
-      rightKey="age65Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 75-84"
-      leftKey="age75Cases"
-      rightKey="age75Population"
-      {...props}
-    />
-    <AgeGroupRow
-      label="Ages 85+"
-      leftKey="age85Cases"
-      rightKey="age85Population"
-      {...props}
-    />
-  </FormGrid>
-);
+export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
+  collapsible = true,
+  ...props
+}) => {
+  const [collapsed, setCollapsed] = useState(collapsible);
+  const ageSpecificCaseCounts = (
+    <>
+      <AgeGroupRow
+        label="Ages 0-19"
+        leftKey="age0Cases"
+        rightKey="age0Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 20-44"
+        leftKey="age20Cases"
+        rightKey="age20Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 45-54"
+        leftKey="age45Cases"
+        rightKey="age45Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 55-64"
+        leftKey="age55Cases"
+        rightKey="age55Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 65-74"
+        leftKey="age65Cases"
+        rightKey="age65Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 75-84"
+        leftKey="age75Cases"
+        rightKey="age75Population"
+        {...props}
+      />
+      <AgeGroupRow
+        label="Ages 85+"
+        leftKey="age85Cases"
+        rightKey="age85Population"
+        {...props}
+      />
+    </>
+  );
+  return (
+    <FormGrid>
+      <FormGridRow />
+      <FormHeaderRow label="Staff Population" />
+      <AgeGroupRow
+        label="Facility Staff"
+        leftKey="staffCases"
+        rightKey="staffPopulation"
+        {...props}
+      />
+      {/* empty row for spacing */}
+      <FormGridRow />
+      <FormHeaderRow label="Total Population" />
+      <AgeGroupRow
+        label="Ages Unknown"
+        leftKey="ageUnknownCases"
+        rightKey="ageUnknownPopulation"
+        {...props}
+      />
+      {collapsed ? (
+        <div
+          className="flex flex-row justify-center mt-8 cursor-pointer"
+          onClick={() => {
+            setCollapsed(false);
+          }}
+        >
+          <TextLabel>Add residents and cases by age</TextLabel>
+          <CollapseIcon>▾</CollapseIcon>
+        </div>
+      ) : (
+        ageSpecificCaseCounts
+      )}
+    </FormGrid>
+  );
+};
 
 interface AgeGroupRowProps {
   label: string;

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -140,7 +140,7 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
       <FormGridRow />
       <FormHeaderRow label="Total Population" />
       <AgeGroupRow
-        label="Ages Unknown"
+        label="Resident population (ages unknown)"
         leftKey="ageUnknownCases"
         rightKey="ageUnknownPopulation"
         {...props}

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -236,7 +236,11 @@ const FacilityRow: React.FC<Props> = ({
             valueEntered={newModel.observedAt || startOfToday()}
           />
           <HorizRule />
-          <AgeGroupGrid model={newModel} updateModel={fakeUpdateModel} />
+          <AgeGroupGrid
+            model={newModel}
+            updateModel={fakeUpdateModel}
+            collapsible={true}
+          />
           <HorizRule />
           <InputButton label="Save" onClick={save} />
         </ModalContents>


### PR DESCRIPTION
## Description of the change
Case counts by age groups is initially collapsed in the modal. On click, it expands to include the age specific rows.
![image](https://user-images.githubusercontent.com/6414261/81025856-f5194280-8e2c-11ea-96fb-1bc5b6bf2e30.png)
![Kapture 2020-05-04 at 17 26 24](https://user-images.githubusercontent.com/6414261/81025743-7c19eb00-8e2c-11ea-8dfa-af67e1691de5.gif)
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #305

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
