### PR TITLE
Update Firestore rules to support "viewer" role

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -9,18 +9,34 @@ service cloud.firestore {
 
   match /databases/{database}/documents {
     match /scenarios/{scenario} {
-      function userCanAccess(scenario) {
-        return scenario.data.roles[request.auth.uid] == 'owner';
+      function userIsOwner(scenario) {
+      	return request.auth.uid in scenario.data.roles
+        	? scenario.data.roles[request.auth.uid] == 'owner'
+          : false;
       }
 
+      function userIsViewer(scenario) {
+        return request.auth.uid in scenario.data.roles
+        	? scenario.data.roles[request.auth.uid] == 'viewer'
+          : false;
+      }
+
+      // any authenticated user can create scenarios for themselves
       allow create: if request.auth.uid != null;
 
-      // Scenario owners (and only scenario owners) should have read/write access to their scenarios and child documents
-      allow read, write: if userCanAccess(resource);
+      // Only scenario owners should have read/write access to their scenarios
+      allow read, write: if userIsOwner(resource);
+
+      // Scenario viewers should only be able to read scenarios
+      allow read: if userIsViewer(resource);
 
       match /{documents=**} {
-        allow read, delete, update: if userCanAccess(get(/databases/$(database)/documents/scenarios/$(scenario)));
-        allow create: if userCanAccess(getAfter(/databases/$(database)/documents/scenarios/$(scenario)));
+      	// owners have full CRUD access to scenario children
+        allow read, delete, update: if userIsOwner(get(/databases/$(database)/documents/scenarios/$(scenario)));
+        allow create: if userIsOwner(getAfter(/databases/$(database)/documents/scenarios/$(scenario)));
+
+        // viewers can only read scenario children
+        allow read: if userIsViewer(get(/databases/$(database)/documents/scenarios/$(scenario)));
       }
     }
   }

--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -10,14 +10,14 @@ service cloud.firestore {
   match /databases/{database}/documents {
     match /scenarios/{scenario} {
       function userIsOwner(scenario) {
-      	return request.auth.uid in scenario.data.roles
-        	? scenario.data.roles[request.auth.uid] == 'owner'
+        return request.auth.uid in scenario.data.roles
+          ? scenario.data.roles[request.auth.uid] == 'owner'
           : false;
       }
 
       function userIsViewer(scenario) {
         return request.auth.uid in scenario.data.roles
-        	? scenario.data.roles[request.auth.uid] == 'viewer'
+          ? scenario.data.roles[request.auth.uid] == 'viewer'
           : false;
       }
 
@@ -31,7 +31,7 @@ service cloud.firestore {
       allow read: if userIsViewer(resource);
 
       match /{documents=**} {
-      	// owners have full CRUD access to scenario children
+        // owners have full CRUD access to scenario children
         allow read, delete, update: if userIsOwner(get(/databases/$(database)/documents/scenarios/$(scenario)));
         allow create: if userIsOwner(getAfter(/databases/$(database)/documents/scenarios/$(scenario)));
 


### PR DESCRIPTION
## Description of the change

Distinguishes between owners (full read/write access) and viewers (read only) in Firestore security rules pertaining to scenarios and their descendants. 

I tested these against the `scenario_test` collection in the Firestore rules playground (they are currently deployed for that collection for anyone who'd like to do their own testing) and also verified there are no regressions in the app against that collection with these rules in place. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #428 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
