### PR TITLE
Add functionality to duplicate a facility

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -540,20 +540,18 @@ export const removeScenarioUser = async (
   }
 };
 
-const batchSetFacilityModelVersions = async (
+const batchSetFacilityModelVersions = (
   modelVersions: ModelInputs[],
   facilityDocRef: firebase.firestore.DocumentReference,
   batch: firebase.firestore.WriteBatch,
 ) => {
-  modelVersions.forEach((modelVersion: ModelInputs) => {
-    const modelVersionDoc = facilityDocRef
-      .collection(modelVersionCollectionId)
-      .doc();
+  const modelVersionDoc = facilityDocRef
+    .collection(modelVersionCollectionId)
+    .doc();
 
+  modelVersions.forEach((modelVersion: ModelInputs) => {
     batch.set(modelVersionDoc, modelVersion);
   });
-
-  return batch;
 };
 
 /**
@@ -704,7 +702,7 @@ export const duplicateFacility = async (
       scenarioId,
       facilityId,
     });
-    await batchSetFacilityModelVersions(modelVersions, facilityRef, batch);
+    batchSetFacilityModelVersions(modelVersions, facilityRef, batch);
 
     // Delete old facility id and set new createdAt timestamp on payload
     delete facilityCopy.id;
@@ -829,7 +827,8 @@ export const duplicateScenario = async (
         scenarioId,
         facilityId: facility.id,
       });
-      await batchSetFacilityModelVersions(modelVersions, facilityDoc, batch);
+
+      batchSetFacilityModelVersions(modelVersions, facilityDoc, batch);
     }
 
     await batch.commit();

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -582,7 +582,7 @@ export const removeScenarioUser = async (
 export const saveFacility = async (
   scenarioId: string,
   facility: any,
-): Promise<void> => {
+): Promise<Facility | void> => {
   try {
     const scenarioRef = await getScenarioRef(scenarioId);
 
@@ -656,8 +656,9 @@ export const saveFacility = async (
 
       batch.set(newModelVersionDoc, facility.modelInputs);
     }
-
     await batch.commit();
+    const savedFacilityDoc = await facilityDoc.get();
+    return buildFacility(scenarioId, savedFacilityDoc);
   } catch (error) {
     console.error("Encountered error while attempting to save a facility:");
     console.error(error);
@@ -665,6 +666,30 @@ export const saveFacility = async (
       error,
       "You don't have permission to edit this facility.",
     );
+  }
+};
+
+export const duplicateFacility = async (
+  scenarioId: string,
+  facility: Facility,
+): Promise<Facility | void> => {
+  const facilityId = facility.id;
+  try {
+    const timestamp = currrentTimestamp();
+    delete facility.id;
+    const duplicatedFacility = {
+      ...facility,
+      name: `Copy of ${facility.name}`,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    return saveFacility(scenarioId, duplicatedFacility);
+  } catch (error) {
+    console.error(
+      `Encountered error while attempting to duplicate facility: ${facilityId}`,
+    );
+    console.error(error);
+    return;
   }
 };
 

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -545,11 +545,10 @@ const batchSetFacilityModelVersions = (
   facilityDocRef: firebase.firestore.DocumentReference,
   batch: firebase.firestore.WriteBatch,
 ) => {
-  const modelVersionDoc = facilityDocRef
-    .collection(modelVersionCollectionId)
-    .doc();
-
   modelVersions.forEach((modelVersion: ModelInputs) => {
+    const modelVersionDoc = facilityDocRef
+      .collection(modelVersionCollectionId)
+      .doc();
     batch.set(modelVersionDoc, modelVersion);
   });
 };

--- a/src/design-system/EditInPlace.tsx
+++ b/src/design-system/EditInPlace.tsx
@@ -106,6 +106,10 @@ const EditInPlace: React.FC<Props> = ({
     }
   };
 
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
   return (
     <EditInPlaceDiv minHeight={minHeight}>
       {!editing && ((requiredFlag && value) || !requiredFlag) ? (

--- a/src/design-system/PopUpMenu.tsx
+++ b/src/design-system/PopUpMenu.tsx
@@ -15,6 +15,7 @@ interface MenuProps {
 
 interface ItemProps {
   item: Item;
+  toggleMenu: (event: React.MouseEvent<Element>) => void;
 }
 
 const PopUpMenuDiv = styled.div`
@@ -46,13 +47,14 @@ const PopUpMenuContents = styled.div`
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.1);
 `;
 
-const PopUpMenuItem: React.FC<ItemProps> = ({ item }) => {
+const PopUpMenuItem: React.FC<ItemProps> = ({ toggleMenu, item }) => {
   const clickItem = (event: React.MouseEvent<Element>) => {
     // If the PopUpMenuItem is embedded within an element that is
     // clickable (i.e. a Scenario Library Card) we need to prevent
     // that parent element's click action from firing so that we
     // allow the menu item's click action to execute uninterrupted.
     event.stopPropagation();
+    toggleMenu(event);
     item.onClick();
   };
   return <div onClick={clickItem}>{item.name}</div>;
@@ -79,7 +81,11 @@ const PopUpMenu: React.FC<MenuProps> = ({ items }) => {
       {isComponentVisible && (
         <PopUpMenuContents>
           {items.map((item) => (
-            <PopUpMenuItem item={item} key={`menu-${item.name}`} />
+            <PopUpMenuItem
+              toggleMenu={toggleMenu}
+              item={item}
+              key={`menu-${item.name}`}
+            />
           ))}
         </PopUpMenuContents>
       )}

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -2,7 +2,11 @@ import { navigate } from "gatsby";
 import React, { useContext, useState } from "react";
 import styled from "styled-components";
 
-import { deleteFacility, saveFacility } from "../database/index";
+import {
+  deleteFacility,
+  duplicateFacility,
+  saveFacility,
+} from "../database/index";
 import Colors from "../design-system/Colors";
 import iconDuplicatePath from "../design-system/icons/ic_duplicate.svg";
 import InputButton, { StyledButton } from "../design-system/InputButton";
@@ -178,7 +182,17 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   const closeDeleteModal = () => {
     updateShowDeleteModal(false);
   };
-  const popupItems = [{ name: "Delete", onClick: openDeleteModal }];
+  const onDuplicateFacility = async () => {
+    if (facility) {
+      await rejectionToast(
+        duplicateFacility(scenarioId, facility).then(() => navigate("/")),
+      );
+    }
+  };
+  const popupItems = [
+    { name: "Duplicate", onClick: onDuplicateFacility },
+    { name: "Delete", onClick: openDeleteModal },
+  ];
   const removeFacility = async () => {
     const facilityId = facility?.id;
     if (facilityId) {

--- a/src/page-multi-facility/FacilityInputForm.tsx
+++ b/src/page-multi-facility/FacilityInputForm.tsx
@@ -16,6 +16,7 @@ import ModalDialog from "../design-system/ModalDialog";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import PopUpMenu from "../design-system/PopUpMenu";
 import { Spacer } from "../design-system/Spacer";
+import { useToasts } from "../design-system/Toast";
 import Tooltip from "../design-system/Tooltip";
 import useRejectionToast from "../hooks/useRejectionToast";
 import useScreenWidth from "../hooks/useScreenWidth";
@@ -138,9 +139,13 @@ interface Props {
 }
 
 const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
-  const { facility: initialFacility, rtData, dispatchRtData } = useContext(
-    FacilityContext,
-  );
+  const { addToast } = useToasts();
+  const {
+    facility: initialFacility,
+    setFacility,
+    rtData,
+    dispatchRtData,
+  } = useContext(FacilityContext);
   const [facility, updateFacility] = useState(initialFacility);
   const [facilityName, setFacilityName] = useState(facility?.name || undefined);
   const [description, setDescription] = useState(
@@ -185,7 +190,16 @@ const FacilityInputForm: React.FC<Props> = ({ scenarioId }) => {
   const onDuplicateFacility = async () => {
     if (facility) {
       await rejectionToast(
-        duplicateFacility(scenarioId, facility).then(() => navigate("/")),
+        duplicateFacility(scenarioId, facility)
+          .then((duplicatedFacility) => {
+            if (duplicatedFacility) {
+              setFacility(duplicatedFacility);
+              updateFacility(duplicatedFacility);
+              updateFacilityRtData(duplicatedFacility, dispatchRtData);
+              setFacilityName(duplicatedFacility.name);
+            }
+          })
+          .then(() => addToast("Facility successfully duplicated")),
       );
     }
   };

--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -1,5 +1,5 @@
 import hexAlpha from "hex-alpha";
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
@@ -58,6 +58,10 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
     FacilityContext,
   );
   const [facility, updateFacility] = useState(initialFacility);
+
+  useEffect(() => {
+    updateFacility(initialFacility);
+  }, [initialFacility]);
 
   if (data === undefined) return <Loading />;
 


### PR DESCRIPTION
## Description of the change

This adds a `Duplicate` option in the popup menu for the facility input page. It saves a new facility with all of the current inputs copied over (and no historical / version data), and sets the facility name to be `Copy of "facility name"`. I also added a toast for when the page is finished re-rendering. 

I needed to add a `useEffect` to "refresh" the internal state of the `facility` for the `RtTimeseriesContainer` component and the `EditInPlace` which is used for the name and description. This is because updating the `FacilityContext` does not actually re-render all of the children components and the internal state of `facility` stays the same.  

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #204 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
