### PR TITLE
rules for new users collection

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -8,6 +8,10 @@ service cloud.firestore {
   }
 
   match /databases/{database}/documents {
+    function userIsAuthenticated() {
+      return request.auth.uid != null;
+    }
+
     match /scenarios/{scenario} {
       function userIsOwner(scenario) {
         return request.auth.uid in scenario.data.roles
@@ -22,7 +26,7 @@ service cloud.firestore {
       }
 
       // any authenticated user can create scenarios for themselves
-      allow create: if request.auth.uid != null;
+      allow create: if userIsAuthenticated();
 
       // Only scenario owners should have read/write access to their scenarios
       allow read, write: if userIsOwner(resource);
@@ -38,6 +42,15 @@ service cloud.firestore {
         // viewers can only read scenario children
         allow read: if userIsViewer(get(/databases/$(database)/documents/scenarios/$(scenario)));
       }
+    }
+
+    match /users/{user} {
+      function userIsSelf(user) {
+        return user.data.auth0Id == request.auth.uid;
+      }
+
+      allow read: if userIsAuthenticated();
+      allow write: if userIsSelf(resource);
     }
   }
 }


### PR DESCRIPTION
## Description of the change

A `users` collection now exists in our Firestore instance (because I created it). This defines the necessary db access rules on that collection to support scenario sharing.

I tested these rules in the Firestore console rules simulator.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #430 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
