### PR TITLE
exclude hospital beds from y axis range

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -128,7 +128,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
-    yExtent: { extent: [0], includeAnnotations: true },
+    yExtent: { extent: [0], includeAnnotations: false },
     margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 0 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],
@@ -152,6 +152,16 @@ const CurveChart: React.FC<CurveChartProps> = ({
           }
         : {},
     ],
+    svgAnnotationRules: ({ d, yScale }) => {
+      if (d.type === "y") {
+        // don't try to render hospital beds that won't fit in the chart;
+        // otherwise they might be visible
+        if (d.count > yScale.domain()[1]) {
+          return;
+        }
+      }
+      return null;
+    },
     hoverAnnotation: true,
     tooltipContent: Tooltip,
     // these two options place the hover targets along the line


### PR DESCRIPTION
## Description of the change

Does what it says on the tin; if they fit, they fit, but we no longer stretch the y axis to accommodate them. Mostly as easy as flipping a switch, but a little extra work was needed to stop them from being rendered and visible outside the bounds of the chart (a plain CSS fix was too blunt and affected other annotations such as tooltips).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #338 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
