### PR TITLE
Align y-axis max value for original and current curve charts

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -77,6 +77,7 @@ interface CurveChartProps {
   hospitalBeds: number;
   markColors: MarkColors;
   hideAxes?: boolean;
+  yAxisExtent?: number[];
   addAnnotations?: boolean;
 }
 
@@ -110,6 +111,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   hospitalBeds,
   markColors,
   hideAxes,
+  yAxisExtent = [0],
   addAnnotations = true,
 }) => {
   const frameProps = {
@@ -128,7 +130,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
-    yExtent: { extent: [0], includeAnnotations: false },
+    yExtent: { extent: yAxisExtent, includeAnnotations: false },
     margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 0 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],

--- a/src/page-response-impact/ProjectionCharts.tsx
+++ b/src/page-response-impact/ProjectionCharts.tsx
@@ -1,3 +1,4 @@
+import { flattenDeep } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
@@ -23,6 +24,16 @@ const ProjectionCharts: React.FC<Props> = ({
   originalCurveInputs,
   currentCurveInputs,
 }) => {
+  const originalCurveData = getCurveChartData(originalCurveInputs);
+  const currentCurveData = getCurveChartData(currentCurveInputs);
+  const maxValue = Math.ceil(
+    Math.max(
+      ...flattenDeep([
+        Object.values(currentCurveData),
+        Object.values(originalCurveData),
+      ]),
+    ),
+  );
   return (
     <>
       <CurveChartContainer>
@@ -33,9 +44,10 @@ const ProjectionCharts: React.FC<Props> = ({
         <CurveChart
           chartHeight={250}
           hideAxes={false}
+          yAxisExtent={[0, maxValue]}
           hospitalBeds={systemWideData.hospitalBeds}
           markColors={MarkColors}
-          curveData={getCurveChartData(originalCurveInputs)}
+          curveData={originalCurveData}
         />
       </CurveChartContainer>
       <CurveChartContainer>
@@ -46,9 +58,10 @@ const ProjectionCharts: React.FC<Props> = ({
         <CurveChart
           chartHeight={250}
           hideAxes={false}
+          yAxisExtent={[0, maxValue]}
           hospitalBeds={systemWideData.hospitalBeds}
           markColors={MarkColors}
-          curveData={getCurveChartData(currentCurveInputs)}
+          curveData={currentCurveData}
         />
       </CurveChartContainer>
     </>


### PR DESCRIPTION
## Description of the change

This PR sets the y-axis range on both current and original curve charts to be the highest value from either chart so that they match. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #397 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
