### PR TITLE
Prevent jarring style change when editing scenario & facility names

### DIFF
--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -1,0 +1,139 @@
+import classNames from "classnames";
+import React, { useEffect, useRef, useState } from "react";
+import styled, { StyledComponent } from "styled-components";
+
+import Colors from "./Colors";
+import iconEditSrc from "./icons/ic_edit.svg";
+
+const EditInPlaceDiv = styled.div`
+  min-height: 100px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  .edit-in-place__input {
+    background-color: ${Colors.gray};
+    height: 100%;
+    resize: none;
+    width: 100%;
+  }
+
+  &.has-invalid-input {
+    box-shadow: #ff0000 0px 0px 1.5px 1px;
+  }
+`;
+
+const IconEdit = styled.img`
+  flex: 0 0 auto;
+  height: 10px;
+  margin-left: 10px;
+  width: 10px;
+  visibility: hidden;
+
+  ${EditInPlaceDiv}:hover & {
+    visibility: visible;
+  }
+`;
+
+function resize(textArea: HTMLTextAreaElement | null) {
+  if (!textArea) return;
+  textArea.style.height = "auto";
+  const height =
+    textArea.scrollHeight + textArea.offsetHeight - textArea.clientHeight;
+  textArea.style.height = `${height}px`;
+}
+
+export interface Props {
+  autoResizeVertically?: boolean;
+  BaseComponent: StyledComponent<any, any>;
+  initialValue?: string;
+  setInitialValue: (description?: string) => void;
+  placeholderValue?: string | undefined;
+  placeholderText?: string | undefined;
+  maxLengthValue?: number | undefined;
+  requiredFlag?: boolean;
+  persistChanges?: (changes: { description: string | undefined }) => void;
+}
+
+const EditInPlace: React.FC<Props> = ({
+  autoResizeVertically,
+  BaseComponent,
+  initialValue,
+  setInitialValue,
+  placeholderValue,
+  placeholderText,
+  maxLengthValue,
+  requiredFlag,
+  persistChanges,
+}) => {
+  const [editing, setEditing] = useState(false);
+
+  const textAreaRef = useRef(null);
+
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (autoResizeVertically) {
+      resize(textAreaRef.current);
+    }
+  }, [autoResizeVertically, editing, value]);
+
+  const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
+    if (event.key !== "Enter") return;
+    else if (event.key === "Enter" && requiredFlag && !value?.trim()) {
+      event.preventDefault();
+      return;
+    }
+    onEnter();
+  };
+
+  const updateValue = () => {
+    if ((requiredFlag && value?.trim()) || !requiredFlag) {
+      setEditing(false);
+      setInitialValue(value);
+      if (persistChanges) {
+        persistChanges({ description: value });
+      }
+    } else {
+      setEditing(true);
+      setInitialValue("");
+      if (persistChanges) {
+        persistChanges({ description: "" });
+      }
+    }
+  };
+
+  return (
+    <EditInPlaceDiv>
+      {!editing && ((requiredFlag && value) || !requiredFlag) ? (
+        <BaseComponent onClick={() => setEditing(true)}>
+          <span>{value || placeholderValue}</span>
+        </BaseComponent>
+      ) : (
+        <BaseComponent
+          as="textarea"
+          autoFocus
+          className={classNames("edit-in-place__input", {
+            "has-invalid-input": requiredFlag && !value?.trim(),
+          })}
+          maxLength={maxLengthValue}
+          onBlur={updateValue}
+          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setValue(event.target.value)
+          }
+          onKeyDown={(event: React.KeyboardEvent) => {
+            onEnterPress(event, updateValue);
+          }}
+          placeholder={placeholderText || ""}
+          ref={textAreaRef}
+          required={requiredFlag}
+          value={value}
+        />
+      )}
+      <IconEdit alt="Description" src={iconEditSrc} />
+    </EditInPlaceDiv>
+  );
+};
+
+export default EditInPlace;

--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -1,4 +1,3 @@
-import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 import styled, { StyledComponent } from "styled-components";
 
@@ -14,13 +13,15 @@ const EditInPlaceDiv = styled.div<Pick<Props, "minHeight">>`
 
   .edit-in-place__input {
     background-color: ${Colors.gray};
+    box-shadow: none;
     height: 100%;
+    outline: none;
     resize: none;
     width: 100%;
-  }
 
-  &.has-invalid-input {
-    box-shadow: #ff0000 0px 0px 1.5px 1px;
+    &:invalid {
+      outline: 1px solid ${Colors.red};
+    }
   }
 `;
 
@@ -73,6 +74,8 @@ const EditInPlace: React.FC<Props> = ({
 
   const [value, setValue] = useState(initialValue);
 
+  const valueIsInvalid = requiredFlag && !value?.trim();
+
   useEffect(() => {
     if (autoResizeVertically) {
       resize(textAreaRef.current);
@@ -81,7 +84,7 @@ const EditInPlace: React.FC<Props> = ({
 
   const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
     if (event.key !== "Enter") return;
-    else if (event.key === "Enter" && requiredFlag && !value?.trim()) {
+    else if (event.key === "Enter" && valueIsInvalid) {
       event.preventDefault();
       return;
     }
@@ -89,17 +92,17 @@ const EditInPlace: React.FC<Props> = ({
   };
 
   const updateValue = () => {
-    if ((requiredFlag && value?.trim()) || !requiredFlag) {
-      setEditing(false);
-      setInitialValue(value);
-      if (persistChanges) {
-        persistChanges(value);
-      }
-    } else {
+    if (valueIsInvalid) {
       setEditing(true);
       setInitialValue("");
       if (persistChanges) {
         persistChanges("");
+      }
+    } else {
+      setEditing(false);
+      setInitialValue(value);
+      if (persistChanges) {
+        persistChanges(value);
       }
     }
   };
@@ -114,9 +117,7 @@ const EditInPlace: React.FC<Props> = ({
         <BaseComponent
           as="textarea"
           autoFocus
-          className={classNames("edit-in-place__input", {
-            "has-invalid-input": requiredFlag && !value?.trim(),
-          })}
+          className="edit-in-place__input"
           maxLength={maxLengthValue}
           onBlur={updateValue}
           onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>

--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -5,8 +5,8 @@ import styled, { StyledComponent } from "styled-components";
 import Colors from "./Colors";
 import iconEditSrc from "./icons/ic_edit.svg";
 
-const EditInPlaceDiv = styled.div`
-  min-height: 100px;
+const EditInPlaceDiv = styled.div<Pick<Props, "minHeight">>`
+  min-height: ${(props) => props.minHeight}px;
   width: 100%;
   display: flex;
   flex-direction: row;
@@ -38,9 +38,8 @@ const IconEdit = styled.img`
 
 function resize(textArea: HTMLTextAreaElement | null) {
   if (!textArea) return;
-  textArea.style.height = "auto";
-  const height =
-    textArea.scrollHeight + textArea.offsetHeight - textArea.clientHeight;
+  textArea.style.height = "0";
+  const height = textArea.scrollHeight;
   textArea.style.height = `${height}px`;
 }
 
@@ -52,8 +51,9 @@ export interface Props {
   placeholderValue?: string | undefined;
   placeholderText?: string | undefined;
   maxLengthValue?: number | undefined;
+  minHeight: number;
   requiredFlag?: boolean;
-  persistChanges?: (changes: { description: string | undefined }) => void;
+  persistChanges?: (changes: string | undefined) => void;
 }
 
 const EditInPlace: React.FC<Props> = ({
@@ -66,9 +66,9 @@ const EditInPlace: React.FC<Props> = ({
   maxLengthValue,
   requiredFlag,
   persistChanges,
+  minHeight,
 }) => {
   const [editing, setEditing] = useState(false);
-
   const textAreaRef = useRef(null);
 
   const [value, setValue] = useState(initialValue);
@@ -93,19 +93,19 @@ const EditInPlace: React.FC<Props> = ({
       setEditing(false);
       setInitialValue(value);
       if (persistChanges) {
-        persistChanges({ description: value });
+        persistChanges(value);
       }
     } else {
       setEditing(true);
       setInitialValue("");
       if (persistChanges) {
-        persistChanges({ description: "" });
+        persistChanges("");
       }
     }
   };
 
   return (
-    <EditInPlaceDiv>
+    <EditInPlaceDiv minHeight={minHeight}>
       {!editing && ((requiredFlag && value) || !requiredFlag) ? (
         <BaseComponent onClick={() => setEditing(true)}>
           <span>{value || placeholderValue}</span>

--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -16,6 +16,7 @@ const EditInPlaceDiv = styled.div<Pick<Props, "minHeight">>`
     box-shadow: none;
     height: 100%;
     outline: none;
+    outline-offset: 0;
     resize: none;
     width: 100%;
 

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -15,19 +15,17 @@ const Description = styled.label`
 interface Props
   extends Pick<
     EditInPlaceProps,
-    | "placeholderValue"
-    | "placeholderText"
-    | "maxLengthValue"
-    | "requiredFlag"
-    | "persistChanges"
+    "placeholderValue" | "placeholderText" | "maxLengthValue" | "requiredFlag"
   > {
   description?: string | undefined;
+  persistChanges?: (changes: { description: string | undefined }) => void;
   setDescription: (description?: string) => void;
 }
 
 const InputDescription: React.FC<Props> = ({
   description,
   setDescription,
+  persistChanges,
   ...passThruProps
 }) => {
   return (
@@ -35,6 +33,10 @@ const InputDescription: React.FC<Props> = ({
       autoResizeVertically
       BaseComponent={Description}
       initialValue={description}
+      minHeight={100}
+      persistChanges={(description: string | undefined) =>
+        persistChanges && persistChanges({ description })
+      }
       setInitialValue={setDescription}
       {...passThruProps}
     />

--- a/src/design-system/InputDescription.tsx
+++ b/src/design-system/InputDescription.tsx
@@ -1,17 +1,8 @@
-import classNames from "classnames";
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import iconEditSrc from "./icons/ic_edit.svg";
-
-const DescriptionDiv = styled.div`
-  min-height: 100px;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-`;
+import EditInPlace, { Props as EditInPlaceProps } from "./EditInPlace";
 
 const Description = styled.label`
   color: ${Colors.forest};
@@ -21,104 +12,32 @@ const Description = styled.label`
   font-weight: 400;
 `;
 
-const IconEdit = styled.img`
-  flex: 0 0 auto;
-  height: 10px;
-  margin-left: 10px;
-  width: 10px;
-  visibility: hidden;
-
-  ${DescriptionDiv}:hover & {
-    visibility: visible;
-  }
-`;
-
-const TextArea = styled.textarea`
-  background-color: ${Colors.gray};
-  color: ${Colors.forest};
-  font-size: 13px;
-  height: 100%;
-  resize: none;
-  width: 100%;
-
-  &.has-invalid-input {
-    box-shadow: #ff0000 0px 0px 1.5px 1px;
-  }
-`;
-
-interface Props {
+interface Props
+  extends Pick<
+    EditInPlaceProps,
+    | "placeholderValue"
+    | "placeholderText"
+    | "maxLengthValue"
+    | "requiredFlag"
+    | "persistChanges"
+  > {
   description?: string | undefined;
   setDescription: (description?: string) => void;
-  placeholderValue?: string | undefined;
-  placeholderText?: string | undefined;
-  maxLengthValue?: number | undefined;
-  requiredFlag?: boolean;
-  persistChanges?: (changes: { description: string | undefined }) => void;
 }
 
 const InputDescription: React.FC<Props> = ({
   description,
   setDescription,
-  placeholderValue,
-  placeholderText,
-  maxLengthValue,
-  requiredFlag,
-  persistChanges,
+  ...passThruProps
 }) => {
-  const [editingDescription, setEditingDescription] = useState(false);
-  const [value, setValue] = useState(description);
-
-  const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
-    if (event.key !== "Enter") return;
-    else if (event.key === "Enter" && requiredFlag && !value?.trim()) {
-      event.preventDefault();
-      return;
-    }
-    onEnter();
-  };
-
-  const updateDescription = () => {
-    if ((requiredFlag && value?.trim()) || !requiredFlag) {
-      setEditingDescription(false);
-      setDescription(value);
-      if (persistChanges) {
-        persistChanges({ description: value });
-      }
-    } else {
-      setEditingDescription(true);
-      setDescription("");
-      if (persistChanges) {
-        persistChanges({ description: "" });
-      }
-    }
-  };
-
   return (
-    <DescriptionDiv>
-      {!editingDescription && ((requiredFlag && value) || !requiredFlag) ? (
-        <Description onClick={() => setEditingDescription(true)}>
-          <span>{value || placeholderValue}</span>
-        </Description>
-      ) : (
-        <Description>
-          <TextArea
-            className={classNames({
-              "has-invalid-input": requiredFlag && !value?.trim(),
-            })}
-            value={value}
-            placeholder={placeholderText || ""}
-            maxLength={maxLengthValue}
-            required={requiredFlag}
-            onBlur={updateDescription}
-            onChange={(event) => setValue(event.target.value)}
-            onKeyDown={(event) => {
-              onEnterPress(event, updateDescription);
-            }}
-          />
-        </Description>
-      )}
-      <IconEdit alt="Description" src={iconEditSrc} />
-    </DescriptionDiv>
+    <EditInPlace
+      autoResizeVertically
+      BaseComponent={Description}
+      initialValue={description}
+      setInitialValue={setDescription}
+      {...passThruProps}
+    />
   );
 };
 

--- a/src/design-system/InputNameWithIcon.tsx
+++ b/src/design-system/InputNameWithIcon.tsx
@@ -1,14 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import iconEditSrc from "./icons/ic_edit.svg";
+import EditInPlace, { Props as EditInPlaceProps } from "./EditInPlace";
 import iconFolderSrc from "./icons/ic_folder.svg";
-import InputText from "./InputText";
-
-const requiredInputStyle = {
-  outline: "none",
-};
 
 const borderStyle = `1px solid ${Colors.paleGreen}`;
 
@@ -18,29 +13,19 @@ const NameLabelDiv = styled.label`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  width: 75%,
-  padding-right: 25%;
   padding-bottom: 15px;
   border-bottom: ${borderStyle};
+  font-size: 24px;
+  font-family: Libre Baskerville;
+  font-weight: normal;
+  letter-spacing: -0.06em;
+  line-height: 24px;
 `;
 
 const IconFolder = styled.img`
   display: inline;
-  width: 12px;
-  height: 12px;
-  margin-right: 12px;
-`;
-
-const IconEdit = styled.img`
   flex: 0 0 auto;
-  height: 10px;
-  margin-left: 10px;
-  visibility: hidden;
-  width: 10px;
-
-  ${NameLabelDiv}:hover & {
-    visibility: visible;
-  }
+  margin-right: 12px;
 `;
 
 const Heading = styled.h1`
@@ -53,83 +38,38 @@ const Heading = styled.h1`
   line-height: 24px;
 `;
 
-interface Props {
+interface Props
+  extends Pick<
+    EditInPlaceProps,
+    "placeholderValue" | "placeholderText" | "maxLengthValue" | "requiredFlag"
+  > {
   name?: string | undefined;
+  persistChanges?: (changes: { name: string | undefined }) => void;
   setName: (name?: string) => void;
-  placeholderValue?: string | undefined;
-  placeholderText?: string | undefined;
-  maxLengthValue?: number | undefined;
-  requiredFlag?: boolean;
-  persistChanges?: (changes: object) => void;
   showIcon?: boolean;
 }
 
 const InputNameWithIcon: React.FC<Props> = ({
   name,
-  setName,
-  placeholderValue,
-  placeholderText,
-  maxLengthValue,
-  requiredFlag,
   persistChanges,
+  setName,
   showIcon,
+  ...passThruProps
 }) => {
-  const [editingName, setEditingName] = useState(false);
-  const [value, setValue] = useState(name);
-
-  // Reset Name field border
-  if (!editingName) requiredInputStyle.outline = "none";
-
-  const onEnterPress = (event: React.KeyboardEvent, onEnter: Function) => {
-    if (event.key !== "Enter") return;
-    onEnter();
-  };
-
-  const updateName = () => {
-    if ((requiredFlag && value?.trim()) || !requiredFlag) {
-      setEditingName(false);
-      setName(value);
-      if (persistChanges) {
-        persistChanges({ name: value });
-      }
-    } else {
-      setEditingName(true);
-      setName("");
-      if (persistChanges) {
-        persistChanges({ name: "" });
-      }
-    }
-
-    if (requiredFlag && !value?.trim()) {
-      requiredInputStyle.outline = `1px solid ${Colors.red}`;
-    } else {
-      requiredInputStyle.outline = "none";
-    }
-  };
-
   return (
     <NameLabelDiv>
-      {!editingName && ((requiredFlag && name) || !requiredFlag) ? (
-        <Heading onClick={() => setEditingName(true)}>
-          {showIcon && <IconFolder alt="folder" src={iconFolderSrc} />}
-          <span>{value || placeholderValue}</span>
-        </Heading>
-      ) : (
-        <InputText
-          type="text"
-          headerStyle={true}
-          focus={true}
-          valueEntered={value}
-          onValueChange={(value) => setValue(value)}
-          onBlur={() => updateName()}
-          onKeyDown={(event) => onEnterPress(event, updateName)}
-          maxLength={maxLengthValue}
-          placeholder={placeholderText || ""}
-          required={requiredFlag}
-          style={requiredInputStyle}
-        />
-      )}
-      <IconEdit alt="Name" src={iconEditSrc} />
+      {showIcon && <IconFolder alt="folder" src={iconFolderSrc} />}
+      <EditInPlace
+        autoResizeVertically
+        BaseComponent={Heading}
+        initialValue={name}
+        minHeight={30}
+        persistChanges={(name: string | undefined) =>
+          persistChanges && persistChanges({ name })
+        }
+        setInitialValue={setName}
+        {...passThruProps}
+      />
     </NameLabelDiv>
   );
 };


### PR DESCRIPTION
## Description of the change

Building on the input changes in #326, this applies a similar treatment to the input component that handled scenario and facility names. That involved factoring out most of the UI logic into a separate `EditInPlace` component that takes a component and produces a textarea that mirrors its styles. (I may have been _slightly_ overzealous in trashing the old form behavior in that previous PR; some of it has been resurrected here, most notably the adjustable height feature.)

There should be no regression in the description edit fields for scenarios and facilities, and the name inputs on those respective pages should now behave according to @cawarren 's specifications in our UI polish doc.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #164 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
