### PR TITLE
force sidebar re-render after scenario switch

### DIFF
--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -1,6 +1,6 @@
 import { format } from "date-fns";
 import { navigate } from "gatsby";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { saveScenario } from "../database";
@@ -99,10 +99,19 @@ const ScenarioSidebar: React.FC<Props> = (props) => {
   const [name, setName] = useState(scenario?.name);
   const [promoDismissed, setPromoDismissed] = useState(false);
   const [description, setDescription] = useState(scenario?.description);
+  // need this to force a form state refresh when switching scenarios
+  const [renderKey, setRenderKey] = useState(scenario?.id);
+
   const promoType: string | null = getEnabledPromoType(scenario, numFacilities);
 
+  useEffect(() => {
+    setName(scenario?.name);
+    setDescription(scenario?.description);
+    setRenderKey(scenario?.id);
+  }, [scenario]);
+
   return (
-    <div className="flex flex-col w-1/4 mr-24">
+    <div className="flex flex-col w-1/4 mr-24" key={renderKey}>
       <div className="flex-1 flex flex-col pb-4">
         <ScenarioName>
           {showScenarioLibrary && (


### PR DESCRIPTION
## Description of the change

Fixes an issue where the scenario name and description were not being updated in the scenario sidebar after changing scenarios.

The scenario sidebar and its descendants have accumulated some convoluted state management logic that contributed to this bug, and this PR does not do anything to improve that; instead I had to just force its entire component tree to re-render when the scenario changes, which forces all the form inputs to re-initialize.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #348 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
