### PR TITLE
Remove Hospital beds annotation from chart on scenario page.

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -77,6 +77,7 @@ interface CurveChartProps {
   hospitalBeds: number;
   markColors: MarkColors;
   hideAxes?: boolean;
+  includeAnnotations?: boolean;
 }
 
 const xAxisOptions: any[] = [
@@ -109,6 +110,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   hospitalBeds,
   markColors,
   hideAxes,
+  includeAnnotations = true,
 }) => {
   const frameProps = {
     lines: Object.entries(curveData).map(([bucket, values]) => ({
@@ -126,7 +128,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
-    yExtent: { extent: [0], includeAnnotations: true },
+    yExtent: { extent: [0], includeAnnotations },
     margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 0 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -77,7 +77,7 @@ interface CurveChartProps {
   hospitalBeds: number;
   markColors: MarkColors;
   hideAxes?: boolean;
-  includeAnnotations?: boolean;
+  addAnnotations?: boolean;
 }
 
 const xAxisOptions: any[] = [
@@ -110,7 +110,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   hospitalBeds,
   markColors,
   hideAxes,
-  includeAnnotations = true,
+  addAnnotations = true,
 }) => {
   const frameProps = {
     lines: Object.entries(curveData).map(([bucket, values]) => ({
@@ -128,7 +128,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
-    yExtent: { extent: [0], includeAnnotations },
+    yExtent: { extent: [0], includeAnnotations: true },
     margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 0 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],
@@ -141,14 +141,16 @@ const CurveChart: React.FC<CurveChartProps> = ({
       hideAxes ? xAxisOptions[1] : xAxisOptions[0],
     ],
     annotations: [
-      {
-        type: "y",
-        className: "threshold-annotation",
-        count: hospitalBeds,
-        color: markColors.hospitalBeds,
-        note: { label: "Hospital Beds", lineType: null, dy: 1, dx: 0 },
-        disable: ["connector"],
-      },
+      addAnnotations
+        ? {
+            type: "y",
+            className: "threshold-annotation",
+            count: hospitalBeds,
+            color: markColors.hospitalBeds,
+            note: { label: "Hospital Beds", lineType: null, dy: 1, dx: 0 },
+            disable: ["connector"],
+          }
+        : {},
     ],
     hoverAnnotation: true,
     tooltipContent: Tooltip,

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -13,7 +13,7 @@ interface Props {
   hideAxes?: boolean;
   markColors: MarkColors;
   curveData?: ChartData;
-  includeAnnotations?: boolean;
+  addAnnotations?: boolean;
 }
 
 const CurveChartContainer: React.FC<Props> = ({
@@ -22,7 +22,7 @@ const CurveChartContainer: React.FC<Props> = ({
   chartHeight,
   hideAxes,
   curveData,
-  includeAnnotations = true,
+  addAnnotations = true,
 }) => {
   const { hospitalBeds } = useEpidemicModelState();
   const [curveDataFiltered, setCurveDataFiltered] = useState(curveData);
@@ -56,7 +56,7 @@ const CurveChartContainer: React.FC<Props> = ({
       hospitalBeds={hospitalBeds}
       markColors={markColors}
       hideAxes={hideAxes}
-      includeAnnotations={includeAnnotations}
+      addAnnotations={addAnnotations}
     />
   );
 };

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -13,6 +13,7 @@ interface Props {
   hideAxes?: boolean;
   markColors: MarkColors;
   curveData?: ChartData;
+  includeAnnotations?: boolean;
 }
 
 const CurveChartContainer: React.FC<Props> = ({
@@ -21,6 +22,7 @@ const CurveChartContainer: React.FC<Props> = ({
   chartHeight,
   hideAxes,
   curveData,
+  includeAnnotations = true,
 }) => {
   const { hospitalBeds } = useEpidemicModelState();
   const [curveDataFiltered, setCurveDataFiltered] = useState(curveData);
@@ -54,6 +56,7 @@ const CurveChartContainer: React.FC<Props> = ({
       hospitalBeds={hospitalBeds}
       markColors={markColors}
       hideAxes={hideAxes}
+      includeAnnotations={includeAnnotations}
     />
   );
 };

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -165,7 +165,7 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
             hideAxes={true}
             groupStatus={groupStatus}
             markColors={markColors}
-            includeAnnotations={false}
+            addAnnotations={false}
           />
         </div>
       </DataContainer>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -165,6 +165,7 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
             hideAxes={true}
             groupStatus={groupStatus}
             markColors={markColors}
+            includeAnnotations={false}
           />
         </div>
       </DataContainer>


### PR DESCRIPTION
## Description of the change
Removed the hospital beds annotation from scenario page. Annotation is still present on the facility page.
Scenario page:
![image](https://user-images.githubusercontent.com/6414261/81223325-b0131e80-8f9a-11ea-92ef-5a57caa43302.png)
Facility detail page:
![image](https://user-images.githubusercontent.com/6414261/81223528-f9fc0480-8f9a-11ea-8c8e-2689a08d4514.png)



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues
#306 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
