### PR TITLE
vary hospitalization rate by age bracket

### DIFF
--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -35,6 +35,7 @@ interface SingleDayInputs {
   totalInfectious: number;
   totalPopulation: number;
   totalSusceptibleIncarcerated: number;
+  pSevereCase: number;
 }
 
 export enum seirIndex {
@@ -81,8 +82,6 @@ const dHospitalLag = 2.9;
 const dHospitalRecovery = 22;
 // days from hospital admission to deceased (fatality scenario)
 const dHospitalFatality = 8.3;
-// probability case will be severe enough for the hospital
-const pSevereCase = 0.26;
 // factor for inferring exposure based on confirmed cases
 const ratioExposedToInfected = dIncubation / dInfectious;
 // factor for estimating population adjustment based on expected turnover
@@ -107,6 +106,7 @@ function simulateOneDay(inputs: SimulationInputs & SingleDayInputs) {
     totalPopulation,
     populationAdjustment,
     totalSusceptibleIncarcerated,
+    pSevereCase,
   } = inputs;
 
   const alpha = 1 / dIncubation;
@@ -257,6 +257,20 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ageGroupFatalityRates[ageGroupIndex.age85] = 0.1885;
   ageGroupFatalityRates[ageGroupIndex.staff] = 0.026;
 
+  // source: Centers for Disease Control,
+  // https://www.cdc.gov/mmwr/volumes/69/wr/mm6912e2.htm#T1_down
+  // we use the average of the range provided for each group
+  const ageGroupHospitalizationRates: number[] = [];
+  ageGroupHospitalizationRates[ageGroupIndex.ageUnknown] = 0.2605;
+  ageGroupHospitalizationRates[ageGroupIndex.age0] = 0.0205;
+  ageGroupHospitalizationRates[ageGroupIndex.age20] = 0.1755;
+  ageGroupHospitalizationRates[ageGroupIndex.age45] = 0.2475;
+  ageGroupHospitalizationRates[ageGroupIndex.age55] = 0.253;
+  ageGroupHospitalizationRates[ageGroupIndex.age65] = 0.3605;
+  ageGroupHospitalizationRates[ageGroupIndex.age75] = 0.446;
+  ageGroupHospitalizationRates[ageGroupIndex.age85] = 0.508;
+  ageGroupHospitalizationRates[ageGroupIndex.staff] = 0.2605;
+
   // adjust population figures based on expected turnover
   ageGroupPopulations = adjustPopulations({
     ageGroupPopulations,
@@ -350,6 +364,7 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
         rateOfSpreadCells,
         rateOfSpreadDorms,
         pFatalityRate: rate,
+        pSevereCase: ageGroupHospitalizationRates[ageGroup],
         facilityDormitoryPct,
         simulateStaff: ageGroup === ageGroupIndex.staff,
         populationAdjustment: expectedPopulationChanges[day],


### PR DESCRIPTION
## Description of the change

Similar to what we do with fatality rates, this lets us vary the hospitalization rate in our simulations by age bracket. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #172 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
