### PR TITLE
Fix "Save" button to the bottom of facility detail page to be always visible when editing a facility

### DIFF
--- a/src/hooks/useScreenWidth.tsx
+++ b/src/hooks/useScreenWidth.tsx
@@ -1,0 +1,18 @@
+// reports the screen width (including after resize)
+import { useEffect, useState } from "react";
+
+const useScreenWidth = (): number => {
+  const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+
+  const updateWidth = () => {
+    const newWidth = window.innerWidth;
+    setScreenWidth(newWidth);
+  };
+  useEffect(() => {
+    window.addEventListener("resize", updateWidth);
+    return () => window.removeEventListener("resize", updateWidth);
+  });
+  return screenWidth;
+};
+
+export default useScreenWidth;

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -45,6 +45,10 @@ const ButtonSection = styled.div<ButtonSectionProps>`
     screenWidth > 1280 ? (screenWidth - 1280) / 2 : 0}px;
 `;
 
+const PageContainerWithBottomMargin = styled(PageContainer)`
+  margin-bottom: 60px;
+`;
+
 const DescRow = styled.div`
   display: flex;
   justify-content: space-between;
@@ -183,7 +187,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   };
 
   return (
-    <PageContainer>
+    <PageContainerWithBottomMargin>
       <Column width={"45%"}>
         <InputName
           name={facilityName}
@@ -271,7 +275,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
           </ModalButtons>
         </ModalContents>
       </ModalDialog>
-    </PageContainer>
+    </PageContainerWithBottomMargin>
   );
 };
 

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -13,6 +13,7 @@ import { Column, PageContainer } from "../design-system/PageColumn";
 import PopUpMenu from "../design-system/PopUpMenu";
 import { Spacer } from "../design-system/Spacer";
 import Tooltip from "../design-system/Tooltip";
+import useScreenWidth from "../hooks/useScreenWidth";
 import FacilityInformation from "../impact-dashboard/FacilityInformation";
 import MitigationInformation from "../impact-dashboard/MitigationInformation";
 import useModel from "../impact-dashboard/useModel";
@@ -25,8 +26,23 @@ import HistoricalCasesChart from "./HistoricalCasesChart";
 import LocaleInformationSection from "./LocaleInformationSection";
 import { Facility } from "./types";
 
-const ButtonSection = styled.div`
-  margin-top: 30px;
+interface ButtonSectionProps {
+  screenWidth: number;
+}
+
+const ButtonSection = styled.div<ButtonSectionProps>`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 100px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: ${Colors.slate};
+  z-index: 1;
+  margin-left: ${({ screenWidth }) =>
+    screenWidth > 1280 ? (screenWidth - 1280) / 2 : 0}px;
 `;
 
 const DescRow = styled.div`
@@ -122,6 +138,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   );
   const model = useModel();
 
+  const screenWidth = useScreenWidth();
   const save = () => {
     if (facilityName) {
       // Set observedAt to right now when updating a facility from this input form
@@ -226,7 +243,7 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
         <FacilityInformation />
         <SectionHeader>Rate of Spread</SectionHeader>
         <MitigationInformation />
-        <ButtonSection>
+        <ButtonSection className="pl-8" screenWidth={screenWidth}>
           <InputButton label="Save" onClick={save} />
         </ButtonSection>
         <div className="mt-8" />


### PR DESCRIPTION
## Description of the change

Puts the _Save_ button in a fixed bar on the facility page so that users always know how to save and update their data.

![image](https://user-images.githubusercontent.com/10144236/82839630-9ed07a00-9e95-11ea-85b9-a3b513a1506e.png)

![467](https://user-images.githubusercontent.com/10144236/82840333-c4f71980-9e97-11ea-810c-eb68ba2b0b83.gif)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #467

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant

