### PR TITLE
Add Rt empty state aka "not enough data"

### DIFF
--- a/src/design-system/Colors.tsx
+++ b/src/design-system/Colors.tsx
@@ -45,6 +45,7 @@ const Colors = {
   opacityGray: hexAlpha(BaseColors.forestGray, 0.2),
   forest50: hexAlpha(BaseColors.forest, 0.5),
   forest30: hexAlpha(BaseColors.forest, 0.5),
+  darkRed10: hexAlpha(BaseColors.darkRed, 0.1),
 };
 
 // Shared colors for the Projection charts

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -71,7 +71,7 @@ const CancelButton = styled(ModalButton)`
   color: ${Colors.forest};
 `;
 
-const RtChartEmptyState = styled.div`
+const RtChartEmptyState = styled.button`
   display: flex;
   align-items: center;
   text-align: center;
@@ -256,10 +256,21 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           {rtTimeseriesData ? (
             <RtTimeseries data={rtTimeseriesData} />
           ) : (
-            <RtChartEmptyState>
-              Live rate of spread could not be calculated for this facility.
-              Click here to add at least 10 days of confirmed case data.
-            </RtChartEmptyState>
+            facility && (
+              <AddCasesRow>
+                <AddCasesModal
+                  facility={facility}
+                  trigger={
+                    <RtChartEmptyState>
+                      Live rate of spread could not be calculated for this
+                      facility. Click here to add at least 10 days of confirmed
+                      case data.
+                    </RtChartEmptyState>
+                  }
+                  onSave={onModalSave}
+                />
+              </AddCasesRow>
+            )
           )}
         </RtChartContainer>
 

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -1,11 +1,9 @@
 import { navigate } from "gatsby";
-import hexAlpha from "hex-alpha";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
 import { deleteFacility, saveFacility } from "../database/index";
 import Colors from "../design-system/Colors";
-import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import iconDuplicatePath from "../design-system/icons/ic_duplicate.svg";
 import InputButton, { StyledButton } from "../design-system/InputButton";
 import InputDescription from "../design-system/InputDescription";
@@ -71,18 +69,6 @@ const CancelButton = styled(ModalButton)`
   color: ${Colors.forest};
 `;
 
-const RtChartEmptyState = styled.button`
-  display: flex;
-  align-items: center;
-  text-align: center;
-  border: 1px solid ${Colors.darkRed};
-  border-radius: 2px;
-  background-color: ${Colors.darkRed10};
-  color: ${Colors.darkRed};
-  padding: 20px;
-  height: 200px;
-`;
-
 const borderStyle = `1px solid ${Colors.paleGreen}`;
 
 export const SectionHeader = styled.header`
@@ -115,21 +101,6 @@ const AddCasesButton = styled.button`
   font-family: "Poppins", sans-serif;
   font-size: 12px;
   line-height: 1.3;
-`;
-
-const ChartHeader = styled.div`
-  align-items: baseline;
-  border-bottom: ${borderStyle};
-  display: flex;
-  justify-content: space-between;
-`;
-
-const ChartTitle = styled.div`
-  color: ${hexAlpha(Colors.forest, 0.7)};
-  font-family: "Poppins", sans-serif;
-  font-size: 9px;
-  font-weight: 600;
-  padding: 5px 0;
 `;
 
 interface Props {
@@ -188,14 +159,6 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
     updateShowDeleteModal(false);
   };
 
-  const rtTimeseriesData = facility
-    ? rtData
-      ? rtData[facility.id]
-      : undefined
-    : // when creating a new facility, there will never be Rt data;
-      // setting this value to null will suppress the chart
-      null;
-
   const onModalSave = (newFacility: Facility) => {
     updateFacility(newFacility);
     updateFacilityRtData(newFacility, dispatchRtData);
@@ -241,38 +204,14 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
         </DescRow>
         <div className="mt-5 mb-5 border-b border-gray-300" />
 
-        <RtChartContainer>
-          <ChartHeader>
-            <ChartTitle>Rate of Spread</ChartTitle>
-            {rtTimeseriesData && (
-              <HelpButtonWithTooltip>
-                This chart shows the rate of spread of Covid-19 over time. When
-                the Rt value is above 1 (the red line), the virus is spreading.
-                If the Rt value is below 1, the virus is on track to be
-                extinguished at this facility.
-              </HelpButtonWithTooltip>
-            )}
-          </ChartHeader>
-          {rtTimeseriesData ? (
-            <RtTimeseries data={rtTimeseriesData} />
-          ) : (
-            facility && (
-              <AddCasesRow>
-                <AddCasesModal
-                  facility={facility}
-                  trigger={
-                    <RtChartEmptyState>
-                      Live rate of spread could not be calculated for this
-                      facility. Click here to add at least 3 days of confirmed
-                      case data.
-                    </RtChartEmptyState>
-                  }
-                  onSave={onModalSave}
-                />
-              </AddCasesRow>
-            )
-          )}
-        </RtChartContainer>
+        {facility && (
+          <RtChartContainer>
+            <RtTimeseries
+              facility={facility}
+              data={rtData ? rtData[facility.id] : undefined}
+            />
+          </RtChartContainer>
+        )}
 
         <LocaleInformationSection
           systemType={systemType}

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -1,9 +1,11 @@
 import { navigate } from "gatsby";
+import hexAlpha from "hex-alpha";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
 import { deleteFacility, saveFacility } from "../database/index";
 import Colors from "../design-system/Colors";
+import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import iconDuplicatePath from "../design-system/icons/ic_duplicate.svg";
 import InputButton, { StyledButton } from "../design-system/InputButton";
 import InputDescription from "../design-system/InputDescription";
@@ -69,6 +71,18 @@ const CancelButton = styled(ModalButton)`
   color: ${Colors.forest};
 `;
 
+const RtChartEmptyState = styled.div`
+  display: flex;
+  align-items: center;
+  text-align: center;
+  border: 1px solid ${Colors.darkRed};
+  border-radius: 2px;
+  background-color: ${Colors.darkRed10};
+  color: ${Colors.darkRed};
+  padding: 20px;
+  height: 200px;
+`;
+
 const borderStyle = `1px solid ${Colors.paleGreen}`;
 
 export const SectionHeader = styled.header`
@@ -101,6 +115,21 @@ const AddCasesButton = styled.button`
   font-family: "Poppins", sans-serif;
   font-size: 12px;
   line-height: 1.3;
+`;
+
+const ChartHeader = styled.div`
+  align-items: baseline;
+  border-bottom: ${borderStyle};
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ChartTitle = styled.div`
+  color: ${hexAlpha(Colors.forest, 0.7)};
+  font-family: "Poppins", sans-serif;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 5px 0;
 `;
 
 interface Props {
@@ -213,7 +242,25 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
         <div className="mt-5 mb-5 border-b border-gray-300" />
 
         <RtChartContainer>
-          <RtTimeseries data={rtTimeseriesData} />
+          <ChartHeader>
+            <ChartTitle>Rate of Spread</ChartTitle>
+            {rtTimeseriesData && (
+              <HelpButtonWithTooltip>
+                This chart shows the rate of spread of Covid-19 over time. When
+                the Rt value is above 1 (the red line), the virus is spreading.
+                If the Rt value is below 1, the virus is on track to be
+                extinguished at this facility.
+              </HelpButtonWithTooltip>
+            )}
+          </ChartHeader>
+          {rtTimeseriesData ? (
+            <RtTimeseries data={rtTimeseriesData} />
+          ) : (
+            <RtChartEmptyState>
+              Live rate of spread could not be calculated for this facility.
+              Click here to add at least 10 days of confirmed case data.
+            </RtChartEmptyState>
+          )}
         </RtChartContainer>
 
         <LocaleInformationSection

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -263,7 +263,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
                   trigger={
                     <RtChartEmptyState>
                       Live rate of spread could not be calculated for this
-                      facility. Click here to add at least 10 days of confirmed
+                      facility. Click here to add at least 3 days of confirmed
                       case data.
                     </RtChartEmptyState>
                   }

--- a/src/rt-timeseries/RtTimeseries.tsx
+++ b/src/rt-timeseries/RtTimeseries.tsx
@@ -1,5 +1,4 @@
 import { scaleTime, timeFormat } from "d3";
-import hexAlpha from "hex-alpha";
 import numeral from "numeral";
 // no type defs for Semiotic
 const ResponsiveXYFrame = require("semiotic/lib/ResponsiveXYFrame") as any;
@@ -9,7 +8,6 @@ import styled from "styled-components";
 import ChartTooltip from "../design-system/ChartTooltip";
 import ChartWrapper from "../design-system/ChartWrapper";
 import Colors, { lighten } from "../design-system/Colors";
-import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import { RtData, RtRecord } from "../infection-model/rt";
 
 interface Props {
@@ -24,27 +22,11 @@ type Line = {
 
 const formatDate = timeFormat("%B %-d");
 
-const borderStyle = `1px solid ${Colors.paleGreen}`;
 const RtTimeseriesWrapper = styled(ChartWrapper)`
   .uncertainty {
     fill: ${Colors.darkGray};
     fill-opacity: 0.3;
   }
-`;
-
-const ChartHeader = styled.div`
-  align-items: baseline;
-  border-bottom: ${borderStyle};
-  display: flex;
-  justify-content: space-between;
-`;
-
-const ChartTitle = styled.div`
-  color: ${hexAlpha(Colors.forest, 0.7)};
-  font-family: "Poppins", sans-serif;
-  font-size: 9px;
-  font-weight: 600;
-  padding: 5px 0;
 `;
 
 export const TooltipContents = styled.div`
@@ -59,6 +41,7 @@ export const TooltipLabel = styled.div`
   font-size: 11px;
   font-weight: normal;
 `;
+
 export const TooltipValue = styled.div`
   font-size: 14px;
   font-weight: 600;
@@ -104,15 +87,6 @@ const RtTimeseries: React.FC<Props> = ({ data }) => {
 
   return (
     <RtTimeseriesWrapper>
-      <ChartHeader>
-        <ChartTitle>Rate of Spread</ChartTitle>
-        <HelpButtonWithTooltip>
-          This chart shows the rate of spread of Covid-19 over time. When the Rt
-          value is above 1 (the red line), the virus is spreading. If the Rt
-          value is below 1, the virus is on track to be extinguished at this
-          facility.
-        </HelpButtonWithTooltip>
-      </ChartHeader>
       <ResponsiveXYFrame
         annotations={[
           {

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -1,21 +1,107 @@
-import React from "react";
+import hexAlpha from "hex-alpha";
+import React, { useContext, useState } from "react";
+import styled from "styled-components";
 
+import Colors from "../design-system/Colors";
+import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import Loading from "../design-system/Loading";
 import { RtData } from "../infection-model/rt";
+import { updateFacilityRtData } from "../infection-model/rt";
+import AddCasesModal from "../page-multi-facility/AddCasesModal";
+import { FacilityContext } from "../page-multi-facility/FacilityContext";
+import { Facility } from "../page-multi-facility/types";
 import RtTimeseries from "./RtTimeseries";
+
+const borderStyle = `1px solid ${Colors.paleGreen}`;
+
+const ChartHeader = styled.div`
+  align-items: baseline;
+  border-bottom: ${borderStyle};
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ChartTitle = styled.div`
+  color: ${hexAlpha(Colors.forest, 0.7)};
+  font-family: "Poppins", sans-serif;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 5px 0;
+`;
+
+const AddCasesRow = styled.div`
+  margin-bottom: 16px;
+`;
+
+const RtChartEmptyState = styled.button`
+  display: flex;
+  align-items: center;
+  text-align: center;
+  border: 1px solid ${Colors.darkRed};
+  border-radius: 2px;
+  background-color: ${Colors.darkRed10};
+  color: ${Colors.darkRed};
+  padding: 20px;
+  height: 200px;
+`;
 
 interface Props {
   data?: RtData | null;
+  facility: Facility;
 }
 
 const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
-  const notEnoughData = data && data.Rt.length < 2;
-  return data ? (
-    notEnoughData ? null : (
-      <RtTimeseries data={data} />
-    )
-  ) : data === null ? null : (
-    <Loading />
+  const { facility: initialFacility, dispatchRtData } = useContext(
+    FacilityContext,
+  );
+  const [facility, updateFacility] = useState(initialFacility);
+
+  const onModalSave = (newFacility: Facility) => {
+    updateFacility(newFacility);
+    updateFacilityRtData(newFacility, dispatchRtData);
+  };
+
+  const isLoading = data === undefined;
+  const notEnoughData = data === null || (data && data.Rt.length < 2);
+
+  if (isLoading) return <Loading />;
+
+  return (
+    <>
+      <ChartHeader>
+        <ChartTitle>Rate of Spread</ChartTitle>
+        {data && (
+          <HelpButtonWithTooltip>
+            This chart shows the rate of spread of Covid-19 over time. When the
+            Rt value is above 1 (the red line), the virus is spreading. If the
+            Rt value is below 1, the virus is on track to be extinguished at
+            this facility.
+          </HelpButtonWithTooltip>
+        )}
+      </ChartHeader>
+
+      {notEnoughData ? (
+        <>
+          {facility && (
+            <AddCasesRow>
+              <AddCasesModal
+                facility={facility}
+                trigger={
+                  <RtChartEmptyState>
+                    Live rate of spread could not be calculated for this
+                    facility. Click here to add at least 3 days of confirmed
+                    case data.
+                  </RtChartEmptyState>
+                }
+                onSave={onModalSave}
+              />
+            </AddCasesRow>
+          )}
+        </>
+      ) : (
+        <>{data && <RtTimeseries data={data} />}</>
+      )}
+    </>
   );
 };
 

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -80,9 +80,8 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
         )}
       </ChartHeader>
 
-      {notEnoughData ? (
-        <>
-          {facility && (
+      {notEnoughData
+        ? facility && (
             <AddCasesRow>
               <AddCasesModal
                 facility={facility}
@@ -96,11 +95,8 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
                 onSave={onModalSave}
               />
             </AddCasesRow>
-          )}
-        </>
-      ) : (
-        <>{data && <RtTimeseries data={data} />}</>
-      )}
+          )
+        : data && <RtTimeseries data={data} />}
     </>
   );
 };


### PR DESCRIPTION
## Description of the change

When there isn't enough data to generate a Rt chart, show a red box / button "empty state" instead that is the same action as the "Add or update cases" modal.

Question mark icon with tooltip appears conditionally when there is data.

IS:
![empty-state](https://user-images.githubusercontent.com/1372946/82369575-19982180-99cc-11ea-8904-45db5beb4fbe.gif)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of https://github.com/Recidiviz/covid19-dashboard/issues/280

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
