### PR TITLE
[Excalibur] Add back button to /impact error page

### DIFF
--- a/src/page-response-impact/ValidDataWrapper.tsx
+++ b/src/page-response-impact/ValidDataWrapper.tsx
@@ -1,9 +1,14 @@
+import { Link } from "gatsby";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
+import iconBackSrc from "../design-system/icons/ic_back.svg";
+import { Spacer } from "../design-system/Spacer";
 import { sumAgeGroupPopulations } from "../impact-dashboard/EpidemicModelContext";
 import { Facilities } from "../page-multi-facility/types";
+import { BackDiv, IconBack } from "./styles";
+
 const POPULATION_DATA_ERROR_MSG =
   "Impact could not be generated because one or more of your facilities does not have an incarcerated population count. Please add population numbers and try again.";
 const LOCALE_DATA_ERROR_MSG =
@@ -56,6 +61,13 @@ const ValidDataWrapper: React.FC<Props> = ({ children, facilities = [] }) => {
     <ValidDataWrapperContainer>
       {Object.values(errors).some((e) => e) ? (
         <div>
+          <Spacer y={24} />
+          <Link to="/">
+            <BackDiv className="ml-5">
+              <IconBack alt="back" src={iconBackSrc} />
+              Back to model
+            </BackDiv>
+          </Link>
           {errors.locale && (
             <ErrorMessage>{LOCALE_DATA_ERROR_MSG}</ErrorMessage>
           )}


### PR DESCRIPTION
## Description of the change

Add an explicit “Back to model” navigation on the error text

Note: I think this should go to the home page since you are coming from the modal to get to /impact.

IS:
![image](https://user-images.githubusercontent.com/1372946/81452584-197e6300-913c-11ea-900e-63e7793afef0.png)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of: https://github.com/Recidiviz/covid19-dashboard/issues/360 
Closes `P2: Add an explicit “Back to model” navigation on the error text` from https://docs.google.com/document/d/1_jbpbsObUWkakyitmuIMaNKhq1YVU_fpo4j06ip8ets/edit#

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
