### PR TITLE
[Excalibur] Add button to scenario sidebar that navigates to /impact

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,3 +3,4 @@
 # (actual deployment builds will use Now configuration)
 
 GATSBY_USE_RT="true"
+GATSBY_SHOW_IMPACT_BUTTON="false"

--- a/src/design-system/InputButton.tsx
+++ b/src/design-system/InputButton.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import styled from "styled-components";
 
 export const StyledButton = styled.button<Props>`
-  background: #00615c;
-  font-size: 16px;
-  border-radius: 12px;
+  background: ${(props) => props.styles?.background || "#00615c"};
+  font-size: ${(props) => props.styles?.fontSize || "16px"};
+  border-radius: ${(props) => props.styles?.borderRadius || "12px"};
   color: white;
-  font-family: "Poppins", sans-serif;
+  font-family: ${(props) =>
+    props.styles?.fontFamily || "'Poppins', sans-serif"};
   height: 48px;
   width: ${(props) => props.styles?.width || "200px"};
   outline: none;

--- a/src/design-system/PromoBoxWithButton.tsx
+++ b/src/design-system/PromoBoxWithButton.tsx
@@ -23,7 +23,7 @@ const PromoBox = styled.div`
   font-family: "Poppins", sans-serif;
   font-size: 12px;
   font-weight: 100;
-  margin-top: 24px;
+  margin: 24px 0;
   padding: 16px;
 `;
 

--- a/src/feature-flags/featureFlags.tsx
+++ b/src/feature-flags/featureFlags.tsx
@@ -5,6 +5,7 @@ export type FeatureFlags = {
   useRt: boolean;
   // TODO: Delete this flag once #202 is done
   showRateOfSpreadTab: boolean;
+  showImpactButton: boolean;
 };
 
 const { FlagsProvider, Flag, useFlag, useFlags } = createFlags<FeatureFlags>();
@@ -15,6 +16,7 @@ export const FeatureFlagsProvider: React.FC = ({ children }) => {
       flags={{
         useRt: process.env.GATSBY_USE_RT === "true",
         showRateOfSpreadTab: true,
+        showImpactButton: process.env.GATSBY_SHOW_IMPACT_BUTTON === "true",
       }}
     >
       {children}

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -1,11 +1,15 @@
 import { format } from "date-fns";
+import { navigate } from "gatsby";
 import React, { useState } from "react";
 
 import { saveScenario } from "../database";
+import Colors from "../design-system/Colors";
+import InputButton from "../design-system/InputButton";
 import InputDescription from "../design-system/InputDescription";
 import InputNameWithIcon from "../design-system/InputNameWithIcon";
 import PromoBoxWithButton from "../design-system/PromoBoxWithButton";
 import { Spacer } from "../design-system/Spacer";
+import { useFlag } from "../feature-flags";
 import useScenario from "../scenario-context/useScenario";
 import ToggleRow from "./ToggleRow";
 import { Scenario } from "./types";
@@ -57,6 +61,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const scenario = scenarioState.data;
   const { numFacilities } = props;
   const updatedAtDate = Number(scenario?.updatedAt);
+  const showImpactButton = useFlag(["showImpactButton"]);
 
   const handleScenarioChange = (scenarioChange: any) => {
     if (scenarioChange.name || scenarioChange.description) {
@@ -133,6 +138,20 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
               }
             }}
           />
+
+          {showImpactButton && (
+            <InputButton
+              styles={{
+                background: Colors.green,
+                borderRadius: "4px",
+                fontSize: "14px",
+                fontFamily: "PingFang SC",
+                width: "100%",
+              }}
+              label="Generate Impact Report"
+              onClick={() => navigate("/impact")}
+            />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description of the change

This PR adds a button to the scenario sidebar "Generate Impact Report" that will navigate to the `/impact` page. I tried to add a feature flag for showing this button so that it doesn't block any releases, let me know if I set that up okay or if I misunderstood how they work!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #229

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
