### PR TITLE
Change firebase query to use composite index for modelVersions. 

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -6,7 +6,7 @@ import "firebase/firestore";
 
 import createAuth0Client from "@auth0/auth0-spa-js";
 import { format, startOfDay, startOfToday } from "date-fns";
-import { pick, orderBy } from "lodash";
+import { pick, orderBy, uniqBy } from "lodash";
 
 import config from "../auth/auth_config.json";
 import { MMMMdyyyy } from "../constants";
@@ -290,9 +290,11 @@ export const getFacilities = async (
 export const getFacilityModelVersions = async ({
   facilityId,
   scenarioId,
+  distinctByObservedAt = false,
 }: {
   facilityId: string;
   scenarioId: string;
+  distinctByObservedAt?: boolean;
 }): Promise<ModelInputs[]> => {
   const db = await getDb();
 
@@ -307,9 +309,16 @@ export const getFacilityModelVersions = async ({
       .orderBy("updatedAt", "desc")
       .get();
 
-    return historyResults.docs.map((doc) => {
-      return buildModelInputs(doc.data());
-    });
+    let modelVersions = historyResults.docs.map((doc) =>
+      buildModelInputs(doc.data()),
+    );
+    return distinctByObservedAt
+      ? uniqBy(
+          modelVersions,
+          // make sure time doesn't enter into the uniqueness
+          (record) => record.observedAt.toDateString(),
+        )
+      : modelVersions;
   } catch (error) {
     console.error(
       "Encountered error while attempting to retrieve facility model versions:",

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -304,6 +304,7 @@ export const getFacilityModelVersions = async ({
       .doc(facilityId)
       .collection(modelVersionCollectionId)
       .orderBy("observedAt", "asc")
+      .orderBy("updatedAt", "desc")
       .get();
 
     return historyResults.docs.map((doc) => {

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -79,15 +79,8 @@ const getRtInputsForFacility = async (
   let modelVersions = await getFacilityModelVersions({
     scenarioId: facility.scenarioId,
     facilityId: facility.id,
+    distinctByObservedAt: true,
   });
-
-  // inputs must contain no more than one record per day.
-  // when we have multiples, filter out all but the most recently updated
-  modelVersions = uniqBy(
-    modelVersions,
-    // make sure time doesn't enter into the uniqueness
-    (record) => record.observedAt.toDateString(),
-  );
 
   const cases: number[] = [];
   const dates: string[] = [];

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -83,16 +83,8 @@ const getRtInputsForFacility = async (
 
   // inputs must contain no more than one record per day.
   // when we have multiples, filter out all but the most recently updated
-  // TODO: it may be possible to do this filtering directly in the query
-  // with a compound index, see #254 and replace this code if possible
   modelVersions = uniqBy(
-    orderBy(
-      modelVersions,
-      ["observedAt", "updatedAt"],
-      // uniqBy retains only the first item when it encounters duplicates,
-      // so make sure the most recently updated one is first
-      ["asc", "desc"],
-    ),
+    modelVersions,
     // make sure time doesn't enter into the uniqueness
     (record) => record.observedAt.toDateString(),
   );

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -5,7 +5,7 @@ import {
   fromUnixTime,
   parseISO,
 } from "date-fns";
-import { mapValues, maxBy, minBy, orderBy, uniqBy } from "lodash";
+import { mapValues, maxBy, minBy, uniqBy } from "lodash";
 
 import { RateOfSpreadType } from "../constants/EpidemicModel";
 import { getFacilityModelVersions } from "../database";

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -5,7 +5,7 @@ import {
   fromUnixTime,
   parseISO,
 } from "date-fns";
-import { mapValues, maxBy, minBy, uniqBy } from "lodash";
+import { mapValues, maxBy, minBy } from "lodash";
 
 import { RateOfSpreadType } from "../constants/EpidemicModel";
 import { getFacilityModelVersions } from "../database";


### PR DESCRIPTION
## Description of the change
- Add a new composite index for modelVersions sub collection.
- Changed getFacilityModelVersions to order by observedAt and updatedAt to account for multiple observations on the same day. observedAt is sorted asc and updatedAt is sorted desc.
- Removed the extraneous orderBy done in getRtInputsForFacility, since this is taken care of in the query itself.

- Verified that getRtInputsForFacility returns the same o/p before and after the change.
- No index errors on console due to using the composite index.

E.g. o/p of getRtInputsForFacility selecting only the most recent updatedAt for every observedAt.

![image](https://user-images.githubusercontent.com/6414261/81623439-636b8100-93a8-11ea-94c0-4c1c4e57f2eb.png)


## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #254

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
