### PR TITLE
[Merlin] Make loading spinner appear in center of row

### DIFF
--- a/src/design-system/Loading.tsx
+++ b/src/design-system/Loading.tsx
@@ -4,17 +4,23 @@ import styled from "styled-components";
 
 import Colors from "./Colors";
 
-const LoadingContainer = styled.div`
+const LoadingContainer = styled.div<Props>`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   height: 100%;
+  min-height: ${(props) => props.styles?.minHeight};
+  padding-bottom: ${(props) => props.styles?.paddingBottom};
 `;
 
-const Loading: React.FC = () => {
+interface Props {
+  styles?: React.CSSProperties;
+}
+
+const Loading: React.FC<Props> = (props) => {
   return (
-    <LoadingContainer>
+    <LoadingContainer styles={props.styles}>
       <BounceLoader size={60} color={Colors.forest} />
     </LoadingContainer>
   );

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -1,23 +1,11 @@
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 import { useEffect, useState } from "react";
-import BounceLoader from "react-spinners/BounceLoader";
-import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
+import Loading from "../design-system/Loading";
 import { MarkColors } from "./ChartArea";
 import CurveChart, { ChartData } from "./CurveChart";
 import { useEpidemicModelState } from "./EpidemicModelContext";
-
-const LoadingContainerCustom = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  min-height: 177px;
-  padding-bottom: 32px;
-`;
 
 interface Props {
   chartHeight?: number;
@@ -60,9 +48,12 @@ const CurveChartContainer: React.FC<Props> = ({
   }, [groupStatus, curveData]);
 
   return !curveDataFiltered ? (
-    <LoadingContainerCustom>
-      <BounceLoader size={60} color={Colors.forest} />
-    </LoadingContainerCustom>
+    <Loading
+      styles={{
+        minHeight: "177px",
+        paddingBottom: "32px",
+      }}
+    />
   ) : (
     <CurveChart
       chartHeight={chartHeight}

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -1,11 +1,23 @@
 import isEmpty from "lodash/isEmpty";
 import React from "react";
 import { useEffect, useState } from "react";
+import BounceLoader from "react-spinners/BounceLoader";
+import styled from "styled-components";
 
-import Loading from "../design-system/Loading";
+import Colors from "../design-system/Colors";
 import { MarkColors } from "./ChartArea";
 import CurveChart, { ChartData } from "./CurveChart";
 import { useEpidemicModelState } from "./EpidemicModelContext";
+
+const LoadingContainerCustom = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 177px;
+  padding-bottom: 32px;
+`;
 
 interface Props {
   chartHeight?: number;
@@ -48,7 +60,9 @@ const CurveChartContainer: React.FC<Props> = ({
   }, [groupStatus, curveData]);
 
   return !curveDataFiltered ? (
-    <Loading />
+    <LoadingContainerCustom>
+      <BounceLoader size={60} color={Colors.forest} />
+    </LoadingContainerCustom>
   ) : (
     <CurveChart
       chartHeight={chartHeight}


### PR DESCRIPTION
## Description of the change

To achieve this, make row full-height on load and account for padding

WAS:
![spinner-was](https://user-images.githubusercontent.com/1372946/81891452-4d52f180-955d-11ea-8d6c-b722cd5a3bb6.gif)

IS:
![spinner](https://user-images.githubusercontent.com/1372946/81891459-4fb54b80-955d-11ea-9155-ddbb6a43ed1c.gif)

👉 Please let me know if this is not the right approach. I tried adding a conditional prop to `LoadingContainer` [here](https://github.com/Recidiviz/covid19-dashboard/blob/master/src/design-system/Loading.tsx#L7-L13) but got stuck / couldn't achieve the same result. If not the right approach, any similar components here I could look at? 

FWIW it's good on mobile as-is, seems like the height of the chart is constant.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of https://github.com/Recidiviz/covid19-dashboard/issues/372 cc @cawarren @sychang 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
