### PR TITLE
Set Rate of Spread panel chart range to 0-5

### DIFF
--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -265,7 +265,7 @@ const RtComparisonChart: React.FC<{ data: RtComparisonData[] }> = ({
     Math.max(...data.map((record) => record.values.high90 || 0)),
   );
 
-  const maxExtent = maxRtHigh90 >= 4 ? maxRtHigh90 + 1 : 5;
+  const maxExtent = Math.max(maxRtHigh90 + 1, 5);
 
   return (
     <RtComparisonChartWrapper>

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -261,9 +261,11 @@ export const isRtComparisonData = (
 const RtComparisonChart: React.FC<{ data: RtComparisonData[] }> = ({
   data,
 }) => {
-  const maxExtent = Math.ceil(
+  const maxRtHigh90 = Math.ceil(
     Math.max(...data.map((record) => record.values.high90 || 0)),
   );
+
+  const maxExtent = maxRtHigh90 >= 4 ? maxRtHigh90 + 1 : 5;
 
   return (
     <RtComparisonChartWrapper>


### PR DESCRIPTION
## Description of the change

Set the Rate of Spread panel chart's x-axis from 0-5 for all cases except when the Rt range is greater than or equal to 4, then set it to the max plus 1. 

@macfarlandian While I was testing this I tried to add historical cases to a facility to try and get an Rt calculation that went beyond 4 and while doing it I noticed this error whenever my cases number was very close to the total residents number (i.e. I put 20,000 cases for 25,000 residents) Just wanted to check if this is an expected error or if I should open an issue for it:

![image](https://user-images.githubusercontent.com/5402804/82927666-e6a6de00-9f35-11ea-98b9-11247b226de8.png)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #386 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
