### PR TITLE
Debounce inputs to make text easier to enter

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "qs": "^6.9.3",
     "react": "^16.0.0",
     "react-date-picker": "^8.0.1",
+    "react-debounce-input": "^3.2.2",
     "react-dom": "^16.0.0",
     "react-helmet": "^6.0.0",
     "react-hot-loader": "^4.12.20",

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,6 +1,5 @@
-import React from "react";
-import { DebounceInput, DebounceInputProps } from "react-debounce-input";
-import styled from "styled-components";
+import { DebounceInput } from "react-debounce-input";
+import { css } from "styled-components";
 
 import Colors from "./Colors";
 
@@ -17,16 +16,29 @@ export interface InputValueProps<T> {
 
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;
 
-type CustomDebounceInputProps = DebounceInputProps<
-  HTMLInputElement,
-  React.InputHTMLAttributes<HTMLInputElement>
->;
+/**
+ * This component has the same functionality as DebounceInput, except that it
+ * removes the type parameter. This is because we can't use DebounceInput as-is
+ * with styled-components. Specifically, we cannot do the following
+ *
+ *     let MyComponent = styled(DebounceInput<HTMLInputElement>)`
+ *       ...
+ *     `
+ *
+ * because it's invalid syntax.
+ *
+ * NOTE: This trick currently depends on DebounceInput being implemented as a
+ * class component. If it becomes a function component in the future, then we
+ * might need to use the slightly more complicated method of building a wrapper
+ * component (but it can that component can be used the same way).
+ *
+ * NOTE: If a future version of TypeScript/JSX/styled-components allows us to do
+ * this (or if there's an easier way to do this), then we should use that method
+ * instead.
+ */
+export class CustomDebounceInput extends DebounceInput<HTMLInputElement> {}
 
-const CustomDebounceInput: React.FC<CustomDebounceInputProps> = (props) => (
-  <DebounceInput<HTMLInputElement> {...props} />
-);
-
-export const StyledInput = styled(CustomDebounceInput)`
+export const InputStyle = css`
   background: ${Colors.gray};
   border-radius: 2px;
   border: none;

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -12,7 +12,6 @@ export interface InputLabelProps {
 
 export interface InputValueProps<T> {
   valueEntered: T | undefined;
-  valuePlaceholder?: T;
   onValueChange: (value: T | undefined) => void;
 }
 

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 
 import Colors from "./Colors";
@@ -11,30 +10,8 @@ export interface InputLabelProps {
 
 export interface InputValueProps<T> {
   valueEntered: T | undefined;
-  valueDefault?: T;
   valuePlaceholder?: T;
   onValueChange: (value: T | undefined) => void;
-}
-
-export function useInputValue<T>(props: InputValueProps<T>) {
-  // We display the default value when valueEntered has never existed. A naive
-  // implementation would display the default value as long as valueEntered
-  // currently does not exist, but this means that if the user clears the entire
-  // input, it would immediately be populated with the default value -- this can
-  // be unexpected behavior.
-  let [shouldShowDefault, setShouldShowDefault] = useState(
-    props.valueEntered == null,
-  );
-
-  useEffect(() => {
-    // As soon as the user has entered some value, we should never show the
-    // default value again.
-    if (shouldShowDefault && props.valueEntered != null) {
-      setShouldShowDefault(false);
-    }
-  }, [shouldShowDefault, props.valueEntered]);
-
-  return shouldShowDefault ? props.valueDefault : props.valueEntered;
 }
 
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { DebounceInput, DebounceInputProps } from "react-debounce-input";
 import styled, { css } from "styled-components";
 
 import Colors from "./Colors";
@@ -16,11 +18,22 @@ export interface InputValueProps<T> {
 
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;
 
-interface InputProps {
+interface StyleProps {
   headerStyle?: boolean;
 }
 
-export const StyledInput = styled.input<InputProps>`
+type Props = StyleProps &
+  DebounceInputProps<
+    HTMLInputElement,
+    React.InputHTMLAttributes<HTMLInputElement>
+  >;
+
+const CustomDebounceInput: React.FC<StyleProps & Props> = ({
+  headerStyle: _,
+  ...props
+}) => <DebounceInput {...props} />;
+
+export const StyledInput = styled(CustomDebounceInput)`
   background: ${Colors.gray};
   border-radius: 2px;
   border: none;

--- a/src/design-system/Input.tsx
+++ b/src/design-system/Input.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DebounceInput, DebounceInputProps } from "react-debounce-input";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import Colors from "./Colors";
 
@@ -17,20 +17,14 @@ export interface InputValueProps<T> {
 
 export type InputBaseProps<T> = InputLabelProps & InputValueProps<T>;
 
-interface StyleProps {
-  headerStyle?: boolean;
-}
+type CustomDebounceInputProps = DebounceInputProps<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>;
 
-type Props = StyleProps &
-  DebounceInputProps<
-    HTMLInputElement,
-    React.InputHTMLAttributes<HTMLInputElement>
-  >;
-
-const CustomDebounceInput: React.FC<StyleProps & Props> = ({
-  headerStyle: _,
-  ...props
-}) => <DebounceInput {...props} />;
+const CustomDebounceInput: React.FC<CustomDebounceInputProps> = (props) => (
+  <DebounceInput<HTMLInputElement> {...props} />
+);
 
 export const StyledInput = styled(CustomDebounceInput)`
   background: ${Colors.gray};
@@ -47,20 +41,4 @@ export const StyledInput = styled(CustomDebounceInput)`
   outline: 0 solid transparent;
   padding: 0 16px;
   width: 100%;
-
-  ${(props) =>
-    props.headerStyle &&
-    css`
-      font-family: "Libre Baskerville", serif;
-      font-style: normal;
-      font-weight: normal;
-      font-size: 64px;
-      line-height: 64px;
-      letter-spacing: -0.03em;
-      color: #006c67;
-      font-size: 1.875rem;
-      margin: 0 !important;
-      padding: 0 !important;
-      background-color: transparent;
-    `};
 `;

--- a/src/design-system/InputDate.tsx
+++ b/src/design-system/InputDate.tsx
@@ -11,7 +11,7 @@ import DatePicker from "react-date-picker/dist/entry.nostyle";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import { InputBaseProps, useInputValue } from "./Input";
+import { InputBaseProps } from "./Input";
 import InputLabelAndHelp from "./InputLabelAndHelp";
 
 const InputContainer = styled.div`
@@ -84,7 +84,6 @@ type Props = InputBaseProps<Date> & {
 
 const InputDate: React.FC<Props> = (props) => {
   const { labelAbove, labelHelp, onValueChange } = props;
-  const inputValue = useInputValue(props);
 
   return (
     <InputContainer>
@@ -109,7 +108,7 @@ const InputDate: React.FC<Props> = (props) => {
         }
         tileClassName={props.tileClassName}
         tileContent={props.tileContent}
-        value={inputValue}
+        value={props.valueEntered}
         yearPlaceholder="yyyy"
       />
     </InputContainer>

--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import { StyledInput } from "./Input";
+import { InputStyle } from "./Input";
 import TextLabel from "./TextLabel";
 
 interface Props {
@@ -41,7 +41,8 @@ const SelectWrapper = styled.div`
   }
 `;
 
-const StyledSelect = styled(StyledInput)`
+const StyledSelect = styled.input`
+  ${InputStyle}
   appearance: none;
   padding-right: ${caretSize * 2 + 16}px;
   text-overflow: ellipsis;

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -55,7 +55,9 @@ interface Props extends InputBaseProps<string> {
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   focus?: boolean;
+  maxLength?: number;
   placeholder?: string;
+  required?: boolean;
   style?: object;
 }
 
@@ -79,6 +81,8 @@ const InputText: React.FC<Props> = (props) => {
           value={props.valueEntered ?? ""}
           headerStyle={!!props.headerStyle}
           placeholder={props.placeholder ?? placeholder}
+          maxLength={props.maxLength}
+          required={props.required}
           onChange={(e) => props.onValueChange(e.target.value)}
           onBlur={props.onBlur}
           onKeyDown={props.onKeyDown}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import { InputBaseProps, StyledInput, useInputValue } from "./Input";
+import { InputBaseProps, StyledInput } from "./Input";
 import InputLabelAndHelp from "./InputLabelAndHelp";
 
 const TextInputContainer = styled.div`
@@ -55,7 +55,6 @@ interface Props extends InputBaseProps<string> {
 }
 
 const InputText: React.FC<Props> = (props) => {
-  let inputValue = useInputValue(props);
   const placeholder = props.valuePlaceholder ?? props.labelPlaceholder;
   const nameInput = useRef() as React.MutableRefObject<HTMLInputElement>;
 
@@ -72,7 +71,7 @@ const InputText: React.FC<Props> = (props) => {
         <WrappedInput
           type={props.type}
           ref={nameInput}
-          value={inputValue ?? ""}
+          value={props.valueEntered ?? ""}
           headerStyle={!!props.headerStyle}
           placeholder={props.placeholder ?? placeholder}
           maxLength={props.maxLength}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -56,13 +56,11 @@ interface Props extends InputBaseProps<string> {
   onKeyDown?: (event: React.KeyboardEvent) => void;
   focus?: boolean;
   maxLength?: number;
-  placeholder?: string;
   required?: boolean;
   style?: object;
 }
 
 const InputText: React.FC<Props> = (props) => {
-  const placeholder = props.valuePlaceholder ?? props.labelPlaceholder;
   const nameInput = useRef() as React.MutableRefObject<HTMLInputElement>;
 
   useEffect(() => {
@@ -80,7 +78,7 @@ const InputText: React.FC<Props> = (props) => {
           inputRef={nameInput}
           value={props.valueEntered ?? ""}
           headerStyle={!!props.headerStyle}
-          placeholder={props.placeholder ?? placeholder}
+          placeholder={props.labelPlaceholder}
           maxLength={props.maxLength}
           required={props.required}
           onChange={(e) => props.onValueChange(e.target.value)}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -33,25 +33,10 @@ const WrappedInput = styled(StyledInput)`
   */
   width: 0;
   color: ${Colors.green};
-
-  // make placeholder font size smaller than the input's
-  &::-webkit-input-placeholder {
-    ${(props) => (props.headerStyle ? "font-size: 18px" : "")}
-  }
-  &::-moz-placeholder {
-    ${(props) => (props.headerStyle ? "font-size: 18px" : "")}
-  }
-  &:-ms-input-placeholder {
-    ${(props) => (props.headerStyle ? "font-size: 18px" : "")}
-  }
-  &:-moz-placeholder {
-    ${(props) => (props.headerStyle ? "font-size: 18px" : "")}
-  }
 `;
 
 interface Props extends InputBaseProps<string> {
   type: "text" | "number";
-  headerStyle?: boolean;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   focus?: boolean;
@@ -77,7 +62,6 @@ const InputText: React.FC<Props> = (props) => {
           type={props.type}
           inputRef={nameInput}
           value={props.valueEntered ?? ""}
-          headerStyle={!!props.headerStyle}
           placeholder={props.labelPlaceholder}
           maxLength={props.maxLength}
           required={props.required}

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -5,13 +5,20 @@ import Colors from "./Colors";
 import { InputBaseProps, StyledInput } from "./Input";
 import InputLabelAndHelp from "./InputLabelAndHelp";
 
+/**
+ * How long after the last keystroke should we make updates based off the input?
+ */
+const InputTextTimeoutMs = 1000;
+
 const TextInputContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
 `;
 
-const InputWrapper = styled(StyledInput)`
+const InputWrapper = styled.div`
+  ${StyledInput}
+
   align-items: center;
   display: flex;
   flex-direction: row;
@@ -19,7 +26,7 @@ const InputWrapper = styled(StyledInput)`
 
 const WrappedInput = styled(StyledInput)`
   margin: 0;
-  padding: 0;
+
   /*
     This is a little weird but we need a fixed number to override
     default sizing. Element will still flex as needed.
@@ -48,9 +55,7 @@ interface Props extends InputBaseProps<string> {
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   focus?: boolean;
-  maxLength?: number;
   placeholder?: string;
-  required?: boolean;
   style?: object;
 }
 
@@ -67,18 +72,17 @@ const InputText: React.FC<Props> = (props) => {
   return (
     <TextInputContainer>
       <InputLabelAndHelp label={props.labelAbove} labelHelp={props.labelHelp} />
-      <InputWrapper as="div" style={props.style}>
+      <InputWrapper style={props.style}>
         <WrappedInput
           type={props.type}
-          ref={nameInput}
+          inputRef={nameInput}
           value={props.valueEntered ?? ""}
           headerStyle={!!props.headerStyle}
           placeholder={props.placeholder ?? placeholder}
-          maxLength={props.maxLength}
-          required={props.required}
           onChange={(e) => props.onValueChange(e.target.value)}
           onBlur={props.onBlur}
           onKeyDown={props.onKeyDown}
+          debounceTimeout={InputTextTimeoutMs}
         />
         {props.children}
       </InputWrapper>

--- a/src/design-system/InputText.tsx
+++ b/src/design-system/InputText.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 
 import Colors from "./Colors";
-import { InputBaseProps, StyledInput } from "./Input";
+import { CustomDebounceInput, InputBaseProps, InputStyle } from "./Input";
 import InputLabelAndHelp from "./InputLabelAndHelp";
 
 /**
@@ -17,15 +17,17 @@ const TextInputContainer = styled.div`
 `;
 
 const InputWrapper = styled.div`
-  ${StyledInput}
+  ${InputStyle}
 
   align-items: center;
   display: flex;
   flex-direction: row;
 `;
 
-const WrappedInput = styled(StyledInput)`
+const WrappedInput = styled(CustomDebounceInput)`
+  ${InputStyle}
   margin: 0;
+  padding: 0;
 
   /*
     This is a little weird but we need a fixed number to override

--- a/src/design-system/InputTextNumeric.tsx
+++ b/src/design-system/InputTextNumeric.tsx
@@ -41,7 +41,6 @@ const InputTextNumeric: React.FC<Props> = (props) => {
       {...props}
       type="number"
       valueEntered={formatValue(props.valueEntered)}
-      valuePlaceholder={formatValue(props.valuePlaceholder)}
       onValueChange={onValueChange}
       labelPlaceholder={
         props.labelPlaceholder ??

--- a/src/design-system/InputTextNumeric.tsx
+++ b/src/design-system/InputTextNumeric.tsx
@@ -41,7 +41,6 @@ const InputTextNumeric: React.FC<Props> = (props) => {
       {...props}
       type="number"
       valueEntered={formatValue(props.valueEntered)}
-      valueDefault={formatValue(props.valueDefault)}
       valuePlaceholder={formatValue(props.valuePlaceholder)}
       onValueChange={onValueChange}
       labelPlaceholder={

--- a/yarn.lock
+++ b/yarn.lock
@@ -10258,7 +10258,7 @@ lodash.clonedeep@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.8:
+lodash.debounce@^4, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -12834,6 +12834,14 @@ react-date-picker@^8.0.1:
     react-calendar "^3.0.0"
     react-fit "^1.0.3"
     update-input-width "^1.1.1"
+
+react-debounce-input@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-debounce-input/-/react-debounce-input-3.2.2.tgz#d2cc99c1ce47fae89037965f5699edc1b0317197"
+  integrity sha512-RIBu68Cq/gImKz/2h1cE042REDqyqj3D+7SJ3lnnIpJX0ht9D9PfH7KAnL+SgDz6hvKa9pZS2CnAxlkrLmnQlg==
+  dependencies:
+    lodash.debounce "^4"
+    prop-types "^15.7.2"
 
 react-dev-utils@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
## Description of the change

Using the "react-debounce-input" package, we now debounce inputs with a debounce time of 1s.

Specifically, using this package, inputs don't pass up their new values unless:
- 1s has passed without any user interaction, or
- the focus has left the input (the user has clicked or tabbed away), or
- the user presses the Enter key.

(For future reference, the last two triggers can be easily turned off if need be. For example, if we use this package with textareas in the future, we probably want to disable having Enter key immediately register the input. (See readme for more info about this https://www.npmjs.com/package/react-debounce-input)

**Impact:** On the facilities page, you can now input an entire number instead of typing it digit by digit, waiting for the graph on the right to update before you can enter the next number.
- On modern browsers, there's only a few fractions of a second saved, but the interface feels much less laggy.
- On IE, each new text input took ~2 seconds to update. This reduces the time it takes to enter a 4-digit number from 8s (often longer, because sometimes you're not sure how long to wait before pressing the next key) to 2s!

(This is hard to demonstrate with a GIF because GIFs themselves are kind of laggy. See for yourself with the Now preview link!)

Note: This PR is fairly straightforward, but it took a few tries to figure out the best approach! Previously I experimented with writing debouncing code manually, or by using other libraries.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Addresses part of #261 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
