### PR TITLE
Add chart header, bar color change on hover for historical cases graph on facility page.

### DIFF
--- a/src/page-multi-facility/HistoricalCasesChart/ChartHeader.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/ChartHeader.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import styled from "styled-components";
+
+import Colors from "../../design-system/Colors";
+import addIcon from "./icons/ic_plus.svg";
+
+const ChartHeaderDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(70, 116, 114, 0.2);
+  border-top: 1px solid rgba(70, 116, 114, 0.2);
+  margin-bottom: 1.5rem;
+`;
+
+const ChartTabContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+`;
+
+const ChartTab = styled.label`
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 16px;
+  font-style: normal;
+  font-family: "Poppins", sans serif;
+  color: ${Colors.forest};
+  padding-bottom: 4px;
+  border-bottom: 1px solid ${Colors.forest};
+  cursor: pointer;
+  margin-right: 1.625rem;
+`;
+
+const AddHistoricalDataButton = styled.button`
+  background: ${Colors.green};
+  height: 27px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid ${Colors.darkGray};
+  border-left: 1px solid ${Colors.darkGray};
+`;
+
+const AddHistoricalDataLabel = styled.label`
+  font-family: "Poppins", sans serif;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 9px;
+  line-height: 16px;
+  color: ${Colors.white};
+  opacity: 0.7;
+  display: inline;
+  margin-left: 1rem;
+  margin-right: 1rem;
+`;
+
+const AddButtonImg = styled.img`
+  display: inline;
+  margin-left: 1rem;
+  opacity: 0.7;
+`;
+
+interface ChartHeaderProps {
+  setModalOpen: (modalOpen: boolean) => void;
+}
+
+const ChartHeader: React.FC<ChartHeaderProps> = ({ setModalOpen }) => {
+  return (
+    <ChartHeaderDiv>
+      <ChartTabContainer>
+        <ChartTab>Cases</ChartTab>
+      </ChartTabContainer>
+      <AddHistoricalDataButton onClick={() => setModalOpen(true)}>
+        <AddButtonImg src={addIcon} />
+        <AddHistoricalDataLabel>Add historical data</AddHistoricalDataLabel>
+      </AddHistoricalDataButton>
+    </ChartHeaderDiv>
+  );
+};
+
+export default ChartHeader;

--- a/src/page-multi-facility/HistoricalCasesChart/ChartHeader.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/ChartHeader.tsx
@@ -55,6 +55,7 @@ const AddHistoricalDataLabel = styled.label`
   display: inline;
   margin-left: 1rem;
   margin-right: 1rem;
+  cursor: pointer;
 `;
 
 const AddButtonImg = styled.img`

--- a/src/page-multi-facility/HistoricalCasesChart/icons/ic_plus.svg
+++ b/src/page-multi-facility/HistoricalCasesChart/icons/ic_plus.svg
@@ -1,0 +1,4 @@
+<svg width="11" height="11" viewBox="0 0 11 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.3172 1V9.55458" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.55382 5.19629H1" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/page-multi-facility/HistoricalCasesChart/index.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/index.tsx
@@ -92,16 +92,25 @@ const HistoricalCasesChart: React.FC<Props> = ({ facility, onModalSave }) => {
     getDatesInterval(startDate, dateFns.addDays(startDate, numDays)),
   );
 
+  const [hoveredPieceKey, setHoveredPieceKey] = useState<number | null>();
+
   if (!facility) return null;
 
   const frameProps = {
     data,
     oPadding: 1,
-    style: () => {
+    style: (d: { renderKey: number }) => {
       return {
-        fill: Colors.opacityForest,
-        stroke: "white",
+        fill: d.renderKey == hoveredPieceKey ? Colors.teal : Colors.forest,
+        stroke: Colors.white,
       };
+    },
+    customHoverBehavior: (d: { pieces: { renderKey: number }[] }) => {
+      if (d) {
+        setHoveredPieceKey(d.pieces[0].renderKey);
+      } else {
+        setHoveredPieceKey(null);
+      }
     },
     type: "bar",
     axes: [

--- a/src/page-multi-facility/HistoricalCasesChart/index.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/index.tsx
@@ -9,6 +9,7 @@ import useFacilityModelVersions from "../../hooks/useFacilityModelVersions";
 import { totalConfirmedCases } from "../../impact-dashboard/EpidemicModelContext";
 import { Facility, ModelInputs } from "../types";
 import BarChartTooltip, { Summary } from "./BarChartTooltip";
+import ChartHeader from "./ChartHeader";
 import HistoricalAddCasesModal from "./HistoricalAddCasesModal";
 import ScrollChartDates from "./ScrollChartDates";
 
@@ -135,6 +136,7 @@ const HistoricalCasesChart: React.FC<Props> = ({ facility, onModalSave }) => {
 
   return (
     <ChartWrapper>
+      <ChartHeader setModalOpen={setModalOpen} />
       <ResponsiveOrdinalFrame {...frameProps} />
       <ScrollChartDates
         endDate={endDate}


### PR DESCRIPTION
## Description of the change

Adds the following features from #404 TODO's:
- Change the bar's color to a darker color on hover to signify it as a click target
- Add the chart header with the Cases title and a button that opens the Add Cases modal with yesterday's date pre-selected (or what the current default date is)
![Kapture 2020-05-19 at 16 14 56](https://user-images.githubusercontent.com/6414261/82387481-01d09580-99ec-11ea-829a-022ae5a5c48a.gif)

Based off Daniela's branch.

Note:
- There is some delay while changing the bar color on hover. It seems to be from the library (using customHoverBehavior). So I changed the hover color to be teal instead of green to make it more obvious. @sychang lmk if this doesn't work.
Other options for this:
1. pieceHoverAnnotation, which changes bar color on hover instantaneously, but doesn't give the tooltip for days with missing data.
2. hoverAnnotation, which will change the color of all bars with data on hover.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #404 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
