### PR TITLE
Set facility name input to editing until input blurs or Enter key is pressed

### DIFF
--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -70,12 +70,10 @@ const EditInPlace: React.FC<Props> = ({
   persistChanges,
   minHeight,
 }) => {
-  const [editing, setEditing] = useState(false);
   const textAreaRef = useRef(null);
-
   const [value, setValue] = useState(initialValue);
-
   const valueIsInvalid = requiredFlag && !value?.trim();
+  const [editing, setEditing] = useState(valueIsInvalid);
 
   useEffect(() => {
     if (autoResizeVertically) {


### PR DESCRIPTION
## Description of the change

This uses the `valueIsInvalid` check to initially set the `editing` state for the input component. If the value is empty and is required, then it will be `editing=true`, and it will change to `editing=false` only when onBlur or onEnterPress are called and the value is valid. 
 
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes  #371

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
