### PR TITLE
[Excalibur] Modal design tweaks

### DIFF
--- a/src/design-system/InputDate.tsx
+++ b/src/design-system/InputDate.tsx
@@ -23,11 +23,9 @@ const InputContainer = styled.div`
       border-radius: 2px;
       border: none;
       box-shadow: none;
-      color: #00413e;
+      color: ${Colors.green};
       flex: 1 1 auto;
-      font-family: "Rubik", sans-serif;
-      font-size: 16px;
-      font-weight: 400;
+      font: 13px/16px "Poppins", sans-serif;
       margin-top: 8px;
       outline: 0 solid transparent;
       padding: 16px;

--- a/src/page-response-impact/BaselinePopulationModal/BaselinePopulationForm.tsx
+++ b/src/page-response-impact/BaselinePopulationModal/BaselinePopulationForm.tsx
@@ -71,7 +71,6 @@ const TooltipText = styled.div`
 
 const buttonStyle = {
   width: "200px",
-  fontFamily: "PingFang SC",
   fontSize: "14px",
 };
 

--- a/src/page-response-impact/BaselinePopulationModal/index.tsx
+++ b/src/page-response-impact/BaselinePopulationModal/index.tsx
@@ -41,7 +41,6 @@ export interface Props {
 
 const buttonStyle = {
   width: "80px",
-  fontFamily: "PingFang SC",
   fontSize: "14px",
   background: "transparent",
   color: Colors.forest,


### PR DESCRIPTION
## Description of the change

- Change styling of InputDate to match Input on view (Date was larger than other fonts)
- Change modal button fonts (Generate and Back are serif fonts, should be sans-serif / consistent with descriptive text at the top)

WAS:
![image](https://user-images.githubusercontent.com/1372946/81642395-26b77e00-93d8-11ea-9da2-302abc6dc59a.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/81642331-05569200-93d8-11ea-8afc-5e3abee8c972.png)

---

This also changes the form on the "Add Facility" page, but makes the inputs more consistent:

IS (inputs are matching):
![image](https://user-images.githubusercontent.com/1372946/81642502-62eade80-93d8-11ea-9f7c-2bba46ac2bad.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of [Excalibur UI polish Google doc]( https://docs.google.com/document/d/1_jbpbsObUWkakyitmuIMaNKhq1YVU_fpo4j06ip8ets/edit)

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
