### PR TITLE
Add authenticated users to Firestore 

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -50,7 +50,8 @@ service cloud.firestore {
       }
 
       allow read: if userIsAuthenticated();
-      allow write: if userIsSelf(resource);
+      allow update, delete: if userIsSelf(resource) && userIsSelf(request.resource);
+      allow create: if userIsSelf(request.resource);
     }
   }
 }

--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -50,7 +50,7 @@ service cloud.firestore {
       }
 
       allow read: if userIsAuthenticated();
-      allow update, delete: if userIsSelf(resource) && userIsSelf(request.resource);
+      allow update: if userIsSelf(resource) && userIsSelf(request.resource);
       allow create: if userIsSelf(request.resource);
     }
   }

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -6,5 +6,4 @@ The Auth0 tenant for the production, hosted instance of this app is controlled b
 If you are working with Recidiviz on the production instance, reach out to covid@recidiviz.org
 about receiving your log in credentials.
 
-All files included in this directory are copied directly from Auth0 docs. They are unmodified with
-the exception of updates to import paths.
+All files included in this directory are adapted from Auth0 docs.

--- a/src/auth/react-auth0-spa.tsx
+++ b/src/auth/react-auth0-spa.tsx
@@ -77,6 +77,7 @@ export const Auth0Provider = ({
     setUser(user);
   };
 
+  // This hook is specific to our application and not derived from Auth0 example code
   useEffect(() => {
     async function updateStoredUser() {
       if (user !== undefined) {

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -382,7 +382,7 @@ export const saveUser = async (userData: UserToSave): Promise<void> => {
       db.collection(usersCollectionId).add(buildCreatePayload(userData));
     }
   } catch (e) {
-    console.error("Encounter error while trying to save user:\n", e);
+    console.error("Encountered error while trying to save user:\n", e);
   }
 };
 

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -7,15 +7,22 @@ import "firebase/firestore";
 import createAuth0Client from "@auth0/auth0-spa-js";
 import { format, startOfDay, startOfToday } from "date-fns";
 import { pick, orderBy, uniqBy } from "lodash";
+import { Optional } from "utility-types";
 
 import config from "../auth/auth_config.json";
 import { MMMMdyyyy } from "../constants";
 import { persistedKeys } from "../impact-dashboard/EpidemicModelContext";
-import { Facility, ModelInputs, Scenario } from "../page-multi-facility/types";
+import {
+  Facility,
+  ModelInputs,
+  Scenario,
+  User,
+} from "../page-multi-facility/types";
 import {
   buildFacility,
   buildModelInputs,
   buildScenario,
+  buildUser,
 } from "./type-transforms";
 
 // As long as there is just one Auth0 config, this endpoint will work with any environment (local, prod, etc.).
@@ -24,6 +31,7 @@ const tokenExchangeEndpoint =
 const scenariosCollectionId = "scenarios";
 const facilitiesCollectionId = "facilities";
 const modelVersionCollectionId = "modelVersions";
+const usersCollectionId = "users";
 
 // Note: None of these are secrets.
 let firebaseConfig = {
@@ -325,6 +333,56 @@ export const getFacilityModelVersions = async ({
     );
     console.error(error);
     return [];
+  }
+};
+
+export const getUser = async (auth0Id: string): Promise<User | null> => {
+  try {
+    const db = await getDb();
+    const userResult = await db
+      .collection(usersCollectionId)
+      .where("auth0Id", "==", auth0Id)
+      .get();
+    if (userResult.docs.length > 1) {
+      throw new Error(`Multiple users found matching id ${auth0Id}`);
+    } else if (userResult.docs.length === 0) {
+      throw new Error(`No users found matching id ${auth0Id}`);
+    }
+    return buildUser(userResult.docs[0]);
+  } catch (e) {
+    console.error("Encountered error while attempting to retrieve user: \n", e);
+    return null;
+  }
+};
+
+type UserToSave = Omit<User, "id"> &
+  Optional<User, "id"> & {
+    auth0Id?: string;
+  };
+
+export const saveUser = async (userData: UserToSave): Promise<void> => {
+  const db = await getDb();
+
+  try {
+    if (userData.id) {
+      // we are updating an existing user
+      db.collection(usersCollectionId)
+        .doc(userData.id)
+        .update(buildUpdatePayload(userData));
+    } else {
+      // we are creating a new user
+      // auth0Id is needed for lookups so don't allow creation without it
+      if (!userData.auth0Id) {
+        throw new Error(
+          `Missing required field "auth0Id" in object ${JSON.stringify(
+            userData,
+          )}`,
+        );
+      }
+      db.collection(usersCollectionId).add(buildCreatePayload(userData));
+    }
+  } catch (e) {
+    console.error("Encounter error while trying to save user:\n", e);
   }
 };
 

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -1,8 +1,14 @@
 import { parseISO } from "date-fns";
 import * as firebase from "firebase/app";
+import { pick } from "lodash";
 
 import { PlannedRelease } from "../impact-dashboard/EpidemicModelContext";
-import { Facility, ModelInputs, Scenario } from "../page-multi-facility/types";
+import {
+  Facility,
+  ModelInputs,
+  Scenario,
+  User,
+} from "../page-multi-facility/types";
 
 const timestampToDate = (timestamp: firebase.firestore.Timestamp): Date => {
   return timestamp.toDate();
@@ -80,4 +86,10 @@ export const buildScenario = (
   });
 
   return scenario;
+};
+
+export const buildUser = (document: firebase.firestore.DocumentData): User => {
+  const data = document.data();
+
+  return { ...pick(data, ["name", "email"]), id: document.id };
 };

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -49,3 +49,9 @@ export type BaselinePopulations = {
   staffPopulation: number;
   incarceratedPopulation: number;
 };
+
+export type User = {
+  id: string;
+  name: string;
+  email: string;
+};


### PR DESCRIPTION
## Description of the change

Creates fetch and save functions for documents in the new Firestore `users` collection. Upon successful authentication, uses these new functions as needed to create or update the corresponding document to store the name and email provided by Auth0. (This is a slightly different approach than what was outlined in the linked tickets, because there is not, as far as I could tell, any way to detect and respond to a new user registration from the Auth0 web client. On the other hand, this also gets us a bonus feature of keeping our records in sync with Auth0 as people revisit the site.)

I also had to update the Firestore security rules, because it turns out there was a flaw in my testing previously and it wasn't actually possible to create a new user document for oneself. These rules (tested in the Firestore console and locally) should allow for that and also forbid users from changing their Auth0 ids (whether inadvertently or for malicious reasons, whatever those might be). The rules are already live — I needed them in place to test this, and no prod code refers to the collection yet anyway, so it should be safe.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #432, closes #431, closes #435 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
