### PR TITLE
Case counts UI polish

### DIFF
--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -7,6 +7,7 @@ import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import iconEditSrc from "../design-system/icons/ic_edit.svg";
 import { Spacer } from "../design-system/Spacer";
+import Tooltip from "../design-system/Tooltip";
 import { useFlag } from "../feature-flags";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
@@ -109,7 +110,7 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
       <DataContainer className="flex flex-row mb-8 border-b">
         <div className="w-2/5 flex flex-col justify-between">
           <div className="flex flex-row h-full">
-            <div className="w-1/4 font-bold">
+            <div className="w-1/4 font-bold flex justify-start">
               <div
                 // prevent interaction with children from triggering a row click
                 onClick={(e) => e.stopPropagation()}
@@ -121,7 +122,17 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
               >
                 <AddCasesModal
                   facility={facility}
-                  trigger={<CaseText>{confirmedCases}</CaseText>}
+                  trigger={
+                    <Tooltip
+                      content={
+                        <div>Click to add new or previous day cases</div>
+                      }
+                    >
+                      <CaseText className="hover:underline">
+                        {confirmedCases}
+                      </CaseText>
+                    </Tooltip>
+                  }
                   updateFacility={updateFacility}
                 />
               </div>


### PR DESCRIPTION
## Description of the change
Fixes these issues:

- The cases number should be the click target, not the div it’s in
Currently the entire area around the cases number is clickable to get the Add Cases modal. However, this makes it difficult for the user to know whether they’re clicking cases or the facility name (which also has a large click target). The cases number itself should be the click target for the ‘Add cases’ modal.

- Style improvements for cases number click target
The text should gain an underline on-hover
The text should have a tooltip on-hover, which reads ‘Click to add new or previous day cases’

![Kapture 2020-05-06 at 12 12 24](https://user-images.githubusercontent.com/6414261/81218252-c4ebb400-8f92-11ea-8b72-ef7fb8284a76.gif)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues
#306 
## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
