### PR TITLE
Add real data to the Rt comparison chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-is": "^16.13.1",
     "react-popper": "^2.1.0",
     "react-spinners": "^0.8.1",
-    "react-tabs": "^3.1.0",
     "react-virtualized": "^9.21.2",
     "react-virtualized-auto-sizer": "^1.0.2",
     "regenerator-runtime": "^0.13.5",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@types/react-tabs": "^2.3.1",
     "babel-jest": "^25.4.0",
     "jest": "^25.4.0",
+    "jest-date-mock": "^1.0.8",
     "jest-styled-components": "^7.0.2",
     "ts-jest": "^25.4.0"
   }

--- a/setupTests.tsx
+++ b/setupTests.tsx
@@ -1,2 +1,3 @@
 import "@testing-library/jest-dom";
 import "jest-styled-components";
+import "jest-date-mock";

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -1,3 +1,10 @@
+import { Facilities } from "../page-multi-facility/types";
+
 // Date Format Constants
 export const MMMD = "MMM d";
 export const MMMMdyyyy = "MMMM d, yyyy";
+
+export type FetchedFacilities = {
+  data: Facilities;
+  loading: boolean;
+};

--- a/src/infection-model/__tests__/rt.test.tsx
+++ b/src/infection-model/__tests__/rt.test.tsx
@@ -1,4 +1,6 @@
-import { getNewestRt, getOldestRt } from "../rt";
+import { advanceTo } from "jest-date-mock";
+
+import { getDaysAgoRt, getNewestRt, getOldestRt } from "../rt";
 
 describe("getNewestRt and getOldestRt", () => {
   const rtRecords = [
@@ -15,5 +17,12 @@ describe("getNewestRt and getOldestRt", () => {
 
   test("getOldestRt returns the oldest RTRecord", () => {
     expect(getOldestRt(rtRecords)).toEqual(rtRecords[1]);
+  });
+
+  test("getDaysAgoRt returns the newest record that is at least X days old", () => {
+    advanceTo(new Date(2020, 4, 5, 12));
+    expect(getDaysAgoRt(rtRecords, 0)).toEqual(rtRecords[3]);
+    expect(getDaysAgoRt(rtRecords, 1)).toEqual(rtRecords[4]);
+    expect(getDaysAgoRt(rtRecords, 5)).toEqual(rtRecords[0]);
   });
 });

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -1,5 +1,10 @@
 import { ascending } from "d3-array";
-import { formatISO, fromUnixTime, parseISO } from "date-fns";
+import {
+  differenceInCalendarDays,
+  formatISO,
+  fromUnixTime,
+  parseISO,
+} from "date-fns";
 import { mapValues, maxBy, minBy, orderBy, uniqBy } from "lodash";
 
 import { RateOfSpreadType } from "../constants/EpidemicModel";
@@ -142,6 +147,16 @@ export const getOldestRt = (rtRecords: RtRecord[]) => {
 
 export const getNewestRt = (rtRecords: RtRecord[]) => {
   return maxBy(rtRecords, (rtRecord) => rtRecord.date);
+};
+
+export const getDaysAgoRt = (rtRecords: RtRecord[], daysAgo: number) => {
+  const today = new Date();
+  return maxBy(
+    rtRecords.filter(
+      (record) => differenceInCalendarDays(today, record.date) >= daysAgo,
+    ),
+    "date",
+  );
 };
 
 export const rtSpreadType = (rtValue: number | null | undefined) => {

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -1,6 +1,5 @@
 import { navigate } from "gatsby";
 import React, { useContext, useEffect, useState } from "react";
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import styled from "styled-components";
 
 import { FetchedFacilities } from "../constants";
@@ -50,54 +49,32 @@ const AddFacilityButtonText = styled.span`
   vertical-align: middle;
 `;
 
-const ScenarioTabs = styled.div`
-  .react-tabs {
-    &__tab-list {
-      display: flex;
-      flex-direction: row;
-      justify-content: flex-end;
-      cursor: pointer;
-    }
-    &__tab {
-      opacity: 0.7;
-      margin: 0 0 0 32px;
-      &--selected {
-        opacity: 1;
-        border-bottom: 4px solid ${Colors.teal};
-        padding-bottom: 1.5rem;
-      }
-    }
-  }
+const ScenarioTabs = styled.div``;
+
+const ScenarioTabList = styled.ul`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  cursor: pointer;
 `;
 
-const ScenarioPanelsDiv = styled.div`
-  .panel-shown {
-    display: block;
-  }
-  .panel-hidden {
-    display: none;
-  }
+const ScenarioTab = styled.li<{ active?: boolean }>`
+  opacity: 0.7;
+  margin: 0 0 0 32px;
+
+  ${(props) =>
+    props.active
+      ? `
+    opacity: 1;
+    border-bottom: 4px solid ${Colors.teal};
+    padding-bottom: 1.5rem;
+  `
+      : null}
 `;
 
 interface ScenarioPanelsProps {
   selectedTabIndex: number;
 }
-
-// This is necessary so we don't reload the tab details while switching tabs
-// since that makes the UI slow.
-const ScenarioPanels: React.FC<ScenarioPanelsProps> = (props) => {
-  const panelChildren = React.Children.toArray(props.children).map(
-    (child, i) => (
-      <div
-        key={i}
-        className={props.selectedTabIndex == i ? "panel-shown" : "panel-hidden"}
-      >
-        {child}
-      </div>
-    ),
-  );
-  return <ScenarioPanelsDiv>{panelChildren}</ScenarioPanelsDiv>;
-};
 
 const MultiFacilityImpactDashboard: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
@@ -173,26 +150,26 @@ const MultiFacilityImpactDashboard: React.FC = () => {
             <AddFacilityButtonText>Add Facility</AddFacilityButtonText>
           </AddFacilityButton>
           <ScenarioTabs>
-            <Tabs selectedIndex={selectedTab} onSelect={setSelectedTab}>
-              <TabList>
-                <Tab>
-                  <TextLabel padding={false}>Projections</TextLabel>
-                </Tab>
-                {showRateOfSpreadTab ? (
-                  <Tab>
-                    <TextLabel padding={false}>Rate of spread</TextLabel>
-                  </Tab>
-                ) : null}
-              </TabList>
-              <TabPanel />
-              {showRateOfSpreadTab ? <TabPanel /> : null}
-            </Tabs>
+            <ScenarioTabList>
+              <ScenarioTab
+                active={selectedTab === 0}
+                onClick={() => setSelectedTab(0)}
+              >
+                <TextLabel padding={false}>Projections</TextLabel>
+              </ScenarioTab>
+              {showRateOfSpreadTab ? (
+                <ScenarioTab
+                  active={selectedTab === 1}
+                  onClick={() => setSelectedTab(1)}
+                >
+                  <TextLabel padding={false}>Rate of spread</TextLabel>
+                </ScenarioTab>
+              ) : null}
+            </ScenarioTabList>
           </ScenarioTabs>
         </div>
-        <ScenarioPanels selectedTabIndex={selectedTab}>
-          {projectionsPanel}
-          {showRateOfSpreadTab && <RateOfSpreadPanel facilities={facilities} />}
-        </ScenarioPanels>
+        {selectedTab === 0 && projectionsPanel}
+        {selectedTab === 1 && <RateOfSpreadPanel facilities={facilities} />}
       </div>
     </MultiFacilityImpactDashboardContainer>
   );

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import styled from "styled-components";
 
+import { FetchedFacilities } from "../constants";
 import { getFacilities } from "../database";
 import Colors from "../design-system/Colors";
 import iconAddSrc from "../design-system/icons/ic_add.svg";
@@ -12,11 +13,11 @@ import { useFlag } from "../feature-flags";
 import useFacilitiesRtData from "../hooks/useFacilitiesRtData";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
-import RtComparisonChart from "../rt-comparison-chart";
 import useScenario from "../scenario-context/useScenario";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRow from "./FacilityRow";
 import ProjectionsHeader from "./ProjectionsHeader";
+import RateOfSpreadPanel from "./RateOfSpreadPanel";
 import ScenarioSidebar from "./ScenarioSidebar";
 import { Facilities } from "./types";
 
@@ -105,7 +106,7 @@ const MultiFacilityImpactDashboard: React.FC = () => {
   const { setFacility } = useContext(FacilityContext);
   const useRt = useFlag(["useRt"]);
 
-  const [facilities, setFacilities] = useState({
+  const [facilities, setFacilities] = useState<FetchedFacilities>({
     data: [] as Facilities,
     loading: true,
   });
@@ -157,11 +158,6 @@ const MultiFacilityImpactDashboard: React.FC = () => {
     </>
   );
 
-  const rateOfSpreadPanel = (
-    <>
-      <RtComparisonChart />
-    </>
-  );
   const showRateOfSpreadTab = useFlag(["showRateOfSpreadTab"]);
   return (
     <MultiFacilityImpactDashboardContainer>
@@ -195,7 +191,7 @@ const MultiFacilityImpactDashboard: React.FC = () => {
         </div>
         <ScenarioPanels selectedTabIndex={selectedTab}>
           {projectionsPanel}
-          {rateOfSpreadPanel}
+          {showRateOfSpreadTab && <RateOfSpreadPanel facilities={facilities} />}
         </ScenarioPanels>
       </div>
     </MultiFacilityImpactDashboardContainer>

--- a/src/page-multi-facility/PanelHeader.tsx
+++ b/src/page-multi-facility/PanelHeader.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+
+const HeaderContainer = styled.div`
+  border-color: ${Colors.opacityGray};
+`;
+
+const PanelHeader: React.FC = ({ children }) => {
+  return (
+    <HeaderContainer className="border-t border-b mb-5 py-2 flex flex-row">
+      {children}
+    </HeaderContainer>
+  );
+};
+
+export default PanelHeader;
+
+export const PanelHeaderText = styled.div`
+  color: ${Colors.forest};
+  opacity: 0.7;
+  font-family: "Poppins", sans-serif;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 16px;
+`;

--- a/src/page-multi-facility/ProjectionsHeader.tsx
+++ b/src/page-multi-facility/ProjectionsHeader.tsx
@@ -1,22 +1,17 @@
 import React from "react";
-import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
-import ProjectionsLegend, { LegendText } from "./ProjectionsLegend";
-
-const HeaderContainer = styled.div`
-  border-color: ${Colors.opacityGray};
-`;
+import PanelHeader, { PanelHeaderText } from "./PanelHeader";
+import ProjectionsLegend from "./ProjectionsLegend";
 
 const ProjectionsHeader: React.FC = () => {
   return (
-    <HeaderContainer className="border-t border-b mb-5 py-2 flex flex-row">
+    <PanelHeader>
       <div className="w-2/5 flex flex-row">
-        <LegendText className="w-1/4">Cases</LegendText>
-        <LegendText className="w-3/4">Facility</LegendText>
+        <PanelHeaderText className="w-1/4">Cases</PanelHeaderText>
+        <PanelHeaderText className="w-3/4">Facility</PanelHeaderText>
       </div>
       <ProjectionsLegend />
-    </HeaderContainer>
+    </PanelHeader>
   );
 };
 

--- a/src/page-multi-facility/ProjectionsLegend.tsx
+++ b/src/page-multi-facility/ProjectionsLegend.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import Colors, { MarkColors as markColors } from "../design-system/Colors";
+import { MarkColors as markColors } from "../design-system/Colors";
+import { PanelHeaderText } from "./PanelHeader";
 
 const LegendItem = styled.div`
   display: flex;
@@ -16,33 +17,24 @@ const LegendCircle = styled.div`
   margin-right: 4px;
 `;
 
-export const LegendText = styled.div`
-  color: ${Colors.forest};
-  opacity: 0.7;
-  font-family: "Poppins", sans-serif;
-  font-size: 9px;
-  font-weight: 600;
-  line-height: 16px;
-`;
-
 const ProjectionsLegend: React.FC = () => {
   return (
     <div className="w-3/5 flex flex-row justify-start">
       <LegendItem className="mr-6">
         <LegendCircle color={markColors.fatalities} />
-        <LegendText>Fatalities</LegendText>
+        <PanelHeaderText>Fatalities</PanelHeaderText>
       </LegendItem>
       <LegendItem className="mr-6">
         <LegendCircle color={markColors.exposed} />
-        <LegendText>Exposed</LegendText>
+        <PanelHeaderText>Exposed</PanelHeaderText>
       </LegendItem>
       <LegendItem className="mr-6">
         <LegendCircle color={markColors.infectious} />
-        <LegendText>Infectious</LegendText>
+        <PanelHeaderText>Infectious</PanelHeaderText>
       </LegendItem>
       <LegendItem className="mr-6">
         <LegendCircle color={markColors.hospitalized} />
-        <LegendText>Hospitalized</LegendText>
+        <PanelHeaderText>Hospitalized</PanelHeaderText>
       </LegendItem>
     </div>
   );

--- a/src/page-multi-facility/RateOfSpreadPanel.tsx
+++ b/src/page-multi-facility/RateOfSpreadPanel.tsx
@@ -1,0 +1,84 @@
+import classNames from "classnames";
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { FetchedFacilities } from "../constants";
+import Loading from "../design-system/Loading";
+import RtComparisonChart from "../rt-comparison-chart";
+import PanelHeader, { PanelHeaderText } from "./PanelHeader";
+
+const SpreadContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const DataButtons = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const DataButton = styled(PanelHeaderText)`
+  margin-left: 2em;
+  opacity: 0.4;
+
+  &.RtDataButton--active {
+    opacity: 0.7;
+  }
+`;
+
+const RateOfSpreadPanel: React.FC<{ facilities: FetchedFacilities }> = ({
+  facilities,
+}) => {
+  const [rtDaysOffset, updateRtDaysOffset] = useState<0 | 1 | 7>(0);
+
+  return (
+    <>
+      <PanelHeader>
+        <SpreadContent>
+          <PanelHeaderText>Sorted by Rt</PanelHeaderText>
+          <DataButtons>
+            <DataButton
+              as="button"
+              className={classNames({
+                "RtDataButton--active": rtDaysOffset === 7,
+              })}
+              onClick={() => updateRtDaysOffset(7)}
+            >
+              Last Week
+            </DataButton>
+            <DataButton
+              as="button"
+              className={classNames({
+                "RtDataButton--active": rtDaysOffset === 1,
+              })}
+              onClick={() => updateRtDaysOffset(1)}
+            >
+              Yesterday
+            </DataButton>
+            <DataButton
+              as="button"
+              className={classNames({
+                "RtDataButton--active": rtDaysOffset === 0,
+              })}
+              onClick={() => updateRtDaysOffset(0)}
+            >
+              Current
+            </DataButton>
+          </DataButtons>
+        </SpreadContent>
+      </PanelHeader>
+      {facilities.loading ? (
+        <Loading />
+      ) : (
+        <RtComparisonChart
+          facilities={facilities.data}
+          rtDaysOffset={rtDaysOffset}
+        />
+      )}
+    </>
+  );
+};
+
+export default RateOfSpreadPanel;

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -242,7 +242,7 @@ const svgAnnotationRules = (args: { d: any; rScale: Function }) => {
   return null;
 };
 
-type RtComparisonData = {
+export type RtComparisonData = {
   name: string;
   id: string;
   values: {
@@ -251,6 +251,11 @@ type RtComparisonData = {
     high90?: number;
   };
 };
+
+export const isRtComparisonData = (
+  x: RtComparisonData | undefined,
+): x is RtComparisonData => x !== undefined;
+
 const RtComparisonChart: React.FC<{ data: RtComparisonData[] }> = ({
   data,
 }) => {

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -110,7 +110,7 @@ const Tooltip: React.FC<{
   top: number;
 }> = ({ name, rt, left, top }) => {
   return (
-    <RtComparisonChartTooltip key="hover-tooltip" style={{ left, top }}>
+    <RtComparisonChartTooltip style={{ left, top }}>
       <p>{name}</p>
       <p>
         {rt && `Rate of Spread: ${formatRt(rt)}`}
@@ -183,6 +183,7 @@ const renderHtmlHoverState = ({
   ] = pieces;
   return (
     <Tooltip
+      key="hover-tooltip"
       name={name}
       rt={values.Rt}
       top={middle - pillRadius}

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -85,14 +85,14 @@ const PillsWithConfidenceIntervals = ({
           />
         )}
         <RtPill
-          cx={rScale(values.Rt)}
+          cx={rScale(values.Rt || 0)}
           cy={d.middle}
           r={pillRadius}
           stroke={borderColorScale(values.Rt)}
         />
         <RtLabel
           fill={textColorScale(values.Rt)}
-          x={rScale(values.Rt)}
+          x={rScale(values.Rt || 0)}
           y={d.middle}
         >
           {noData ? "?" : formatRt(values.Rt)}
@@ -110,7 +110,7 @@ const Tooltip: React.FC<{
   top: number;
 }> = ({ name, rt, left, top }) => {
   return (
-    <RtComparisonChartTooltip style={{ left, top }}>
+    <RtComparisonChartTooltip key="hover-tooltip" style={{ left, top }}>
       <p>{name}</p>
       <p>
         {rt && `Rate of Spread: ${formatRt(rt)}`}
@@ -160,7 +160,7 @@ const OLabelText = styled.div`
 
 const renderHtmlOLabels = ({ categories }: { categories: any }) => {
   return (
-    <OLabelContainer>
+    <OLabelContainer key="ordinalAxisLabels">
       {Object.values(categories).map((category: any) => (
         <OLabel key={category.pieces[0].renderKey}>
           <OLabelText>{category.name}</OLabelText>
@@ -224,6 +224,7 @@ const renderSvgHoverState = ({ d, rScale }: any) => {
   } = d;
   return values.low90 ? (
     <HoverRule
+      key="hover-rule"
       stroke={borderColorScale(values.Rt)}
       x1={rScale(0)}
       x2={rScale(values.low90)}

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -1,28 +1,64 @@
-import React from "react";
+import { orderBy, pickBy } from "lodash";
+import React, { useContext, useEffect, useState } from "react";
 
-import RtComparisonChart from "./RtComparisonChart";
+import { getDaysAgoRt } from "../infection-model/rt";
+import { FacilityContext } from "../page-multi-facility/FacilityContext";
+import { Facilities } from "../page-multi-facility/types";
+import RtComparisonChart, {
+  isRtComparisonData,
+  RtComparisonData,
+} from "./RtComparisonChart";
 
-const RtComparisonChartContainer: React.FC = () => {
-  // TODO: not this
-  const fakeData = [
-    // {
-    //   name: "facility 1",
-    //   id: "abc123",
-    //   values: { Rt: 1.9, low90: 0.4, high90: 3.8 },
-    // },
-    // {
-    //   name: "facility 2 what has a long name ",
-    //   id: "def456",
-    //   values: {
-    //     Rt: 0.6,
-    //     low90: 0,
-    //     high90: 1.5,
-    //   },
-    // },
-    // { name: "facility with no data and a long name", id: "xyz789", values: {} },
-  ] as any;
+const RtComparisonChartContainer: React.FC<{
+  facilities: Facilities;
+  rtDaysOffset: number;
+}> = ({ facilities, rtDaysOffset }) => {
+  const { rtData: rtDataMapping } = useContext(FacilityContext);
+  const [chartData, updateChartData] = useState([] as RtComparisonData[]);
 
-  return <RtComparisonChart data={fakeData} />;
+  useEffect(() => {
+    // when the offset changes, reset chart data state to force recomputation
+    updateChartData([]);
+  }, [rtDaysOffset]);
+
+  useEffect(
+    () => {
+      const existingIds = chartData.map((record) => record.id);
+      const newData = pickBy(
+        rtDataMapping,
+        (value, key) => !existingIds.includes(key),
+      );
+      const newRecords = Object.entries(newData)
+        .map(([key, rtData]) => {
+          const facility = facilities.find((f) => f.id === key);
+          if (!facility) return;
+          const values = {} as any;
+          if (rtData) {
+            Object.entries(rtData).forEach(([metric, records]) => {
+              const rtRecord = getDaysAgoRt(records, rtDaysOffset);
+              values[metric] = rtRecord?.value;
+            });
+          }
+          return {
+            name: facility.name,
+            id: key,
+            values,
+          };
+        })
+        .filter(isRtComparisonData);
+
+      if (newRecords.length) {
+        updateChartData(orderBy([...chartData, ...newRecords], ["values.Rt"]));
+      }
+    },
+    // change in rtDaysOffset triggers a state reset
+    // so it should be safe to exclude here;
+    // we don't want to display a mix of data from different days
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [facilities, rtDataMapping, chartData],
+  );
+
+  return <RtComparisonChart data={chartData} />;
 };
 
 export default RtComparisonChartContainer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,7 +4104,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.0, classnames@^2.2.6:
+classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -12563,7 +12563,7 @@ prop-types@15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12981,14 +12981,6 @@ react-spinners@^0.8.1:
   integrity sha512-jWp9gTurv6A1saXyqaqWx3dp2ZCi5eMaa0Y/0h8KdN+3QC7n7aITFKtT4BSX/ufVbvumtGLvheZDdczbgPPLtA==
   dependencies:
     "@emotion/core" "^10.0.15"
-
-react-tabs@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.1.0.tgz#ecc50f034c1d6da2606fab9293055bbc861b382e"
-  integrity sha512-9RKc77HCPsjQDVPyZEw37g3JPtg26oSQ9o4mtaVXjJuLedDX5+TQcE+MRNKR+4aO3GMAY4YslCePGG1//MQ3Jg==
-  dependencies:
-    classnames "^2.2.0"
-    prop-types "^15.5.0"
 
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9507,6 +9507,11 @@ jest-config@^25.4.0:
     pretty-format "^25.4.0"
     realpath-native "^2.0.0"
 
+jest-date-mock@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/jest-date-mock/-/jest-date-mock-1.0.8.tgz#13468c0352c5a3614c6b356dbc6b88eb37d9e0b3"
+  integrity sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==
+
 jest-diff@^25.1.0, jest-diff@^25.2.1, jest-diff@^25.3.0, jest-diff@^25.4.0:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.4.0.tgz#260b70f19a46c283adcad7f081cae71eb784a634"


### PR DESCRIPTION
## Description of the change

Pipes our fetched Rt data into the comparison chart. Includes functionality to look backward in time at different snapshots of Rt (which I have interpreted as "the most recent Rt value as of X days ago", because that seemed to be the only reasonable implementation of what's in the mocks).

Since the initial load can take a while, rather than waiting to render the entire chart we are rendering it a row at a time as the data comes in, but overlaying the entire chart with a loading spinner until all the fetches are complete.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #202 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
