### PR TITLE
Fix bug in showing add cases modal on scroll.

### DIFF
--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -11,7 +11,7 @@ const BackgroundAside = styled.aside`
   display: flex;
   height: 100%;
   justify-content: center;
-  position: absolute;
+  position: fixed;
   top: 0;
   width: 100%;
 `;
@@ -30,7 +30,7 @@ const ModalContainer = styled.div<ModalContainerProps>`
   height: ${(props) => props.height || "auto"};
   width: ${(props) => props.width || "65vw"};
   padding: 35px;
-  position: static;
+  position: fixed;
   max-height: 90%;
   overflow-y: auto;
 `;


### PR DESCRIPTION
## Description of the change
Fix bug in add cases modal in the scenario page where it shows at the top of the page even when the facility row is reachable only by scroll at the bottom.
Verified the modals on facility detail page (add cases and delete) are unaffected.

Before:
![Kapture 2020-05-11 at 17 08 39](https://user-images.githubusercontent.com/6414261/81624122-420b9480-93aa-11ea-84a6-4b7211d44cf1.gif)

After:
![Kapture 2020-05-11 at 17 06 42](https://user-images.githubusercontent.com/6414261/81624156-59e31880-93aa-11ea-9562-889eca891fb6.gif)

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
