### PR TITLE
Get facilities RtData by facility ID on response impact page

### DIFF
--- a/src/hooks/useFacilitiesRtData.tsx
+++ b/src/hooks/useFacilitiesRtData.tsx
@@ -1,14 +1,24 @@
+import { pick } from "lodash";
 import { useContext, useEffect } from "react";
 
 import { FacilityEvents } from "../constants/dispatchEvents";
 import { getRtDataForFacility } from "../infection-model/rt";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
-import { Facilities } from "../page-multi-facility/types";
+import { Facilities, RtDataMapping } from "../page-multi-facility/types";
+
+export function getFacilitiesRtDataById(
+  rtData: RtDataMapping | undefined,
+  facilities: Facilities,
+) {
+  if (!rtData) return null;
+  const facilityIds = facilities.map((f) => f.id);
+  return pick(rtData, facilityIds);
+}
 
 const useFacilitiesRtData = (facilities: Facilities | null) => {
   const { rtData, dispatchRtData } = useContext(FacilityContext);
 
-  async function getRtDataForFacilities(facilities: Facilities) {
+  async function fetchRtDataForFacilities(facilities: Facilities) {
     return await Promise.all(
       [...facilities].map(async (facility) => {
         // don't fetch data if we already have it
@@ -26,7 +36,7 @@ const useFacilitiesRtData = (facilities: Facilities | null) => {
   useEffect(
     () => {
       if (facilities) {
-        getRtDataForFacilities(facilities);
+        fetchRtDataForFacilities(facilities);
       }
     },
     // omitting dispatchRtData because it's not a stable reference,

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -8,7 +8,9 @@ import iconBackSrc from "../design-system/icons/ic_back.svg";
 import Loading from "../design-system/Loading";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import { Spacer } from "../design-system/Spacer";
-import useFacilitiesRtData from "../hooks/useFacilitiesRtData";
+import useFacilitiesRtData, {
+  getFacilitiesRtDataById,
+} from "../hooks/useFacilitiesRtData";
 import { sumAgeGroupPopulations } from "../impact-dashboard/EpidemicModelContext";
 import { useLocaleDataState } from "../locale-data-context";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
@@ -79,6 +81,8 @@ const ResponseImpactDashboard: React.FC<Props> = ({
   const [populationFormSubmitted, setPopulationFormSubmitted] = useState(false);
 
   useFacilitiesRtData(facilities.data);
+
+  const facilitiesRtData = getFacilitiesRtDataById(rtData, facilities.data);
 
   async function saveBaselinePopulations(populations: BaselinePopulations) {
     const initialPopulations = scenario?.baselinePopulations || [];
@@ -183,7 +187,9 @@ const ResponseImpactDashboard: React.FC<Props> = ({
                     <ChartHeader>
                       Rate of spread, R(t), for modelled facilities
                     </ChartHeader>
-                    {rtData && <RtSummaryStats rtData={rtData} />}
+                    {facilitiesRtData && (
+                      <RtSummaryStats rtData={facilitiesRtData} />
+                    )}
                     <SectionSubheader>
                       Peak impact on community health and staff resources
                     </SectionSubheader>


### PR DESCRIPTION
## Description of the change

I'm sorry for introducing this bug! This PR adds a helper function that selects the `rtData` using the facility IDs on the current scenario for the response impact page. I saw this as the quick way to fix this issue, and if anyone has a suggestion for changing how the state is managed I'm happy to work on that too. I thought about saving the `rtData` by scenario ID and facility ID, but thought that would ripple a lot fo changes throughout and wanted to get a fix up soon. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #444 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
