### PR TITLE
Fix typo in Rt promo

### DIFF
--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -53,7 +53,7 @@ const promoTexts: { [promoType: string]: string } = {
     facility by selecting it. This is based on the number of cases over time
     for that facility. To get an accurate Rt, enter case counts for previous
     days by clicking the number of cases on the right (in red) to update case
-    numbers.)`,
+    numbers.`,
 };
 
 export function getPromoText(promoType: string | null) {


### PR DESCRIPTION
## Description of the change

Remove trailing parenthesis at the end of the sentence

WAS:
![image](https://user-images.githubusercontent.com/1372946/81320764-916a6180-9046-11ea-8db2-d8cbc65def61.png)


IS:
![image](https://user-images.githubusercontent.com/1372946/81320738-86afcc80-9046-11ea-8fff-d620b3d2daf5.png)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes https://github.com/Recidiviz/covid19-dashboard/issues/336

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
