### PR TITLE
use opacity on datepicker show/hide

### DIFF
--- a/src/design-system/InputDate.css
+++ b/src/design-system/InputDate.css
@@ -211,7 +211,10 @@
   z-index: 1;
 }
 .react-date-picker__calendar--closed {
-  display: none;
+  opacity: 0;
+}
+.react-date-picker__calendar--open {
+  opacity: 1;
 }
 .react-date-picker__calendar .react-calendar {
   border-width: thin;


### PR DESCRIPTION
## Description of the change

DatePicker selection not saving on Firefox.

DatePicker component with `.react-date-picker__calendar--closed` class was set to `display: none`. In Firefox, maybe element is removed from DOM before onChange method triggers? 

Using opacity to conceal/show DatePicker seems to work on Firefox (Chrome worked either way - even without InputDate.css rules on `closed`/`open`, I guess Chrome works well with `react-date-picker`'s out-of-the-box styling).

In giph, Firefox on left, Chrome on right
![fix-datepicker](https://user-images.githubusercontent.com/8259050/82521911-7b9c7800-9aed-11ea-9f33-f3324b5769da.gif)
 
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #259

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
