### PR TITLE
Fix z-index issue with rt pills displaying above the modal

### DIFF
--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -14,6 +14,7 @@ const BackgroundAside = styled.aside`
   position: fixed;
   top: 0;
   width: 100%;
+  z-index: 10;
 `;
 
 interface ModalContainerProps {


### PR DESCRIPTION
## Description of the change

The z-index on absolutely positioned items weren't explicitly set, so the Add New Cases modal was appearing behind the RtPills. The Modal's z-index is now explicitly set to prevent further issues.

### Before
<img width="844" alt="Screen Shot 2020-05-13 at 11 22 43 AM" src="https://user-images.githubusercontent.com/1332366/81832302-5798cf80-950c-11ea-8c23-6727212a64ba.png">

### After
<img width="978" alt="Screen Shot 2020-05-13 at 11 22 35 AM" src="https://user-images.githubusercontent.com/1332366/81832318-5c5d8380-950c-11ea-8058-f41f27b1c7f3.png">

## Related issues

Closes #355 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
