### PR TITLE
R(t) comparison chart

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -1,6 +1,8 @@
 import { lab } from "d3";
 import hexAlpha from "hex-alpha";
 
+import { RateOfSpreadType } from "../constants/EpidemicModel";
+
 export function darken(color: string, amount: number) {
   // good to use Lab color because it's perceptually uniform
   const { l, a, b } = lab(color);
@@ -54,3 +56,23 @@ export const MarkColors = {
 };
 
 export default Colors;
+
+export const rtPillColors: {
+  [key in RateOfSpreadType]: {
+    text: string;
+    border: string;
+  };
+} = {
+  [RateOfSpreadType.Controlled]: {
+    text: Colors.green,
+    border: Colors.teal,
+  },
+  [RateOfSpreadType.Infectious]: {
+    text: Colors.darkRed,
+    border: Colors.orange,
+  },
+  [RateOfSpreadType.Missing]: {
+    text: Colors.forest,
+    border: Colors.forest30,
+  },
+};

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -2,6 +2,7 @@ import { ascending } from "d3-array";
 import { formatISO, fromUnixTime, parseISO } from "date-fns";
 import { mapValues, maxBy, minBy, orderBy, uniqBy } from "lodash";
 
+import { RateOfSpreadType } from "../constants/EpidemicModel";
 import { getFacilityModelVersions } from "../database";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
 import { Facility } from "../page-multi-facility/types";
@@ -141,4 +142,14 @@ export const getOldestRt = (rtRecords: RtRecord[]) => {
 
 export const getNewestRt = (rtRecords: RtRecord[]) => {
   return maxBy(rtRecords, (rtRecord) => rtRecord.date);
+};
+
+export const rtSpreadType = (rtValue: number | null | undefined) => {
+  if (rtValue === null || rtValue === undefined) {
+    return RateOfSpreadType.Missing;
+  } else if (rtValue > 1) {
+    return RateOfSpreadType.Infectious;
+  } else {
+    return RateOfSpreadType.Controlled;
+  }
 };

--- a/src/page-multi-facility/FacilityRowRtValuePill.tsx
+++ b/src/page-multi-facility/FacilityRowRtValuePill.tsx
@@ -4,38 +4,19 @@ import styled from "styled-components";
 
 import { RateOfSpreadType } from "../constants/EpidemicModel";
 import ChartTooltip from "../design-system/ChartTooltip";
-import Colors from "../design-system/Colors";
+import { rtPillColors } from "../design-system/Colors";
 import PillCircle from "../design-system/PillCircle";
+import { rtSpreadType } from "../infection-model/rt";
 import {
   TooltipContents,
   TooltipLabel,
   TooltipValue,
 } from "../rt-timeseries/RtTimeseries";
 
-const pillColors: {
-  [key in RateOfSpreadType]: {
-    text: string;
-    border: string;
-  };
-} = {
-  [RateOfSpreadType.Controlled]: {
-    text: Colors.green,
-    border: Colors.teal,
-  },
-  [RateOfSpreadType.Infectious]: {
-    text: Colors.darkRed,
-    border: Colors.orange,
-  },
-  [RateOfSpreadType.Missing]: {
-    text: Colors.forest,
-    border: Colors.forest30,
-  },
-};
-
 const RtValuePill = styled.div<{ spreadType: RateOfSpreadType }>`
   ${PillCircle} {
-    border-color: ${(props) => pillColors[props.spreadType].border};
-    color: ${(props) => pillColors[props.spreadType].text};
+    border-color: ${(props) => rtPillColors[props.spreadType].border};
+    color: ${(props) => rtPillColors[props.spreadType].text};
   }
 
   &:hover {
@@ -68,16 +49,6 @@ const PillTooltip = styled.div`
 interface Props {
   latestRt: number | null | undefined;
 }
-
-const rtSpreadType = (latestRt: number | null | undefined) => {
-  if (latestRt === null || latestRt === undefined) {
-    return RateOfSpreadType.Missing;
-  } else if (latestRt > 1) {
-    return RateOfSpreadType.Infectious;
-  } else {
-    return RateOfSpreadType.Controlled;
-  }
-};
 
 const isValidRt = (rtValue: number | null | undefined) =>
   rtValue !== null && rtValue !== undefined;

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -12,6 +12,7 @@ import { useFlag } from "../feature-flags";
 import useFacilitiesRtData from "../hooks/useFacilitiesRtData";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
+import RtComparisonChart from "../rt-comparison-chart";
 import useScenario from "../scenario-context/useScenario";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
@@ -156,7 +157,11 @@ const MultiFacilityImpactDashboard: React.FC = () => {
     </>
   );
 
-  const rateOfSpreadPanel = <> </>;
+  const rateOfSpreadPanel = (
+    <>
+      <RtComparisonChart />
+    </>
+  );
   const showRateOfSpreadTab = useFlag(["showRateOfSpreadTab"]);
   return (
     <MultiFacilityImpactDashboardContainer>

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import { ResponsiveOrdinalFrame } from "semiotic";
 import styled from "styled-components";
 
-import { RateOfSpreadType } from "../constants/EpidemicModel";
 import ChartWrapper from "../design-system/ChartWrapper";
-import Colors from "../design-system/Colors";
+import Colors, { rtPillColors } from "../design-system/Colors";
+import { rtSpreadType } from "../infection-model/rt";
 
 const RtComparisonChartWrapper = styled(ChartWrapper)``;
 
@@ -31,39 +31,8 @@ const RtLabel = styled.text`
   text-anchor: middle;
 `;
 
-// TODO: this is copypasta from the pill component, factor out for reuse
-const pillColors: {
-  [key in RateOfSpreadType]: {
-    text: string;
-    border: string;
-  };
-} = {
-  [RateOfSpreadType.Controlled]: {
-    text: Colors.green,
-    border: Colors.teal,
-  },
-  [RateOfSpreadType.Infectious]: {
-    text: Colors.darkRed,
-    border: Colors.orange,
-  },
-  [RateOfSpreadType.Missing]: {
-    text: Colors.forest,
-    border: Colors.forest30,
-  },
-};
-
-const rtSpreadType = (rtValue: number | null | undefined) => {
-  if (rtValue === null || rtValue === undefined) {
-    return RateOfSpreadType.Missing;
-  } else if (rtValue > 1) {
-    return RateOfSpreadType.Infectious;
-  } else {
-    return RateOfSpreadType.Controlled;
-  }
-};
-
 const getRtColors = (rtValue: number) => {
-  return pillColors[rtSpreadType(rtValue)];
+  return rtPillColors[rtSpreadType(rtValue)];
 };
 
 const borderColorScale = (rtValue: number) => {

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -201,7 +201,6 @@ const htmlAnnotationRules = (args: {
     case "htmlOLabels":
       return renderHtmlOLabels({ categories });
     case "column-hover":
-      console.log(args);
       return renderHtmlHoverState({ d, rScale });
   }
   return null;
@@ -255,8 +254,9 @@ type RtComparisonData = {
 const RtComparisonChart: React.FC<{ data: RtComparisonData[] }> = ({
   data,
 }) => {
-  // TODO: calculate this from data
-  const maxExtent = 5.0;
+  const maxExtent = Math.ceil(
+    Math.max(...data.map((record) => record.values.high90 || 0)),
+  );
 
   return (
     <RtComparisonChartWrapper>

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -1,0 +1,210 @@
+import flatten from "lodash/flatten";
+import numeral from "numeral";
+import React from "react";
+import { ResponsiveOrdinalFrame } from "semiotic";
+import styled from "styled-components";
+
+import { RateOfSpreadType } from "../constants/EpidemicModel";
+import ChartWrapper from "../design-system/ChartWrapper";
+import Colors from "../design-system/Colors";
+
+const RtComparisonChartWrapper = styled(ChartWrapper)``;
+
+const CILine = styled.line`
+  stroke-width: 3px;
+`;
+
+const CI90Line = styled(CILine)`
+  stroke-opacity: 0.3;
+`;
+
+const RtPill = styled.circle`
+  fill: #e9ecec;
+  stroke-width: 1px;
+`;
+
+const RtLabel = styled.text`
+  dominant-baseline: central;
+  font-family: "Poppins", sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  text-anchor: middle;
+`;
+
+// TODO: this is copypasta from the pill component, factor out for reuse
+const pillColors: {
+  [key in RateOfSpreadType]: {
+    text: string;
+    border: string;
+  };
+} = {
+  [RateOfSpreadType.Controlled]: {
+    text: Colors.green,
+    border: Colors.teal,
+  },
+  [RateOfSpreadType.Infectious]: {
+    text: Colors.darkRed,
+    border: Colors.orange,
+  },
+  [RateOfSpreadType.Missing]: {
+    text: Colors.forest,
+    border: Colors.forest30,
+  },
+};
+
+const rtSpreadType = (rtValue: number | null | undefined) => {
+  if (rtValue === null || rtValue === undefined) {
+    return RateOfSpreadType.Missing;
+  } else if (rtValue > 1) {
+    return RateOfSpreadType.Infectious;
+  } else {
+    return RateOfSpreadType.Controlled;
+  }
+};
+
+const getRtColors = (rtValue: number) => {
+  return pillColors[rtSpreadType(rtValue)];
+};
+
+const borderColorScale = (rtValue: number) => {
+  return getRtColors(rtValue).border;
+};
+
+const textColorScale = (rtValue: number) => {
+  return getRtColors(rtValue).text;
+};
+
+const pillRadius = 16;
+
+const PillsWithConfidenceIntervals = ({
+  data,
+  rScale,
+}: {
+  data: any;
+  rScale: (x: number) => number;
+}) => {
+  const elementsToRender = Object.values(data).map((d: any) => {
+    // we've only provided one rAccessor, so we only expect one piece
+    const markRecord = d.pieces[0];
+    const noData = markRecord.data.Rt === undefined;
+    return (
+      <g key={markRecord.renderKey}>
+        {!noData && (
+          <CI90Line
+            stroke={borderColorScale(markRecord.data.Rt)}
+            x1={rScale(markRecord.data.low90)}
+            x2={rScale(markRecord.data.high90)}
+            y1={d.middle}
+            y2={d.middle}
+          />
+        )}
+        <RtPill
+          cx={markRecord.middle}
+          cy={d.middle}
+          r={pillRadius}
+          stroke={borderColorScale(markRecord.data.Rt)}
+        />
+        <RtLabel
+          fill={textColorScale(markRecord.data.Rt)}
+          x={markRecord.middle}
+          y={d.middle}
+        >
+          {noData ? "?" : numeral(markRecord.data.Rt).format("0.0[0]")}
+        </RtLabel>
+      </g>
+    );
+  });
+  return flatten(elementsToRender);
+};
+
+const margin = { top: 12, bottom: 30, left: 180, right: 12 };
+const oLabelRightMargin = 6;
+const oLabelOffset = margin.left;
+const oLabelWidth = oLabelOffset - pillRadius - oLabelRightMargin;
+const oLabelHeight = 50;
+
+const OLabelContainer = styled.div`
+  position: relative;
+  left: -${margin.left}px;
+  width: ${oLabelWidth}px;
+`;
+
+const OLabel = styled.div`
+  align-items: center;
+  color: ${Colors.forest};
+  display: flex;
+  font-size: 14px;
+  font-weight: 600;
+  height: ${oLabelHeight}px;
+  width: ${oLabelWidth}px;
+`;
+
+const OLabelText = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: ${oLabelWidth}px;
+`;
+
+const renderHtmlOLabels = ({ d, categories }: { d: any; categories: any }) => {
+  if (d.type === "htmlOLabels") {
+    return (
+      <OLabelContainer>
+        {Object.values(categories).map((category: any) => (
+          <OLabel key={category.pieces[0].renderKey}>
+            <OLabelText>{category.name}</OLabelText>
+          </OLabel>
+        ))}
+      </OLabelContainer>
+    );
+  }
+  return null;
+};
+
+const RtComparisonChart: React.FC = () => {
+  // TODO: not this
+  const fakeData = [
+    { name: "facility 1", id: "abc123", Rt: 1.9, low90: 0.4, high90: 3.8 },
+    {
+      name:
+        "facility 2 what has a long name that may not fit on my god how long does it have to be",
+      id: "def456",
+      Rt: 0.6,
+      low90: 0,
+      high90: 1.5,
+    },
+    { name: "facility with no data and a long name", id: "xyz789" },
+  ];
+  return (
+    <RtComparisonChartWrapper>
+      <ResponsiveOrdinalFrame
+        annotations={[
+          { type: "htmlOLabels" },
+          {
+            type: "r",
+            value: 1,
+            color: Colors.darkRed,
+            disable: ["connector"],
+          },
+        ]}
+        axes={[{ orient: "bottom", baseline: false }]}
+        data={fakeData}
+        htmlAnnotationRules={renderHtmlOLabels}
+        margin={margin}
+        oAccessor="name"
+        pixelColumnWidth={oLabelHeight}
+        projection="horizontal"
+        // our custom mark will consume the entire data structure,
+        // but this ensures the chart's max extent will be big enough for everything
+        rAccessor="high90"
+        rExtent={[0]}
+        renderKey="id"
+        responsiveWidth
+        size={[300]}
+        type={PillsWithConfidenceIntervals}
+      />
+    </RtComparisonChartWrapper>
+  );
+};
+
+export default RtComparisonChart;

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -5,23 +5,22 @@ import RtComparisonChart from "./RtComparisonChart";
 const RtComparisonChartContainer: React.FC = () => {
   // TODO: not this
   const fakeData = [
-    {
-      name: "facility 1",
-      id: "abc123",
-      values: { Rt: 1.9, low90: 0.4, high90: 3.8 },
-    },
-    {
-      name:
-        "facility 2 what has a long name that may not fit on my god how long does it have to be",
-      id: "def456",
-      values: {
-        Rt: 0.6,
-        low90: 0,
-        high90: 1.5,
-      },
-    },
-    { name: "facility with no data and a long name", id: "xyz789", values: {} },
-  ];
+    // {
+    //   name: "facility 1",
+    //   id: "abc123",
+    //   values: { Rt: 1.9, low90: 0.4, high90: 3.8 },
+    // },
+    // {
+    //   name: "facility 2 what has a long name ",
+    //   id: "def456",
+    //   values: {
+    //     Rt: 0.6,
+    //     low90: 0,
+    //     high90: 1.5,
+    //   },
+    // },
+    // { name: "facility with no data and a long name", id: "xyz789", values: {} },
+  ] as any;
 
   return <RtComparisonChart data={fakeData} />;
 };

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -3,7 +3,27 @@ import React from "react";
 import RtComparisonChart from "./RtComparisonChart";
 
 const RtComparisonChartContainer: React.FC = () => {
-  return <RtComparisonChart />;
+  // TODO: not this
+  const fakeData = [
+    {
+      name: "facility 1",
+      id: "abc123",
+      values: { Rt: 1.9, low90: 0.4, high90: 3.8 },
+    },
+    {
+      name:
+        "facility 2 what has a long name that may not fit on my god how long does it have to be",
+      id: "def456",
+      values: {
+        Rt: 0.6,
+        low90: 0,
+        high90: 1.5,
+      },
+    },
+    { name: "facility with no data and a long name", id: "xyz789", values: {} },
+  ];
+
+  return <RtComparisonChart data={fakeData} />;
 };
 
 export default RtComparisonChartContainer;

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+import RtComparisonChart from "./RtComparisonChart";
+
+const RtComparisonChartContainer: React.FC = () => {
+  return <RtComparisonChart />;
+};
+
+export default RtComparisonChartContainer;

--- a/src/rt-comparison-chart/index.tsx
+++ b/src/rt-comparison-chart/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./RtComparisonChartContainer";
+export * from "./RtComparisonChartContainer";


### PR DESCRIPTION
## Description of the change

Adds a new type of chart (currently with fake data and behind a flag) for comparing Rt across all facilities in a scenario. The actual data handling will follow in a subsequent PR.

![Screen Shot 2020-05-07 at 3 23 12 PM](https://user-images.githubusercontent.com/5385319/81350949-f9856b80-9077-11ea-9fda-e7c9cb2603cb.png)

![Screen Shot 2020-05-07 at 3 25 39 PM](https://user-images.githubusercontent.com/5385319/81350953-fb4f2f00-9077-11ea-9e04-2bc88757424d.png)

The only significant issue I ran into was replicating the feature whereby the facility name changes color on hover. The charting library doesn't support it natively (not surprising as it's a pretty rare thing to see in a chart IMO) and while the API is pretty flexible I was finding it inordinately difficult to get it to work. Personally I don't think the chart suffers much without it so hopefully it's OK to just leave it out @cawarren ? We could come back to it later but it didn't seem worth holding up this PR over any further at this point.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #202 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
