### PR TITLE
Add a Read-Only Banner When a User with a viewer Role is Visiting a S…

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -725,6 +725,10 @@ export const duplicateScenario = async (
     }
 
     await batch.commit();
+
+    const duplicatedScenario = await scenarioDoc.get();
+
+    return buildScenario(duplicatedScenario);
   } catch (error) {
     console.error(
       `Encountered error while attempting to duplicate scenario: ${scenarioId}`,

--- a/src/design-system/icons/ic_eye.svg
+++ b/src/design-system/icons/ic_eye.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="10" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0.5 5C0.5 5 2.5 0.5 6 0.5C9.5 0.5 11.5 5 11.5 5C11.5 5 9.5 9.5 6 9.5C2.5 9.5 0.5 5 0.5 5Z" stroke="#E9EBEB" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6 7C7.10457 7 8 6.10457 8 5C8 3.89543 7.10457 3 6 3C4.89543 3 4 3.89543 4 5C4 6.10457 4.89543 7 6 7Z" stroke="#E9EBEB" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/design-system/icons/ic_recidiviz_color.svg
+++ b/src/design-system/icons/ic_recidiviz_color.svg
@@ -1,0 +1,4 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect y="13" width="13" height="13" fill="#4693BE"/>
+  <rect x="12" width="14" height="14" rx="7" fill="#C53B3E"/>
+</svg>

--- a/src/page-multi-facility/FacilityPage.tsx
+++ b/src/page-multi-facility/FacilityPage.tsx
@@ -8,6 +8,7 @@ import useScenario from "../scenario-context/useScenario";
 import SiteHeader from "../site-header/SiteHeader";
 import { FacilityContext } from "./FacilityContext";
 import FacilityInputForm from "./FacilityInputForm";
+import ReadOnlyScenarioBanner from "./ReadOnlyScenarioBanner";
 
 const FacilityPageDiv = styled.div``;
 
@@ -15,7 +16,7 @@ const FacilityPageDiv = styled.div``;
 const FacilityPage: React.FC = () => {
   const { data: localeDataSource } = useLocaleDataState();
   const { facility } = useContext(FacilityContext);
-  const [scenario] = useScenario();
+  const [scenario, dispatchScenarioUpdate] = useScenario();
 
   return (
     <>
@@ -27,6 +28,12 @@ const FacilityPage: React.FC = () => {
           localeDataSource={localeDataSource}
         >
           <FacilityPageDiv>
+            {scenario.data && (
+              <ReadOnlyScenarioBanner
+                scenario={scenario.data}
+                dispatchScenarioUpdate={dispatchScenarioUpdate}
+              />
+            )}
             <div className="font-body text-green min-h-screen tracking-normal w-full">
               <div className="max-w-screen-xl px-4 mx-auto">
                 <SiteHeader />

--- a/src/page-multi-facility/MultiFacilityPage.tsx
+++ b/src/page-multi-facility/MultiFacilityPage.tsx
@@ -7,15 +7,22 @@ import useScenario from "../scenario-context/useScenario";
 import SiteHeader from "../site-header/SiteHeader";
 import CreateBaselineScenarioPage from "./CreateBaselineScenarioPage";
 import MultiFacilityImpactDashboard from "./MultiFacilityImpactDashboard";
+import ReadOnlyScenarioBanner from "./ReadOnlyScenarioBanner";
 
 const MultiFacilityPageDiv = styled.div``;
 
 const MultiFacilityPage: React.FC = () => {
   const localeState = useLocaleDataState();
-  const [scenario] = useScenario();
+  const [scenario, dispatchScenarioUpdate] = useScenario();
 
   return (
     <MultiFacilityPageDiv>
+      {scenario.data && (
+        <ReadOnlyScenarioBanner
+          scenario={scenario.data}
+          dispatchScenarioUpdate={dispatchScenarioUpdate}
+        />
+      )}
       <div className="font-body text-green min-h-screen tracking-normal w-full">
         <div className="max-w-screen-xl px-4 mx-auto">
           <SiteHeader />

--- a/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
+++ b/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+
+import { useAuth0 } from "../auth/react-auth0-spa";
+import { duplicateScenario } from "../database";
+import Colors from "../design-system/Colors";
+import iconEyeSrc from "../design-system/icons/ic_eye.svg";
+import iconRecidivizSrc from "../design-system/icons/ic_recidiviz_color.svg";
+import Loading from "../design-system/Loading";
+import ModalDialog from "../design-system/ModalDialog";
+import { Scenario } from "./types";
+
+interface BannerProps {
+  visible: boolean;
+}
+
+const Banner = styled.div<BannerProps>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: ${Colors.forest};
+  color: ${Colors.slate};
+  font-family: "Helvetica Neue", sans serif;
+  font-weight: normal;
+  letter-spacing: 0;
+  padding: 20px;
+  height: ${(props) => (props.visible ? "64px" : "0px")};
+  position: relative;
+  top: ${(props) => (props.visible ? "0px" : "-64px")};
+  transition: top 250ms ease;
+`;
+
+const BannerMessage = styled.div`
+  display: flex;
+`;
+
+const IconEye = styled.img`
+  display: inline;
+  width: 16px;
+  height: 16px;
+  margin-right: 10px;
+`;
+
+const Logo = styled.img`
+  display: inline;
+  width: 26px;
+  height: 26px;
+  margin-right: 10px;
+`;
+
+interface Props {
+  scenario: Scenario;
+  dispatchScenarioUpdate: Function;
+}
+
+const ReadOnlyScenarioBanner: React.FC<Props> = (props) => {
+  const { user } = (useAuth0 as any)();
+  const { scenario, dispatchScenarioUpdate } = props;
+  const [readOnlyMode, setReadOnlyMode] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    const userRole = (scenario.roles as any)[user.sub];
+    setReadOnlyMode(userRole != "owner");
+  }, [scenario, user.sub]);
+
+  const duplicate = (scenarioId: string) => {
+    setModalOpen(true);
+    duplicateScenario(scenarioId).then((scenario) => {
+      setModalOpen(false);
+      dispatchScenarioUpdate(scenario);
+    });
+  };
+
+  return (
+    <Banner visible={readOnlyMode}>
+      <Logo alt="Recidiviz" src={iconRecidivizSrc} />
+      <BannerMessage>
+        <IconEye alt="folder" src={iconEyeSrc} />
+        View Only Mode. No edits can be made to this scenario.
+      </BannerMessage>
+      <a href="#" onClick={() => duplicate(scenario.id)}>
+        Duplicate
+      </a>
+      <ModalDialog
+        title={`Duplicating ${scenario.name}`}
+        open={modalOpen}
+        height="30vh"
+        width="25vw"
+      >
+        <Loading />
+      </ModalDialog>
+    </Banner>
+  );
+};
+
+export default ReadOnlyScenarioBanner;


### PR DESCRIPTION
…cenario

## Description of the change

Shows a read-only banner when a user is viewing a scenario that they do not own.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #442 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
