### PR TITLE
Bug fix - Displaying the current scenario's facilities' rtData on the rate of spread tab

### DIFF
--- a/src/hooks/useFacilitiesRtData.tsx
+++ b/src/hooks/useFacilitiesRtData.tsx
@@ -1,19 +1,9 @@
-import { pick } from "lodash";
 import { useContext, useEffect } from "react";
 
 import { FacilityEvents } from "../constants/dispatchEvents";
 import { getRtDataForFacility } from "../infection-model/rt";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
-import { Facilities, RtDataMapping } from "../page-multi-facility/types";
-
-export function getFacilitiesRtDataById(
-  rtData: RtDataMapping | undefined,
-  facilities: Facilities,
-) {
-  if (!rtData) return null;
-  const facilityIds = facilities.map((f) => f.id);
-  return pick(rtData, facilityIds);
-}
+import { Facilities } from "../page-multi-facility/types";
 
 const useFacilitiesRtData = (facilities: Facilities | null) => {
   const { rtData, dispatchRtData } = useContext(FacilityContext);

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -5,13 +5,17 @@ import {
   fromUnixTime,
   parseISO,
 } from "date-fns";
-import { mapValues, maxBy, minBy } from "lodash";
+import { mapValues, maxBy, minBy, pick } from "lodash";
 
 import { FacilityEvents } from "../constants/dispatchEvents";
 import { RateOfSpreadType } from "../constants/EpidemicModel";
 import { getFacilityModelVersions } from "../database";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
-import { Facility } from "../page-multi-facility/types";
+import {
+  Facilities,
+  Facility,
+  RtDataMapping,
+} from "../page-multi-facility/types";
 
 type RawRtRecord = {
   date: string; // timestamp
@@ -173,3 +177,12 @@ export const rtSpreadType = (rtValue: number | null | undefined) => {
     return RateOfSpreadType.Controlled;
   }
 };
+
+export function getFacilitiesRtDataById(
+  rtData: RtDataMapping | undefined,
+  facilities: Facilities,
+) {
+  if (!rtData) return null;
+  const facilityIds = facilities.map((f) => f.id);
+  return pick(rtData, facilityIds);
+}

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -9,11 +9,12 @@ import iconAddSrc from "../design-system/icons/ic_add.svg";
 import Loading from "../design-system/Loading";
 import TextLabel from "../design-system/TextLabel";
 import { useFlag } from "../feature-flags";
-import useFacilitiesRtData, {
-  getFacilitiesRtDataById,
-} from "../hooks/useFacilitiesRtData";
+import useFacilitiesRtData from "../hooks/useFacilitiesRtData";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
-import { updateFacilityRtData } from "../infection-model/rt";
+import {
+  getFacilitiesRtDataById,
+  updateFacilityRtData,
+} from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import useScenario from "../scenario-context/useScenario";
 import { FacilityContext } from "./FacilityContext";

--- a/src/page-response-impact/ResponseImpactDashboard.tsx
+++ b/src/page-response-impact/ResponseImpactDashboard.tsx
@@ -8,10 +8,9 @@ import iconBackSrc from "../design-system/icons/ic_back.svg";
 import Loading from "../design-system/Loading";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import { Spacer } from "../design-system/Spacer";
-import useFacilitiesRtData, {
-  getFacilitiesRtDataById,
-} from "../hooks/useFacilitiesRtData";
+import useFacilitiesRtData from "../hooks/useFacilitiesRtData";
 import { sumAgeGroupPopulations } from "../impact-dashboard/EpidemicModelContext";
+import { getFacilitiesRtDataById } from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
 import { BaselinePopulations, Scenario } from "../page-multi-facility/types";

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -3,8 +3,7 @@ import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Loading from "../design-system/Loading";
-import { getFacilitiesRtDataById } from "../hooks/useFacilitiesRtData";
-import { getDaysAgoRt } from "../infection-model/rt";
+import { getDaysAgoRt, getFacilitiesRtDataById } from "../infection-model/rt";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
 import { Facilities, RtDataMapping } from "../page-multi-facility/types";
 import RtComparisonChart, {


### PR DESCRIPTION
## Description of the change

I think the bug for this issue came from line 67 in the `RtComparisonChartContainer` component, where it copies the previous chartData state with the new chartData state. I'm not sure the original intention for that, so I hope that this fix isn't breaking another feature I am unaware of. Let me know if there's documentation somewhere or an issue I could look at to see what all the features/use cases of this panel should be. 

My update removes copying in the chartData state and it also removes resetting the chartData state to an empty array when `rtDaysOffset` changes. Instead I added `rtDaysOffset` to the useEffect that is calling `generateChartData`, which should reset the chartData state anytime facilities, rtDataMapping and rtDaysOffset changes. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #456 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
