### PR TITLE
Prevent tooltip from showing if not enough data

### DIFF
--- a/src/rt-timeseries/RtTimeseriesContainer.tsx
+++ b/src/rt-timeseries/RtTimeseriesContainer.tsx
@@ -73,7 +73,7 @@ const RtTimeseriesContainer: React.FC<Props> = ({ data }) => {
     <>
       <ChartHeader>
         <ChartTitle>Rate of Spread</ChartTitle>
-        {data && (
+        {!notEnoughData && (
           <HelpButtonWithTooltip>
             This chart shows the rate of spread of Covid-19 over time. When the
             Rt value is above 1 (the red line), the virus is spreading. If the


### PR DESCRIPTION
## Description of the change

WAS:
![image](https://user-images.githubusercontent.com/1372946/83215827-afdeec80-a11c-11ea-8de2-f85e2c915b84.png)

IS no question mark icon with tooltip:
![image](https://user-images.githubusercontent.com/1372946/83215843-b8372780-a11c-11ea-884f-5b07728b2f4c.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes N/A, noticed this when working on something else

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
