### PR TITLE
Add a guard for baselinePopulations in buildScenario

### DIFF
--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -74,18 +74,22 @@ export const buildScenario = (
   scenario.id = document.id;
   scenario.createdAt = timestampToDate(documentData.createdAt);
   scenario.updatedAt = timestampToDate(documentData.updatedAt);
-  scenario.baselinePopulations = documentData.baselinePopulations.map(
-    (population: {
-      date: firebase.firestore.Timestamp;
-      incarceratedPopulation: number;
-      staffPopulation: number;
-    }) => {
-      return {
-        ...population,
-        date: timestampToDate(population.date),
-      };
-    },
-  );
+  scenario.baselinePopulations = documentData.hasOwnProperty(
+    "baselinePopulations",
+  )
+    ? documentData.baselinePopulations.map(
+        (population: {
+          date: firebase.firestore.Timestamp;
+          incarceratedPopulation: number;
+          staffPopulation: number;
+        }) => {
+          return {
+            ...population,
+            date: timestampToDate(population.date),
+          };
+        },
+      )
+    : [];
 
   // Runtime migration: make sure a default value is set for
   // promo status flags added since the last data shakeup


### PR DESCRIPTION
## Description of the change

Adds a check before mapping over baselinePopulations in the buildScenario type-transforms function.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
