### PR TITLE
Remove setting toggles from Scenario UI

### DIFF
--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -46,24 +46,16 @@ export function getEnabledPromoType(
 ) {
   if (!scenario) return null;
 
-  const { dailyReports, dataSharing, promoStatuses } = scenario;
+  const { promoStatuses } = scenario;
 
   return promoStatuses.rtChart
     ? "rtChart"
-    : !dailyReports && promoStatuses?.dailyReports
-    ? "dailyReports"
-    : !dataSharing && promoStatuses?.dataSharing
-    ? "dataSharing"
     : numFacilities && numFacilities < 3 && promoStatuses?.addFacilities
     ? "addFacilities"
     : null;
 }
 
 const promoTexts: { [promoType: string]: string } = {
-  dailyReports:
-    "Turn on 'Daily Reports' to receive briefings based on the data in this scenario, prepared by Recidiviz and CSG.",
-  dataSharing:
-    "Turn on 'Data Sharing' to provide your baseline data to public researchers, to help improve models of disease spread in prisons in the future.",
   addFacilities:
     "Add additional facilities to see the impact across your entire system.",
   rtChart: `New! View the chart of Rt (the rate of spread over time) for any

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -14,7 +14,6 @@ import { Spacer } from "../design-system/Spacer";
 import { useFlag } from "../feature-flags";
 import useScenario from "../scenario-context/useScenario";
 import ScenarioLibraryModal from "./ScenarioLibraryModal";
-import ToggleRow from "./ToggleRow";
 import { Scenario } from "./types";
 
 const HorizontalRule = styled.hr`
@@ -36,10 +35,6 @@ const IconFolder = styled.img`
 interface ToggleContainerProps {
   hidden?: boolean;
 }
-
-const ToggleContainer = styled.div<ToggleContainerProps>`
-  visibility: ${(props) => (props.hidden ? "hidden" : "visibile")};
-`;
 
 interface Props {
   numFacilities?: number | null;
@@ -161,26 +156,6 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
         <div>
           <Spacer y={20} />
           <HorizontalRule />
-          <ToggleContainer hidden={!scenario?.baseline}>
-            <ToggleRow
-              onToggle={() =>
-                handleScenarioChange({ dailyReports: !scenario?.dailyReports })
-              }
-              toggled={scenario?.dailyReports}
-              label="Subscribe to daily reports"
-              labelHelp="If enabled, your baseline scenario will be shared with Recidiviz and CSG. This data will only be used to provide you with daily reports."
-            />
-            <HorizontalRule />
-            <ToggleRow
-              onToggle={() =>
-                handleScenarioChange({ dataSharing: !scenario?.dataSharing })
-              }
-              toggled={scenario?.dataSharing}
-              label="Share data to improve the model"
-              labelHelp="If enabled, your baseline scenario will be made available to Recidiviz and the research community to improve the model and the state of research on the spread of disease in facilities. Any public research will anonymize state and facility names."
-            />
-            <HorizontalRule />
-          </ToggleContainer>
           <PromoBoxWithButton
             enabled={!!scenario?.baseline && !promoDismissed}
             text={getPromoText(promoType) || null}


### PR DESCRIPTION
## Description of the change

Remove the data sharing and daily reports toggles (and their associated promo messages) from the scenario sidebar on the multi-facility view. I left the components themselves in place, since the issue indicates they may still be useful in the future. 

I also didn't change anything in the associated database functions — the default state is not incompatible with the new UI, I figure we may still care about these underlying settings even though they aren't currently exposed on the page, and I didn't want to introduce an inconsistency in the document fields since we don't have a good way to do migrations yet.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #373 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
