### PR TITLE
Verify cases counts increase monotonically in Rt function

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -123,7 +123,8 @@ def compute_r_t(historical_case_counts):
     # counts must be cumulative; reject any that are obviously not
     # (i.e. their values decrease over time)
     if case_df.diff().min() < 0:
-        raise ValueError('Case counts must be cumulative')
+        raise ValueError(
+            'Case counts must be cumulative and monotonically increasing')
 
     # we believe duplicates are mostly an artifact of little-to-no testing
     # and should be excluded from the model

--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -118,6 +118,13 @@ def compute_r_t(historical_case_counts):
     case_df = pd.Series(historical_case_counts['cases'], index=historical_case_counts['dates'])
     case_df.index = pd.to_datetime(case_df.index)
     case_df.index.name = 'date'
+    case_df.sort_index(inplace=True)
+
+    # counts must be cumulative; reject any that are obviously not
+    # (i.e. their values decrease over time)
+    if case_df.diff().min() < 0:
+        raise ValueError('Case counts must be cumulative')
+
     # we believe duplicates are mostly an artifact of little-to-no testing
     # and should be excluded from the model
     case_df = case_df.drop_duplicates(keep='first')

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -88,3 +88,14 @@ class TestCalculateRt(TestCase):
 
         resp = self.get_response_json()
         self.assertIn('error', resp)
+
+        # make sure it doesn't get confused by dates being out of order
+        data = data = {
+            'dates': ['2020-04-15', '2020-04-18', '2020-04-12', '2020-04-19'],
+            'cases': [50, 66, 20, 129]
+        }
+        self.req.get_json.return_value = data
+
+        resp = self.get_response_json()
+        self.assertNotIn('error', resp)
+

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -91,6 +91,7 @@ class TestCalculateRt(TestCase):
 
         # make sure it doesn't get confused by dates being out of order
         data = data = {
+            # here the values decrease but not when sorted in date order
             'dates': ['2020-04-15', '2020-04-18', '2020-04-12', '2020-04-19'],
             'cases': [50, 66, 20, 129]
         }
@@ -98,4 +99,15 @@ class TestCalculateRt(TestCase):
 
         resp = self.get_response_json()
         self.assertNotIn('error', resp)
+
+        data = {
+            # here the values increase but not when sorted in date order
+            'dates': ['2020-04-15', '2020-04-18', '2020-04-12', '2020-04-19'],
+            'cases': [20, 50, 66, 129]
+        }
+        self.req.get_json.return_value = data
+
+        resp = self.get_response_json()
+        self.assertIn('error', resp)
+
 

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -78,3 +78,13 @@ class TestCalculateRt(TestCase):
         # duplicate case counts will be dropped
         expected_response_dates = [data['dates'][1], data['dates'][3]]
         self.verify_response_data(resp, expected_response_dates)
+
+    def test_ensure_cumulative(self):
+        data = {
+            'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
+            'cases': [50, 66, 20, 129]
+        }
+        self.req.get_json.return_value = data
+
+        resp = self.get_response_json()
+        self.assertIn('error', resp)


### PR DESCRIPTION
## Description of the change

The Rt function requires cumulative case counts to produce a valid output; currently it does not validate the inputs for this requirement, and it behaves inconsistently when it is violated. This adds a check for obvious violations (decreases over time) and responds with an error when they are found.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #494 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
