### PR TITLE
Explicitly sets modelInputs.observedAt on the facility details page

### DIFF
--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -120,8 +120,8 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
 
   const save = () => {
     if (facilityName) {
-      // Set observedAt to right now when updating a facility form from this input form
-      const modelUpdate = model[0];
+      // Set observedAt to right now when updating a facility from this input form
+      const modelUpdate = Object.assign({}, model[0]);
       modelUpdate.observedAt = new Date();
 
       saveFacility(scenarioId, {

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -120,12 +120,16 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
 
   const save = () => {
     if (facilityName) {
+      // Set observedAt to right now when updating a facility form from this input form
+      const modelUpdate = model[0];
+      modelUpdate.observedAt = new Date();
+
       saveFacility(scenarioId, {
         id: facility?.id,
         name: facilityName || null,
         description: description || null,
         systemType: systemType || null,
-        modelInputs: model[0],
+        modelInputs: modelUpdate,
       }).then(() => {
         navigate("/");
       });


### PR DESCRIPTION
## Description of the change

As discussed in [this Slack thread](https://recidiviz.slack.com/archives/G010VACT8F2/p1588900629168100), there is a bug causing the `modelInputs.observedAt` date (and consequently the latest `modelVersions.observedAt` date) to be set to whatever is the most recent `observedAt` date in the existing list of model versions. I don't know if this is the most elegant fix, but it works in local testing. The approach is to eliminate any uncertainty or ambiguity and just set `observedAt` to right now when entering updates in this form, which is the desired behavior.

Local testing:
- Updated the facility through the facility input form before and after the change. The buggy behavior happens before the change and not after. After, the modelInputs and modelVersions observedAt fields are set to right now
- Tested the add cases modal after the change and was still able to successfully create an observation/version for a day in the past. It created a `modelVersions` with the right `observedAt` date and _did not_ update `facility.modelInputs`, all as expected. I think went back to the facility details page and made another update and it successfully updated `facility.modelInputs` and added a new `modelVersions`, both with right now as the `observedAt` date.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
