### PR TITLE
test page to run migration script within our auth

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -878,7 +878,6 @@ export const addFacilityCapacity = async ({
   const newInputs = { ...modelInputs, facilityCapacity };
   const timestamp = currrentTimestamp();
   newInputs.updatedAt = timestamp;
-  delete newInputs.facilityOccupancyPct;
 
   const db = await getDb();
   let docToUpdate = db
@@ -891,10 +890,7 @@ export const addFacilityCapacity = async ({
     docToUpdate = docToUpdate
       .collection(modelVersionCollectionId)
       .doc(modelVersionId);
-    updateData = {
-      ...newInputs,
-      facilityOccupancyPct: firebase.firestore.FieldValue.delete(),
-    };
+    updateData = newInputs;
   }
   try {
     if (write) {

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -909,7 +909,7 @@ export const addFacilityCapacity = async ({
   }
 };
 
-export const removeOccupancyPct = async ({
+export const doFirestoreCleanup = async ({
   scenarioId,
   facilityId,
   modelVersionId,
@@ -920,6 +920,10 @@ export const removeOccupancyPct = async ({
   const timestamp = currrentTimestamp();
   newInputs.updatedAt = timestamp;
   delete newInputs.facilityOccupancyPct;
+  // round off any non-integer values that resulted from the pct calc
+  if (newInputs.facilityCapacity) {
+    newInputs.facilityCapacity = Math.round(newInputs.facilityCapacity);
+  }
 
   const db = await getDb();
   let docToUpdate = db

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -4,10 +4,10 @@ import React from "react";
 import AuthWall from "../auth/AuthWall";
 import {
   addFacilityCapacity,
+  doFirestoreCleanup,
   getMigrationFacilities,
   getMigrationModelVersions,
   getMigrationScenarios,
-  removeOccupancyPct,
 } from "../database";
 import { totalIncarceratedPopulation } from "../impact-dashboard/EpidemicModelContext";
 import PageInfo from "../site-metadata/PageInfo";
@@ -57,7 +57,7 @@ const setFacilityCapacity = async ({
   }
 };
 
-const removeDeprecatedFields = async ({
+const cleanupMigratedFields = async ({
   facilityDoc,
   scenarioId,
   modelVersionDoc,
@@ -70,7 +70,7 @@ const removeDeprecatedFields = async ({
     modelVersionId = modelVersionDoc.id;
   }
 
-  removeOccupancyPct({
+  doFirestoreCleanup({
     facilityId: facilityDoc.id,
     modelInputs,
     scenarioId,
@@ -105,13 +105,13 @@ export default () => {
       const scenarioId = scenarioDoc.id;
       const facilities = await getMigrationFacilities(scenarioId);
       facilities.forEach(async (facilityDoc) => {
-        removeDeprecatedFields({ facilityDoc, scenarioId: scenarioId });
+        cleanupMigratedFields({ facilityDoc, scenarioId: scenarioId });
         const modelVersions = await getMigrationModelVersions(
           scenarioId,
           facilityDoc.id,
         );
         modelVersions.forEach(async (modelVersionDoc) => {
-          removeDeprecatedFields({ facilityDoc, scenarioId, modelVersionDoc });
+          cleanupMigratedFields({ facilityDoc, scenarioId, modelVersionDoc });
         });
       });
     });

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import React from "react";
+
+import AuthWall from "../auth/AuthWall";
+import {
+  addFacilityCapacity,
+  getMigrationFacilities,
+  getMigrationModelVersions,
+  getMigrationScenarios,
+} from "../database";
+import { totalIncarceratedPopulation } from "../impact-dashboard/EpidemicModelContext";
+import PageInfo from "../site-metadata/PageInfo";
+
+function calculateFacilityCapacity(modelInputs) {
+  const occupancyPct = modelInputs.facilityOccupancyPct;
+  const pop = totalIncarceratedPopulation(modelInputs);
+  if (pop && occupancyPct) {
+    return pop * occupancyPct;
+  }
+}
+
+// flip this to true to write changes to the database;
+// flip it to false for a dry run that just logs to console
+const write = false;
+
+const setFacilityCapacity = async ({
+  facilityDoc,
+  scenarioId,
+  modelVersionDoc,
+}) => {
+  let { modelInputs } = facilityDoc.data();
+  let modelVersionId;
+
+  if (modelVersionDoc) {
+    modelInputs = modelVersionDoc.data();
+    modelVersionId = modelVersionDoc.id;
+  }
+
+  const capacity = calculateFacilityCapacity(modelInputs);
+  if (capacity) {
+    addFacilityCapacity({
+      facilityId: facilityDoc.id,
+      facilityCapacity: capacity,
+      modelInputs,
+      scenarioId,
+      write,
+      modelVersionId,
+    });
+  } else {
+    console.log(
+      `unable to calculate capacity for facility ${facilityDoc.id}${
+        modelVersionId ? ` version ${modelVersionId}` : ""
+      }`,
+      modelInputs,
+    );
+  }
+};
+
+// eslint-disable-next-line react/display-name
+export default () => {
+  const migrate = async () => {
+    const scenarios = await getMigrationScenarios();
+    scenarios.forEach(async (scenarioDoc) => {
+      const scenarioId = scenarioDoc.id;
+      const facilities = await getMigrationFacilities(scenarioId);
+      facilities.forEach(async (facilityDoc) => {
+        setFacilityCapacity({ facilityDoc, scenarioId: scenarioId });
+        const modelVersions = await getMigrationModelVersions(
+          scenarioId,
+          facilityDoc.id,
+        );
+        modelVersions.forEach(async (modelVersionDoc) => {
+          setFacilityCapacity({ facilityDoc, scenarioId, modelVersionDoc });
+        });
+      });
+    });
+  };
+
+  return (
+    <>
+      <PageInfo title="test page for migration script" />
+      <AuthWall>
+        <div style={{ margin: 45 }}>
+          <button onClick={migrate}>migrate facility capacity</button>
+        </div>
+      </AuthWall>
+    </>
+  );
+};


### PR DESCRIPTION
## Description of the change

This will not be merged, but can be reviewed before I run it locally; it's a migration function (nestled lovingly within a temporary test page behind our auth wall) that calculates and adds `facilityCapacity` to all facilities and their model versions, where possible (i.e. if they have the two existing fields). This relies on a temporary Firestore rule that gives me "superuser" access from the website, which I will have to activate before running this and then revert, so the code itself is safe (will result in a permissions error if you try to run it without being covered by said superuser rule).

I did a full test run (including writes) against the `scenarios_test` collection and everything looked fine; I have done a dry run against the real `scenarios` collection and it looks like there are ~120 documents (mostly model versions) that won't be updated by this (mostly because they don't have any population counts), which doesn't seem too bad.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #490 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
