### PR TITLE
Filter first and duplicate records out of Rt function

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -139,5 +139,6 @@ def compute_r_t(historical_case_counts):
         raise ValueError('Unable to compute R(t) with the provided data')
 
     most_likely = posteriors.idxmax().rename('ML')
+    # the first day is not a valid value because it has no priors; exclude it
     result = pd.concat([most_likely, hdis], axis=1).iloc[1:]
     return result

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -136,5 +136,5 @@ def compute_r_t(historical_case_counts):
         raise ValueError('Unable to compute R(t) with the provided data')
 
     most_likely = posteriors.idxmax().rename('ML')
-    result = pd.concat([most_likely, hdis], axis=1)
+    result = pd.concat([most_likely, hdis], axis=1).iloc[1:]
     return result

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -118,6 +118,9 @@ def compute_r_t(historical_case_counts):
     case_df = pd.Series(historical_case_counts['cases'], index=historical_case_counts['dates'])
     case_df.index = pd.to_datetime(case_df.index)
     case_df.index.name = 'date'
+    # we believe duplicates are mostly an artifact of little-to-no testing
+    # and should be excluded from the model
+    case_df = case_df.drop_duplicates(keep='first')
 
     _, smoothed = prepare_cases(case_df)
 

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -24,15 +24,13 @@ class TestCalculateRt(TestCase):
 
         resp = self.get_response_json()
 
-        for date in data['dates']:
-            rt = next(x for x in resp['Rt'] if x['date'] == date)
-            self.assertIsInstance(rt['value'], float)
+        # the earliest date should not be present in the response
+        for metric in ['Rt', 'low90', 'high90']:
+            self.assertEqual(len(resp[metric]), len(data['dates']) - 1)
 
-            rt = next(x for x in resp['low90'] if x['date'] == date)
-            self.assertIsInstance(rt['value'], float)
-
-            rt = next(x for x in resp['high90'] if x['date'] == date)
-            self.assertIsInstance(rt['value'], float)
+            for date in data['dates'][1:]:
+                rt = next(x for x in resp[metric] if x['date'] == date)
+                self.assertIsInstance(rt['value'], float)
 
 
     def test_invalid_input(self):

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -69,8 +69,8 @@ class TestCalculateRt(TestCase):
 
     def test_exclude_duplicates(self):
         data = {
-        'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
-        'cases': [50, 66, 66, 129]
+            'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
+            'cases': [50, 66, 66, 129]
         }
         self.req.get_json.return_value = data
 

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -41,7 +41,7 @@ class TestCalculateRt(TestCase):
         resp = self.get_response_json()
 
         self.assertIn('error', resp)
-        self.assertRaises(Exception, self.verify_response_data, resp, [])
+        self.assertRaises(KeyError, self.verify_response_data, resp, [])
 
     def test_empty_input(self):
         data = {
@@ -52,7 +52,7 @@ class TestCalculateRt(TestCase):
 
         resp = self.get_response_json()
         self.assertIn('error', resp)
-        self.assertRaises(Exception, self.verify_response_data, resp, data['dates'])
+        self.assertRaises(KeyError, self.verify_response_data, resp, data['dates'])
 
     def test_no_change_threshold(self):
         # even if there is little to no change day-over-day,


### PR DESCRIPTION
## Description of the change

Makes two changes to the Rt function requested by @justkunz: 
- drop the first day's Rt value because it is not meaningful and will always be 0 
- drop duplicate case counts in consecutive input records

The difference this produces can be quite dramatic – I tested it with some real-ish data from our aggregated dataset.

Current prod:
![Screen Shot 2020-05-14 at 4 02 54 PM](https://user-images.githubusercontent.com/5385319/81995035-17197e80-95fe-11ea-9c46-bcc726079c1a.png)

After dropping the first day (same values but much more readable):
![Screen Shot 2020-05-14 at 3 32 02 PM](https://user-images.githubusercontent.com/5385319/81995058-28628b00-95fe-11ea-8841-09bc9403ad50.png)

After filtering out duplicates:
![Screen Shot 2020-05-14 at 3 55 02 PM](https://user-images.githubusercontent.com/5385319/81995069-30222f80-95fe-11ea-869c-d0367ffb1fe6.png)

No frontend changes were necessary, the Rt timeseries component already handles this and ensures there are at least two data points returned from the server before attempting to display the chart. (The other Rt features aren't affected by this because they only care about one value at a time.)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #292 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
