### PR TITLE
Fix issue preventing scenario changes from updating database

### DIFF
--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -60,17 +60,19 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
 
   const handleScenarioChange = (scenarioChange: any) => {
     const changes = Object.assign({}, scenario, scenarioChange);
-    if (Object.keys(scenarioChange).length) {
-      saveScenario(changes).then((_) => {
-        dispatchScenarioUpdate(changes);
-      });
-    }
+    saveScenario(changes).then((_) => {
+      dispatchScenarioUpdate(changes);
+    });
   };
 
-  const handleTextInputChange = (scenarioChange: any) => {
-    // Prevent the input fields from unintentionally updating with a empty value when text field is being edited.
-    if (Object.keys(scenarioChange).length) {
-      handleScenarioChange(scenarioChange);
+  const handleTextInputChange = (textInputChanges: {
+    description?: string;
+    name?: string;
+  }) => {
+    // Prevent the input fields from unintentionally updating with a empty
+    // value when being edited.
+    if (textInputChanges.name || textInputChanges.description) {
+      handleScenarioChange(textInputChanges);
     }
   };
 

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -59,14 +59,21 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const updatedAtDate = Number(scenario?.updatedAt);
 
   const handleScenarioChange = (scenarioChange: any) => {
-    if (scenarioChange.name || scenarioChange.description) {
-      const changes = Object.assign({}, scenario, scenarioChange);
-
+    const changes = Object.assign({}, scenario, scenarioChange);
+    if (Object.keys(scenarioChange).length) {
       saveScenario(changes).then((_) => {
         dispatchScenarioUpdate(changes);
       });
     }
   };
+
+  const handleTextInputChange = (scenarioChange: any) => {
+    // Prevent the input fields from unintentionally updating with a empty value when text field is being edited.
+    if (Object.keys(scenarioChange).length) {
+      handleScenarioChange(scenarioChange);
+    }
+  };
+
   const [name, setName] = useState(scenario?.name);
   const [promoDismissed, setPromoDismissed] = useState(false);
   const [description, setDescription] = useState(scenario?.description);
@@ -82,7 +89,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           placeholderText="Scenario name is required"
           maxLengthValue={124}
           requiredFlag={true}
-          persistChanges={handleScenarioChange}
+          persistChanges={handleTextInputChange}
         />
         <Spacer y={20} />
         <InputDescription
@@ -92,7 +99,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           placeholderText="Scenario description is required"
           maxLengthValue={500}
           requiredFlag={true}
-          persistChanges={handleScenarioChange}
+          persistChanges={handleTextInputChange}
         />
         <Spacer y={20} />
         <div>


### PR DESCRIPTION
## Description of the change

An if statement meant for the name/description fields were unintentionally preventing scenario changes from propagating to the database. This fixes the problem by creating the same check for the name/description in a separate function.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #309 
Closes #317

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
