### PR TITLE
[Excalibur] Make /impact layout more responsive

### DIFF
--- a/src/design-system/PageColumn.tsx
+++ b/src/design-system/PageColumn.tsx
@@ -3,6 +3,10 @@ import styled from "styled-components";
 export const PageContainer = styled.div`
   display: flex;
   flex-direction: row;
+
+  @media (max-width: 700px) {
+    flex-direction: column;
+  }
 `;
 export const Column = styled.div<{ width?: string }>`
   margin: 20px;

--- a/src/design-system/PageColumn.tsx
+++ b/src/design-system/PageColumn.tsx
@@ -11,4 +11,8 @@ export const PageContainer = styled.div`
 export const Column = styled.div<{ width?: string }>`
   margin: 20px;
   width: ${(props) => props.width || "50%"};
+
+  @media (max-width: 700px) {
+    width: 95%;
+  }
 `;

--- a/src/design-system/PageColumn.tsx
+++ b/src/design-system/PageColumn.tsx
@@ -13,6 +13,6 @@ export const Column = styled.div<{ width?: string }>`
   width: ${(props) => props.width || "50%"};
 
   @media (max-width: 700px) {
-    width: 95%;
+    width: inherit;
   }
 `;


### PR DESCRIPTION
## Description of the change

Went the "quick fix" route for now so don't have to change the rest of the markup. 

(The column markup is also used on the Add Facility page, which isn't really responsive at all for now, but this fix makes it a little better)

IS:
![responsive2](https://user-images.githubusercontent.com/1372946/81609356-9869da80-938c-11ea-9189-b8be9688e97d.gif)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of: #360

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
