### PR TITLE
[Excalibur] Update copy for the hospital beds at peak metric to specify incarcerated

### DIFF
--- a/src/page-response-impact/ReducingR0ImpactMetrics.tsx
+++ b/src/page-response-impact/ReducingR0ImpactMetrics.tsx
@@ -36,7 +36,7 @@ const ReducingR0ImpactMetrics: React.FC<Props> = ({ populationImpact }) => {
       <ImpactMetricCard
         title={
           <HospitalBedsTitle
-            title="Hospital beds used at peak"
+            title="Hospital beds used by incarcerated"
             value={populationImpact.hospitalBedsUsed}
           />
         }
@@ -44,7 +44,7 @@ const ReducingR0ImpactMetrics: React.FC<Props> = ({ populationImpact }) => {
         icon={hospitalIcon}
       />
       <ImpactMetricCard
-        title={`Additional staff ${staffAbilityText} to work at peak`}
+        title={`Additional staff ${staffAbilityText} to work`}
         value={formatAbsValue(populationImpact.staffUnableToWork)}
         icon={staffIcon}
       />

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -180,7 +180,7 @@ const ResponseImpactDashboard: React.FC<Props> = ({
                   </ChartHeader>
                   {rtData && <RtSummaryStats rtData={rtData} />}
                   <SectionSubheader>
-                    Impact on community health and staff resources
+                    Peak impact on community health and staff resources
                   </SectionSubheader>
                   {populationImpactData && (
                     <ReducingR0ImpactMetrics


### PR DESCRIPTION
## Description of the change

Update the copy for the hospital beds used at peak card at the bottom of the page so that it is clearer that it is calculated by incarcerated projection numbers (as opposed to the curve charts which sum both incarcerated and staff numbers)

![image](https://user-images.githubusercontent.com/5402804/81746254-ff55c500-945a-11ea-9bc6-51f4b0427cc9.png)

![image (1)](https://user-images.githubusercontent.com/5402804/81746257-011f8880-945b-11ea-9e76-bcf96832adad.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #400 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
