### PR TITLE
Improve Rt function error handling

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -135,7 +135,8 @@ def compute_r_t(historical_case_counts):
     # Raise an error if there are not enough valid cases to use
     # we need at least two days to represent change over time
     if len(smoothed) < 2:
-        raise ValueError('Input has too few cases to compute R(t)')
+        raise ValueError('Not enough data to compute R(t);'
+            ' at least two days of non-repeating case counts are required')
 
     # Note that we're fixing sigma to a value just for the example
     posteriors, _ = get_posteriors(smoothed, sigma=.25)

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -65,14 +65,6 @@ export function isRtError(data: any): data is RtError {
   return has(data, "error");
 }
 
-export function getRtStatus(data: RtData | RtError | undefined) {
-  return {
-    loading: data === undefined,
-    error: isRtError(data),
-    ready: isRtData(data),
-  };
-}
-
 const getFetchUrl = () => {
   let url = "https://us-central1-c19-backend.cloudfunctions.net/calculate_rt";
   if (process.env.NODE_ENV !== "production") {

--- a/src/page-multi-facility/SystemSummary.tsx
+++ b/src/page-multi-facility/SystemSummary.tsx
@@ -120,7 +120,7 @@ const SystemSummary: React.FC<Props> = ({ facilities, scenarioId, rtData }) => {
 
   useEffect(
     () => {
-      const rtDataValues: (RtData | null)[] = Object.values(rtData);
+      const rtDataValues = Object.values(rtData);
       const facilitiesRtRecords: RtRecord[][] = rtDataValues
         .filter(isRtData)
         .map((rtData: RtData) => rtData.Rt);

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -9,8 +9,9 @@ import {
   curveInputsWithRt,
 } from "../infection-model";
 import { getAllValues, getColView } from "../infection-model/matrixUtils";
-import { RtData } from "../infection-model/rt";
+import { isRtData, isRtError } from "../infection-model/rt";
 import { seirIndex } from "../infection-model/seir";
+import { RtValue } from "./types";
 
 function getCurves(
   input: EpidemicModelInputs,
@@ -27,16 +28,15 @@ function getCurves(
 export const useProjectionData = (
   input: EpidemicModelInputs,
   useRt?: boolean,
-  rtData?: RtData | null,
+  rtData?: RtValue,
 ): CurveData | undefined => {
   let latestRt: number | undefined;
 
   if (useRt) {
-    // a null value indicates Rt fetching failed
-    if (rtData === null) {
+    if (isRtError(rtData)) {
       useRt = false;
-    } else {
-      latestRt = rtData?.Rt[rtData.Rt.length - 1].value;
+    } else if (isRtData(rtData)) {
+      latestRt = rtData.Rt[rtData.Rt.length - 1].value;
     }
   }
 

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -1,5 +1,5 @@
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
-import { RtData } from "../infection-model/rt";
+import { RtData, RtError } from "../infection-model/rt";
 
 export interface ModelInputs extends EpidemicModelPersistent {
   observedAt: Date;
@@ -42,8 +42,10 @@ export type PromoStatuses = {
   addFacilities: boolean;
 };
 
+export type RtValue = RtData | RtError;
+
 export type RtDataMapping = {
-  [key in Facility["id"]]: RtData | null;
+  [key in Facility["id"]]: RtValue;
 };
 
 export type BaselinePopulations = {

--- a/src/page-response-impact/RtSummaryStats.tsx
+++ b/src/page-response-impact/RtSummaryStats.tsx
@@ -90,7 +90,7 @@ function rtDonutChartAnnotation(d: any) {
 }
 
 const RtSummaryStats: React.FC<Props> = ({ rtData }) => {
-  const rtDataValues: (RtData | null)[] = Object.values(rtData);
+  const rtDataValues = Object.values(rtData);
   const totalFacilitiesInScenario = rtDataValues.length;
 
   const facilitiesRtRecords: RtRecord[][] = rtDataValues

--- a/src/rt-comparison-chart/RtComparisonChart.tsx
+++ b/src/rt-comparison-chart/RtComparisonChart.tsx
@@ -108,16 +108,17 @@ const Tooltip: React.FC<{
   rt: number | undefined;
   left: number;
   top: number;
-}> = ({ name, rt, left, top }) => {
+  error: Error | undefined;
+}> = ({ name, rt, left, top, error }) => {
   return (
     <RtComparisonChartTooltip style={{ left, top }}>
       <p>{name}</p>
       <p>
         {!!rt && `Rate of Spread: ${formatRt(rt)}`}
-        {rt === undefined &&
+        {(rt === undefined || !!error) &&
           `Insufficient data to calculate rate of spread. Click the number of
           cases on the Projections tab to add case numbers for the last several
-          days or weeks.`}
+          days or weeks.${error ? ` (${error})` : ""}`}
         {rt === 0 && "Covid-19 is not active at this facility."}
       </p>
       <p>
@@ -188,6 +189,7 @@ const renderHtmlHoverState = ({
       rt={values.Rt}
       top={middle - pillRadius}
       left={rScale(values.Rt) | 0}
+      error={values.error}
     />
   );
 };
@@ -251,6 +253,7 @@ export type RtComparisonData = {
     Rt?: number;
     low90?: number;
     high90?: number;
+    error?: Error;
   };
 };
 

--- a/src/rt-comparison-chart/RtComparisonChartContainer.tsx
+++ b/src/rt-comparison-chart/RtComparisonChartContainer.tsx
@@ -3,7 +3,12 @@ import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Loading from "../design-system/Loading";
-import { getDaysAgoRt, getFacilitiesRtDataById } from "../infection-model/rt";
+import {
+  getDaysAgoRt,
+  getFacilitiesRtDataById,
+  isRtData,
+  isRtError,
+} from "../infection-model/rt";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
 import { Facilities, RtDataMapping } from "../page-multi-facility/types";
 import RtComparisonChart, {
@@ -46,11 +51,13 @@ const RtComparisonChartContainer: React.FC<{
         );
         if (!facility) return;
         const values = {} as any;
-        if (rtData) {
+        if (isRtData(rtData)) {
           Object.entries(rtData).forEach(([metric, records]) => {
             const rtRecord = getDaysAgoRt(records, rtDaysOffset);
             values[metric] = rtRecord?.value;
           });
+        } else if (isRtError(rtData)) {
+          values.error = rtData.error;
         }
         return {
           name: facility.name,

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -5,11 +5,11 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import Loading from "../design-system/Loading";
-import { RtData } from "../infection-model/rt";
+import { getRtStatus, RtData } from "../infection-model/rt";
 import { updateFacilityRtData } from "../infection-model/rt";
 import AddCasesModal from "../page-multi-facility/AddCasesModal";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
-import { Facility } from "../page-multi-facility/types";
+import { Facility, RtValue } from "../page-multi-facility/types";
 import RtTimeseries from "./RtTimeseries";
 
 const borderStyle = `1px solid ${Colors.paleGreen}`;
@@ -46,7 +46,7 @@ const RtChartEmptyState = styled.button`
 `;
 
 interface Props {
-  data?: RtData | null;
+  data?: RtValue;
   facility: Facility;
 }
 
@@ -61,10 +61,12 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
     updateFacilityRtData(newFacility, dispatchRtData);
   };
 
-  const isLoading = data === undefined;
-  const notEnoughData = data === null || (data && data.Rt.length < 2);
+  const rtStatus = getRtStatus(data);
 
-  if (isLoading) return <Loading />;
+  const notEnoughData =
+    rtStatus.error || (rtStatus.ready && (data as RtData).Rt.length < 2);
+
+  if (rtStatus.loading) return <Loading />;
 
   return (
     <>
@@ -96,7 +98,7 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
               />
             </AddCasesRow>
           )
-        : data && <RtTimeseries data={data} />}
+        : rtStatus.ready && <RtTimeseries data={data as RtData} />}
     </>
   );
 };

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import Loading from "../design-system/Loading";
-import { getRtStatus, RtData } from "../infection-model/rt";
+import { isRtData, isRtError, RtData } from "../infection-model/rt";
 import { updateFacilityRtData } from "../infection-model/rt";
 import AddCasesModal from "../page-multi-facility/AddCasesModal";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
@@ -56,17 +56,15 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
   );
   const [facility, updateFacility] = useState(initialFacility);
 
+  if (data === undefined) return <Loading />;
+
   const onModalSave = (newFacility: Facility) => {
     updateFacility(newFacility);
     updateFacilityRtData(newFacility, dispatchRtData);
   };
 
-  const rtStatus = getRtStatus(data);
-
   const notEnoughData =
-    rtStatus.error || (rtStatus.ready && (data as RtData).Rt.length < 2);
-
-  if (rtStatus.loading) return <Loading />;
+    isRtError(data) || (isRtData(data) && data.Rt.length < 2);
 
   return (
     <>
@@ -91,14 +89,14 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
                   <RtChartEmptyState>
                     Live rate of spread could not be calculated for this
                     facility. Click here to add at least 3 days of confirmed
-                    case data.
+                    case data. {isRtError(data) && `(${data.error})`}
                   </RtChartEmptyState>
                 }
                 onSave={onModalSave}
               />
             </AddCasesRow>
           )
-        : rtStatus.ready && <RtTimeseries data={data as RtData} />}
+        : isRtData(data) && <RtTimeseries data={data} />}
     </>
   );
 };

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -5,8 +5,11 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import HelpButtonWithTooltip from "../design-system/HelpButtonWithTooltip";
 import Loading from "../design-system/Loading";
-import { isRtData, isRtError, RtData } from "../infection-model/rt";
-import { updateFacilityRtData } from "../infection-model/rt";
+import {
+  isRtData,
+  isRtError,
+  updateFacilityRtData,
+} from "../infection-model/rt";
 import AddCasesModal from "../page-multi-facility/AddCasesModal";
 import { FacilityContext } from "../page-multi-facility/FacilityContext";
 import { Facility, RtValue } from "../page-multi-facility/types";


### PR DESCRIPTION
## Description of the change

Makes Rt failures less opaque, with a combination of backend and frontend changes that support more useful error messaging (something we wanted but deferred in the initial Rt release): 

1. Make Python logging more reliable (with traceable Execution Ids and exception logging) so we can respond with a cleaner error message suitable for UI display
1. On the frontend, create an explicit Rt error object that can be propagated through the UI instead of a `null`. Handle this object everywhere that deals with Rt data (this is the bulk of the PR because we pass it around quite a bit)
1. When we have one of these error objects, include its message in any existing "error" or "unknown value" UI elements. @cawarren this is easy to either change or suppress in favor of additional design input so I decided to just take a stab at implementation and ask for your sign-off here before merging. 

New error messages have been added to:

- The tooltips on Rt pills in the Scenario Projections tab
<img width="519" alt="Screen Shot 2020-05-27 at 6 03 41 PM" src="https://user-images.githubusercontent.com/5385319/83179046-489e4980-a0d6-11ea-903b-abdd5db5faf3.png">

- The tooltips on the chart in the Scenario Rate of Spread tab
<img width="774" alt="Screen Shot 2020-05-27 at 6 04 57 PM" src="https://user-images.githubusercontent.com/5385319/83179096-58b62900-a0d6-11ea-920b-6213b414cc27.png">

- The error message for the Rate of Spread timeseries chart on the Facility page
<img width="557" alt="Screen Shot 2020-05-27 at 6 04 13 PM" src="https://user-images.githubusercontent.com/5385319/83179114-5fdd3700-a0d6-11ea-8ce2-f687cc109a51.png">

There are currently three calc-related error messages that users are likely to encounter (copy suggestions welcome, these did not come off one of our official web copy spreadsheets):
- "Case counts must be cumulative and monotonically increasing": just added in #495, hopefully self-explanatory
- "Not enough data to compute R(t); at least two days of non-repeating case counts are required":  slightly tricky but this is for when we don't have enough usable days (<2, after filtering out duplicates; it would be possible to vary this error before and after deduplication but we currently don't)
- "Unable to compute R(t) with the provided data": any other currently unknown error type

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #407 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
