### PR TITLE
[WIP] [Excalibur] UI polish: add tooltip, allow tooltip placement option to be passed in

### DIFF
--- a/src/design-system/HelpButtonWithTooltip.tsx
+++ b/src/design-system/HelpButtonWithTooltip.tsx
@@ -19,11 +19,27 @@ const HelpButton = styled.span`
 
 interface Props {
   children: React.ReactNode;
+  placement:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
 }
 
 const HelpButtonWithTooltip: React.FC<Props> = (props) => {
   return (
-    <Tooltip content={props.children}>
+    <Tooltip content={props.children} placement={props.placement}>
       <HelpButton>?</HelpButton>
     </Tooltip>
   );

--- a/src/design-system/InputDate.tsx
+++ b/src/design-system/InputDate.tsx
@@ -84,7 +84,11 @@ const InputDate: React.FC<InputBaseProps<Date>> = (props) => {
 
   return (
     <InputContainer>
-      <InputLabelAndHelp label={labelAbove} labelHelp={labelHelp} />
+      <InputLabelAndHelp
+        label={labelAbove}
+        labelHelp={labelHelp}
+        placement="right"
+      />
       <DatePicker
         calendarIcon={null}
         clearIcon={null}

--- a/src/design-system/InputLabelAndHelp.tsx
+++ b/src/design-system/InputLabelAndHelp.tsx
@@ -8,6 +8,22 @@ interface Props {
   label?: React.ReactNode;
   labelHelp?: React.ReactNode;
   softened?: boolean;
+  placement:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
 }
 
 const LabelContainer = styled.div`
@@ -25,7 +41,9 @@ const InputLabelAndHelp: React.FC<Props> = (props) => {
     <LabelContainer>
       <TextLabel softened={props.softened}>{props.label}</TextLabel>
       {props.labelHelp && (
-        <HelpButtonWithTooltip>{props.labelHelp}</HelpButtonWithTooltip>
+        <HelpButtonWithTooltip placement={props.placement}>
+          {props.labelHelp}
+        </HelpButtonWithTooltip>
       )}
     </LabelContainer>
   );

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -67,7 +67,11 @@ const InputText: React.FC<Props> = (props) => {
 
   return (
     <TextInputContainer>
-      <InputLabelAndHelp label={props.labelAbove} labelHelp={props.labelHelp} />
+      <InputLabelAndHelp
+        label={props.labelAbove}
+        labelHelp={props.labelHelp}
+        placement="right"
+      />
       <InputWrapper as="div" style={props.style}>
         <WrappedInput
           type={props.type}

--- a/src/design-system/Tooltip.tsx
+++ b/src/design-system/Tooltip.tsx
@@ -87,6 +87,22 @@ const TooltipArrowDiv = styled.div`
 interface Props {
   content: React.ReactNode;
   children: React.ReactNode;
+  placement:
+    | "auto"
+    | "auto-start"
+    | "auto-end"
+    | "top"
+    | "top-start"
+    | "top-end"
+    | "bottom"
+    | "bottom-start"
+    | "bottom-end"
+    | "right"
+    | "right-start"
+    | "right-end"
+    | "left"
+    | "left-start"
+    | "left-end";
 }
 
 const Tooltip: React.FC<Props> = (props) => {
@@ -107,7 +123,7 @@ const Tooltip: React.FC<Props> = (props) => {
         )}
       </Reference>
       {showTooltip && (
-        <Popper placement="right">
+        <Popper placement={props.placement}>
           {({ ref, style, placement, arrowProps }) => (
             <TooltipContentsDiv
               ref={ref}

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -177,7 +177,10 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
             <AddCasesModal
               facility={facility}
               trigger={
-                <Tooltip content="Click to add new or previous day cases">
+                <Tooltip
+                  content="Click to add new or previous day cases"
+                  placement="right"
+                >
                   <AddCasesButton>
                     <ImgDuplicate alt="" src={iconDuplicatePath} />
                     Add or update cases

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -141,6 +141,7 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
                   facility={facility}
                   trigger={
                     <Tooltip
+                      placement="right"
                       content={
                         <div>Click to add new or previous day cases</div>
                       }

--- a/src/page-multi-facility/ToggleRow.tsx
+++ b/src/page-multi-facility/ToggleRow.tsx
@@ -25,7 +25,7 @@ const ToggleRow: React.FC<Props> = (props) => {
 
   return (
     <ToggleRowContainer>
-      <InputLabelAndHelp softened {...props} />
+      <InputLabelAndHelp softened {...props} placement="right" />
       <InputToggle toggled={toggled} onChange={onToggle} />
     </ToggleRowContainer>
   );

--- a/src/page-response-impact/RtSummaryStats.tsx
+++ b/src/page-response-impact/RtSummaryStats.tsx
@@ -4,6 +4,8 @@ import { ResponsiveOrdinalFrame } from "semiotic";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
+import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
+import { Spacer } from "../design-system/Spacer";
 import { RtData, RtRecord } from "../infection-model/rt";
 import { RtDataMapping } from "../page-multi-facility/FacilityContext";
 import * as rtStats from "./rtStatistics";
@@ -139,6 +141,10 @@ const RtSummaryStats: React.FC<Props> = ({ rtData }) => {
         <LegendContainer>
           <LegendSpan />
           <div>{`Facilities with R(t) < 1.0`}</div>
+          <Spacer x={5} />
+          <HelpButtonWithTooltip>
+            {`An R(t) < 1.0 means the virus will stop spreading. An R(t) > 1.0 means the virus will spread quickly.`}
+          </HelpButtonWithTooltip>
         </LegendContainer>
         <RtSummaryText className="mt-5 mb-5">
           Average R(t) reduction across all facilities since first confirmed

--- a/src/page-response-impact/RtSummaryStats.tsx
+++ b/src/page-response-impact/RtSummaryStats.tsx
@@ -142,7 +142,7 @@ const RtSummaryStats: React.FC<Props> = ({ rtData }) => {
           <LegendSpan />
           <div>{`Facilities with R(t) < 1.0`}</div>
           <Spacer x={5} />
-          <HelpButtonWithTooltip>
+          <HelpButtonWithTooltip placement="top">
             {`An R(t) < 1.0 means the virus will stop spreading. An R(t) > 1.0 means the virus will spread quickly.`}
           </HelpButtonWithTooltip>
         </LegendContainer>

--- a/src/rt-timeseries/RtTimeseries.tsx
+++ b/src/rt-timeseries/RtTimeseries.tsx
@@ -106,7 +106,7 @@ const RtTimeseries: React.FC<Props> = ({ data }) => {
     <RtTimeseriesWrapper>
       <ChartHeader>
         <ChartTitle>Rate of Spread</ChartTitle>
-        <HelpButtonWithTooltip>
+        <HelpButtonWithTooltip placement="right">
           This chart shows the rate of spread of Covid-19 over time. When the Rt
           value is above 1 (the red line), the virus is spreading. If the Rt
           value is below 1, the virus is on track to be extinguished at this


### PR DESCRIPTION
## Description of the change

Successfully adds Excalibur tooltip to the right. But do we want the tooltip to be on the top / is this feature important?

//

WIP: Add placement option for Tooltip 

With this commit, placement="right" looks same as before.

❓But placement="top" has design errors, am not sure where to fix them yet. Do in CSS or use some sort of "tethering" library that determines the position?

Will need to check placement="bottom" and placement="left" as well, if needed.

❓Not sure if possible to make placement optional in TypeScript, with "right" the default value? But limited to the available values from the Popper library.

![tooltip](https://user-images.githubusercontent.com/1372946/81363149-7d9b1b80-9097-11ea-8732-b77b360e6e5e.gif)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes part of https://github.com/Recidiviz/covid19-dashboard/issues/300

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
