### PR TITLE
Assorted UI polish on facility page

### DIFF
--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -34,9 +34,11 @@ const IconEdit = styled.img`
 `;
 
 const TextArea = styled.textarea`
+  background-color: ${Colors.gray};
   color: ${Colors.forest};
   font-size: 13px;
   height: 100%;
+  resize: none;
   width: 100%;
 
   &.has-invalid-input {

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -1,16 +1,9 @@
+import classNames from "classnames";
 import React, { useState } from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
 import iconEditSrc from "./icons/ic_edit.svg";
-import InputTextArea from "./InputTextArea";
-
-const inputTextAreaStyle = {
-  fontFamily: "Helvetica Neue",
-  fontSize: "13px",
-  color: Colors.forest,
-  outline: "none",
-};
 
 const DescriptionDiv = styled.div`
   min-height: 100px;
@@ -40,6 +33,17 @@ const IconEdit = styled.img`
   }
 `;
 
+const TextArea = styled.textarea`
+  color: ${Colors.forest};
+  font-size: 13px;
+  height: 100%;
+  width: 100%;
+
+  &.has-invalid-input {
+    box-shadow: #ff0000 0px 0px 1.5px 1px;
+  }
+`;
+
 interface Props {
   description?: string | undefined;
   setDescription: (description?: string) => void;
@@ -61,9 +65,6 @@ const InputDescription: React.FC<Props> = ({
 }) => {
   const [editingDescription, setEditingDescription] = useState(false);
   const [value, setValue] = useState(description);
-
-  // Reset Description field border
-  if (!editingDescription) inputTextAreaStyle.outline = "none";
 
   const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
     if (event.key !== "Enter") return;
@@ -88,12 +89,6 @@ const InputDescription: React.FC<Props> = ({
         persistChanges({ description: "" });
       }
     }
-
-    if (requiredFlag && !value?.trim()) {
-      inputTextAreaStyle.outline = `1px solid ${Colors.red}`;
-    } else {
-      inputTextAreaStyle.outline = "none";
-    }
   };
 
   return (
@@ -104,10 +99,10 @@ const InputDescription: React.FC<Props> = ({
         </Description>
       ) : (
         <Description>
-          <InputTextArea
-            fillVertical
-            style={inputTextAreaStyle}
-            autoResizeVertically
+          <TextArea
+            className={classNames({
+              "has-invalid-input": requiredFlag && !value?.trim(),
+            })}
             value={value}
             placeholder={placeholderText || ""}
             maxLength={maxLengthValue}

--- a/src/design-system/InputNameWithIcon.tsx
+++ b/src/design-system/InputNameWithIcon.tsx
@@ -60,6 +60,7 @@ interface Props {
   maxLengthValue?: number | undefined;
   requiredFlag?: boolean;
   persistChanges?: (changes: object) => void;
+  showIcon?: boolean;
 }
 
 const InputNameWithIcon: React.FC<Props> = ({
@@ -70,6 +71,7 @@ const InputNameWithIcon: React.FC<Props> = ({
   maxLengthValue,
   requiredFlag,
   persistChanges,
+  showIcon,
 }) => {
   const [editingName, setEditingName] = useState(false);
   const [value, setValue] = useState(name);
@@ -108,7 +110,7 @@ const InputNameWithIcon: React.FC<Props> = ({
     <NameLabelDiv>
       {!editingName && ((requiredFlag && name) || !requiredFlag) ? (
         <Heading onClick={() => setEditingName(true)}>
-          <IconFolder alt="folder" src={iconFolderSrc} />
+          {showIcon && <IconFolder alt="folder" src={iconFolderSrc} />}
           <span>{value || placeholderValue}</span>
         </Heading>
       ) : (

--- a/src/design-system/InputNameWithIcon.tsx
+++ b/src/design-system/InputNameWithIcon.tsx
@@ -45,11 +45,12 @@ const IconEdit = styled.img`
 
 const Heading = styled.h1`
   color: ${Colors.forest};
+  flex: 1 1 auto;
   font-size: 24px;
-  line-height: 24px;
   font-family: Libre Baskerville;
   font-weight: normal;
   letter-spacing: -0.06em;
+  line-height: 24px;
 `;
 
 interface Props {

--- a/src/design-system/InputTextArea.tsx
+++ b/src/design-system/InputTextArea.tsx
@@ -1,58 +1,28 @@
-import React, { useEffect, useRef } from "react";
-import styled, { css } from "styled-components";
+import React from "react";
+import styled from "styled-components";
 
 import Colors from "./Colors";
 import TextLabel from "./TextLabel";
 
 interface Props {
-  autoResizeVertically?: boolean;
   label?: string;
   value?: string;
   placeholder?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onBlur?: (e: React.FormEvent<HTMLTextAreaElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
-  inline?: boolean;
-  fillVertical?: boolean;
-  style?: object;
-  maxLength?: number;
   required?: boolean;
 }
 
-interface InputProps {
-  inline?: boolean;
-  fillVertical?: boolean;
-  fontFamily?: string;
-  fontSize?: string;
-  color?: string;
-  outline?: string;
-}
-
-const TextAreaInput = styled.textarea<InputProps>`
+const TextAreaInput = styled.textarea`
   margin-top: 8px;
   border: none;
-  outline: ${(props) => props.outline || "none"};
   padding: 16px;
   background: #e0e4e4;
   border-radius: 2px;
-  font-size: ${(props) => props.fontSize || "16px"};
   color: ${(props) => props.color || Colors.green};
   resize: none;
-  font-family: ${(props) => props.fontFamily || '"Poppins", sans-serif'};
   width: 100%;
-  ${(props) =>
-    props.inline &&
-    css`
-      margin: 0 !important;
-      padding: 0 !important;
-      font-size: inherit;
-      background-color: transparent;
-    `};
-  ${(props) =>
-    props.fillVertical &&
-    css`
-      height: 100%;
-    `};
 
   // make placeholder font size smaller than the textarea's
   &::-webkit-input-placeholder {
@@ -69,54 +39,24 @@ const TextAreaInput = styled.textarea<InputProps>`
   }
 `;
 
-interface TextAreaContainer {
-  fillVertical?: boolean;
-}
-
-const TextAreaContainer = styled.div<TextAreaContainer>`
+const TextAreaContainer = styled.div`
   margin-bottom: 24px;
   display: flex;
   flex-direction: column;
-  ${(props) =>
-    props.fillVertical &&
-    css`
-      height: 100%;
-    `};
 `;
 
-function resize(textArea: HTMLTextAreaElement | null) {
-  if (!textArea) return;
-  textArea.style.height = "auto";
-  const height =
-    textArea.scrollHeight + textArea.offsetHeight - textArea.clientHeight;
-  textArea.style.height = `${height}px`;
-}
-
 const InputTextArea: React.FC<Props> = (props) => {
-  const textAreaRef = useRef(null);
-
-  useEffect(() => {
-    if (props.autoResizeVertically) {
-      resize(textAreaRef.current);
-    }
-  }, [props.autoResizeVertically, props.value]);
-
   return (
-    <TextAreaContainer fillVertical={!!props.fillVertical}>
+    <TextAreaContainer>
       <TextLabel>{props.label}</TextLabel>
       <TextAreaInput
-        ref={textAreaRef}
-        inline={!!props.inline}
-        fillVertical={!!props.fillVertical}
         onChange={props.onChange}
         onBlur={props.onBlur}
         value={props.value}
         placeholder={props.placeholder}
-        maxLength={props.maxLength}
         required={props.required}
         name={props.label}
         onKeyDown={props.onKeyDown}
-        {...props.style}
       />
     </TextAreaContainer>
   );

--- a/src/design-system/PopUpMenu.tsx
+++ b/src/design-system/PopUpMenu.tsx
@@ -26,7 +26,7 @@ const PopUpMenuDiv = styled.div`
 
 const PopUpMenuIcon = styled.div`
   font-family: "Rubik", sans-serif;
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 600;
   color: ${Colors.forest};
 `;

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -7,7 +7,6 @@ import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import FontSizes from "../design-system/FontSizes";
 import iconEditSrc from "../design-system/icons/ic_edit.svg";
-import InputDescription from "../design-system/InputDescription";
 import { Spacer } from "../design-system/Spacer";
 import { useFlag } from "../feature-flags";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -83,6 +83,7 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
           maxLengthValue={124}
           requiredFlag={true}
           persistChanges={handleScenarioChange}
+          showIcon
         />
         <Spacer y={20} />
         <InputDescription


### PR DESCRIPTION
## Description of the change

- Expands the click target for the facility name and removes the folder icon
- Decreases size of the ellipsis menu
- Eliminates jarring style changes when editing the description, namely the change in typeface and sudden addition of padding. On this one basically I decided to pull the plug on our repeated and unsuccessful attempts to make `InputTextArea` adaptable enough to match the surrounding styles; there didn't seem to be any real benefit to that approach, because there was no boilerplate form handling that was encapsulated by it, and it was resulting in an API that was pretty difficult to use but still didn't actually work as desired. I tried to clean up as much of that as I could. There aren't any regression concerns because this component isn't being used anywhere else so I tried to just leave it with a reasonable interface for someone who might come along later and drop it into a new form and expect it not to do anything weird.

<img width="562" alt="Screen Shot 2020-05-06 at 9 29 22 AM" src="https://user-images.githubusercontent.com/5385319/81202902-19376980-8f7c-11ea-8058-4df14027b88e.png">

<img width="554" alt="Screen Shot 2020-05-06 at 9 26 32 AM" src="https://user-images.githubusercontent.com/5385319/81202715-d6759180-8f7b-11ea-9981-9a4d39a9fe2b.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #306, part of #164 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
