### PR TITLE
Update RT value when new case is added on dashboard or facility page

### DIFF
--- a/src/constants/dispatchEvents.tsx
+++ b/src/constants/dispatchEvents.tsx
@@ -1,0 +1,10 @@
+export const FacilityEvents = {
+  ADD: "add",
+  UPDATE: "add",
+};
+
+const dispatchEvents = {
+  ...FacilityEvents,
+};
+
+export default dispatchEvents;

--- a/src/constants/dispatchEvents.tsx
+++ b/src/constants/dispatchEvents.tsx
@@ -1,10 +1,4 @@
-export const FacilityEvents = {
-  ADD: "add",
-  UPDATE: "add",
-};
-
-const dispatchEvents = {
-  ...FacilityEvents,
-};
-
-export default dispatchEvents;
+export enum FacilityEvents {
+  ADD = "add",
+  UPDATE = "update",
+}

--- a/src/hooks/useFacilitiesRtData.tsx
+++ b/src/hooks/useFacilitiesRtData.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect } from "react";
 
+import { FacilityEvents } from "../constants/dispatchEvents";
 import { getRtDataForFacility } from "../infection-model/rt";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
 import { Facilities } from "../page-multi-facility/types";
@@ -15,7 +16,7 @@ const useFacilitiesRtData = (facilities: Facilities | null, useRt = false) => {
 
         const facilityRtData = await getRtDataForFacility(facility);
         dispatchRtData({
-          type: "add",
+          type: FacilityEvents.ADD,
           payload: { [facility.id]: facilityRtData },
         });
       }),

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -2,6 +2,7 @@ import { ascending } from "d3-array";
 import { formatISO, fromUnixTime, parseISO } from "date-fns";
 import { mapValues, maxBy, minBy, orderBy, uniqBy } from "lodash";
 
+import { FacilityEvents } from "../constants/dispatchEvents";
 import { getFacilityModelVersions } from "../database";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
 import { Facility } from "../page-multi-facility/types";
@@ -134,6 +135,21 @@ export const getRtDataForFacility = async (
     return null;
   }
 };
+
+export async function getUpdatedFacilityRtData(
+  facility: Facility,
+  dispatchRtData: Function,
+) {
+  const facilityRtData = await getRtDataForFacility(facility);
+
+  dispatchRtData({
+    type: FacilityEvents.UPDATE,
+    payload: {
+      id: facility.id,
+      data: facilityRtData,
+    },
+  });
+}
 
 export const getOldestRt = (rtRecords: RtRecord[]) => {
   return minBy(rtRecords, (rtRecord) => rtRecord.date);

--- a/src/page-multi-facility/FacilityContext.tsx
+++ b/src/page-multi-facility/FacilityContext.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 
-import { RtData } from "../infection-model/rt";
-import { Facility } from "./types";
-
-export type RtDataMapping = {
-  [key in Facility["id"]]: RtData | null;
-};
+import { FacilityEvents } from "../constants/dispatchEvents";
+import { Facility, RtDataMapping } from "./types";
 
 interface FacilityContextProps {
   facility?: Facility;
@@ -22,12 +18,24 @@ export const FacilityContext = React.createContext<FacilityContextProps>({
 export const rtDataReducer = (
   state: RtDataMapping,
   action: {
-    type: "add";
-    payload: RtDataMapping;
+    type: FacilityEvents;
+    payload: any;
   },
 ): RtDataMapping => {
   switch (action.type) {
-    case "add":
+    case FacilityEvents.ADD:
       return { ...state, ...action.payload };
+
+    case FacilityEvents.UPDATE:
+      const { id, data } = action.payload;
+      if (!state[id]) {
+        return state;
+      }
+      const newState = { ...state };
+      newState[id] = data;
+      return newState;
+
+    default:
+      return state;
   }
 };

--- a/src/page-multi-facility/FacilityContext.tsx
+++ b/src/page-multi-facility/FacilityContext.tsx
@@ -28,12 +28,7 @@ export const rtDataReducer = (
 
     case FacilityEvents.UPDATE:
       const { id, data } = action.payload;
-      if (!state[id]) {
-        return state;
-      }
-      const newState = { ...state };
-      newState[id] = data;
-      return newState;
+      return { ...state, [id]: data };
 
     default:
       return state;

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -22,6 +22,7 @@ import AddCasesModal from "./AddCasesModal";
 import { FacilityContext } from "./FacilityContext";
 import FacilityProjections from "./FacilityProjections";
 import LocaleInformationSection from "./LocaleInformationSection";
+import { Facility } from "./types";
 
 const ButtonSection = styled.div`
   margin-top: 30px;
@@ -160,6 +161,10 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
       // setting this value to null will suppress the chart
       null;
 
+  const onModalSave = (newFacility: Facility) => {
+    updateFacility(newFacility);
+  };
+
   return (
     <PageContainer>
       <Column width={"45%"}>
@@ -184,7 +189,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
                   </AddCasesButton>
                 </Tooltip>
               }
-              updateFacility={updateFacility}
+              onSave={onModalSave}
             />
           </AddCasesRow>
         )}

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -17,6 +17,7 @@ import { Flag } from "../feature-flags";
 import FacilityInformation from "../impact-dashboard/FacilityInformation";
 import MitigationInformation from "../impact-dashboard/MitigationInformation";
 import useModel from "../impact-dashboard/useModel";
+import { getUpdatedFacilityRtData } from "../infection-model/rt";
 import RtTimeseries from "../rt-timeseries";
 import AddCasesModal from "./AddCasesModal";
 import { FacilityContext } from "./FacilityContext";
@@ -108,7 +109,9 @@ interface Props {
 }
 
 const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
-  const { facility: initialFacility, rtData } = useContext(FacilityContext);
+  const { facility: initialFacility, rtData, dispatchRtData } = useContext(
+    FacilityContext,
+  );
   const [facility, updateFacility] = useState(initialFacility);
   const [facilityName, setFacilityName] = useState(facility?.name || undefined);
   const [description, setDescription] = useState(
@@ -163,6 +166,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
 
   const onModalSave = (newFacility: Facility) => {
     updateFacility(newFacility);
+    getUpdatedFacilityRtData(newFacility, dispatchRtData);
   };
 
   return (

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -14,7 +14,7 @@ import { useFlag } from "../feature-flags";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
 import useModel from "../impact-dashboard/useModel";
-import { getRtDataForFacility, RtData } from "../infection-model/rt";
+import { getUpdatedFacilityRtData, RtData } from "../infection-model/rt";
 import AddCasesModal from "./AddCasesModal";
 import { FacilityContext } from "./FacilityContext";
 import FacilityRowRtValuePill from "./FacilityRowRtValuePill";
@@ -88,6 +88,8 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
 
   const { rtData, setFacility, dispatchRtData } = useContext(FacilityContext);
 
+  console.log("rtData", rtData);
+
   const [facility, updateFacility] = useState(initialFacility);
   let useRt,
     facilityRtData: RtData | undefined | null = undefined,
@@ -119,21 +121,9 @@ const FacilityRow: React.FC<Props> = ({ facility: initialFacility }) => {
     navigate("/facility");
   };
 
-  async function getUpdatedFacilityRtData(facility: Facility) {
-    const facilityRtData = await getRtDataForFacility(facility);
-
-    dispatchRtData({
-      type: FacilityEvents.UPDATE,
-      payload: {
-        id: facility.id,
-        data: facilityRtData,
-      },
-    });
-  }
-
   const onModalSave = (newFacility: Facility) => {
     updateFacility(newFacility);
-    getUpdatedFacilityRtData(newFacility);
+    getUpdatedFacilityRtData(newFacility, dispatchRtData);
   };
 
   return (

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -1,4 +1,5 @@
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+import { RtData } from "../infection-model/rt";
 
 export interface ModelInputs extends EpidemicModelPersistent {
   observedAt: Date;
@@ -36,4 +37,8 @@ export type PromoStatuses = {
   dailyReports: boolean;
   dataSharing: boolean;
   addFacilities: boolean;
+};
+
+export type RtDataMapping = {
+  [key in Facility["id"]]: RtData | null;
 };

--- a/src/page-response-impact/RtSummaryStats.tsx
+++ b/src/page-response-impact/RtSummaryStats.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
 import { RtData, RtRecord } from "../infection-model/rt";
-import { RtDataMapping } from "../page-multi-facility/FacilityContext";
+import { RtDataMapping } from "../page-multi-facility/types";
 import * as rtStats from "./rtStatistics";
 
 interface Props {


### PR DESCRIPTION
## Description of the change

Currently, when a new day of case data is added, the RT value is not refreshing. To see the updated value, the page needs to be manually refreshed. This causes problems especially on the facility page, where refreshing results in clearing the page store and displays an unexpected empty page.

The updated values received from calculate_rt endpoint are now used to update the FacilityContext, and update the frontend accordingly.

In a possible later change, a "loading" indicator might be worth adding while the updated value is received.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Related issues

Closes [#320]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
