### PR TITLE
[Excalibur] Show only positive numbers in the population impact cards

### DIFF
--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -27,8 +27,8 @@ const ModalContainer = styled.div<ModalContainerProps>`
   border-radius: 5px;
   display: flex;
   flex-direction: column;
-  height: ${props => props.height || "auto"};
-  width: ${props => props.width || "65vw"};
+  height: ${(props) => props.height || "auto"};
+  width: ${(props) => props.width || "65vw"};
   padding: 35px;
   position: static;
   max-height: 90%;

--- a/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
+++ b/src/page-response-impact/utils/ResponseImpactCardStateUtils.tsx
@@ -22,18 +22,20 @@ export function buildReductionData(
   // positive value is a reduction
   return {
     incarcerated: {
-      hospitalized:
-        -1 *
-        (currData.incarcerated.hospitalized -
-          origData.incarcerated.hospitalized),
-      fatalities:
-        -1 *
-        (currData.incarcerated.fatalities - origData.incarcerated.fatalities),
+      hospitalized: Math.abs(
+        origData.incarcerated.hospitalized - currData.incarcerated.hospitalized,
+      ),
+      fatalities: Math.abs(
+        origData.incarcerated.fatalities - currData.incarcerated.fatalities,
+      ),
     },
     staff: {
-      hospitalized:
-        -1 * (currData.staff.hospitalized - origData.staff.hospitalized),
-      fatalities: -1 * (currData.staff.fatalities - origData.staff.fatalities),
+      hospitalized: Math.abs(
+        origData.staff.hospitalized - currData.staff.hospitalized,
+      ),
+      fatalities: Math.abs(
+        origData.staff.fatalities - currData.staff.fatalities,
+      ),
     },
   };
 }


### PR DESCRIPTION
## Description of the change

Updates the population reduced by metrics to be positive with `Math.abs`. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #360 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
