### PR TITLE
[Excalibur] Use County Jail total population when system type is 'County Jail'

### DIFF
--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -158,6 +158,8 @@ export function getLocaleDefaults(
       0,
     totalPrisonPopulation:
       dataSource.get(stateCode)?.get(countyName)?.totalPrisonPopulation || 0,
+    totalJailPopulation:
+      dataSource.get(stateCode)?.get(countyName)?.totalJailPopulation || 0,
     // user input defaults
     rateOfSpreadFactor: RateOfSpread.high,
     facilityOccupancyPct: 1,

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -12,6 +12,7 @@ export type LocaleRecord = {
   totalIncarceratedPopulation: number;
   icuBeds: number;
   totalPrisonPopulation?: number;
+  totalJailPopulation?: number;
 };
 
 export type LocaleData = Map<string, Map<string, LocaleRecord>>;
@@ -89,9 +90,11 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
             const reportedCases: number = numeral(row.cases).value() || 0;
             const estimatedTotalCases: number =
               reportedCases * (1 / caseReportingRate);
-            // TODO: distinguish jail vs prison?
             const totalPrisonPopulation: number = numeral(
               row["Prison Population"],
+            ).value();
+            const totalJailPopulation: number = numeral(
+              row["Jail Population (2017)"],
             ).value();
             const totalIncarceratedPopulation: number =
               numeral(row["Total Incarcerated Population"]).value() || 0;
@@ -112,6 +115,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
               ),
               icuBeds: numeral(row["ICU Beds"]).value() || 0,
               ...(totalPrisonPopulation && { totalPrisonPopulation }),
+              ...(totalJailPopulation && { totalJailPopulation }),
             };
           }).filter((row) => row !== undefined);
 

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -119,6 +119,7 @@ const ResponseImpactDashboard: React.FC = () => {
     const localeDefaults = getLocaleDefaults(
       localeDataSource,
       modelInputs[0].stateCode,
+      modelInputs[0].countyName,
     );
 
     setSystemWideData({
@@ -128,7 +129,7 @@ const ResponseImpactDashboard: React.FC = () => {
           ? localeDefaults.totalPrisonPopulation
           : localeDefaults.totalJailPopulation,
     });
-  }, [modelInputs, localeDataSource]);
+  }, [modelInputs, localeDataSource, facilities.data]);
 
   return (
     <ResponseImpactDashboardContainer>

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -55,7 +55,7 @@ const ResponseImpactDashboard: React.FC = () => {
   const [systemWideData, setSystemWideData] = useState({
     hospitalBeds: 0,
     staffPopulation: 0,
-    prisonPopulation: 0,
+    incarceratedPopulation: 0,
   });
   const [reductionCardData, setreductionCardData] = useState<
     reductionCardDataType | undefined
@@ -116,13 +116,17 @@ const ResponseImpactDashboard: React.FC = () => {
   // set system wide data
   useEffect(() => {
     if (modelInputs.length === 0) return;
+    const localeDefaults = getLocaleDefaults(
+      localeDataSource,
+      modelInputs[0].stateCode,
+    );
 
     setSystemWideData({
       ...getSystemWideSums(modelInputs),
-      prisonPopulation: getLocaleDefaults(
-        localeDataSource,
-        modelInputs[0].stateCode,
-      ).totalPrisonPopulation,
+      incarceratedPopulation:
+        facilities.data[0].systemType === "State Prison"
+          ? localeDefaults.totalPrisonPopulation
+          : localeDefaults.totalJailPopulation,
     });
   }, [modelInputs, localeDataSource]);
 
@@ -147,7 +151,7 @@ const ResponseImpactDashboard: React.FC = () => {
             <PopulationImpactMetrics
               reductionData={reductionCardData}
               staffPopulation={systemWideData.staffPopulation}
-              incarceratedPopulation={systemWideData.prisonPopulation}
+              incarceratedPopulation={systemWideData.incarceratedPopulation}
             />
             <SectionHeader>Community Resources Saved</SectionHeader>
             <ChartHeader>

--- a/src/page-response-impact/responseChartData.tsx
+++ b/src/page-response-impact/responseChartData.tsx
@@ -23,7 +23,7 @@ const NUM_SEIR_CATEGORIES = 9;
 
 export type SystemWideData = {
   staffPopulation: number;
-  prisonPopulation: number;
+  incarceratedPopulation: number;
   hospitalBeds: number;
 };
 
@@ -51,12 +51,12 @@ export function getCurveInputs(modelInputs: EpidemicModelState[]) {
 }
 
 function originalEpidemicModelInputs(systemWideData: SystemWideData) {
-  const { staffPopulation, prisonPopulation } = systemWideData;
+  const { staffPopulation, incarceratedPopulation } = systemWideData;
   return {
     staffCases: 1,
     staffPopulation: staffPopulation,
     ageUnknownCases: 1,
-    ageUnknownPopulation: prisonPopulation,
+    ageUnknownPopulation: incarceratedPopulation,
     populationTurnover: 0,
     facilityOccupancyPct: 1,
     facilityDormitoryPct: 0.15,


### PR DESCRIPTION
## Description of the change

As input to the original projection on the `ResponseImpactDashboard`, use the county's `totalJailPopulation` instead of `totalPrisonPopulation` when `systemType='County Jail'`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #289 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
