### PR TITLE
Add top margin to prevent chart peak being cut off

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -131,7 +131,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveWidth: true,
     size: [450, 450],
     yExtent: { extent: yAxisExtent, includeAnnotations: false },
-    margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 0 },
+    margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 10 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],
       strokeWidth: 1,


### PR DESCRIPTION
## Description of the change

WAS:
![image](https://user-images.githubusercontent.com/1372946/83216030-2976da80-a11d-11ea-9ab3-8540167ddb61.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/83216065-3eec0480-a11d-11ea-8303-9ab93dcee2e8.png)

Note: This fix only works on /facility, not the homepage FacilityRow. I can look more into that though, but this fix seemed worth shipping?

I'm familiar with D3 but this is my first time looking at it in the context of this app. Something weird is that even when it's a round number, the values are somewhat off e.g. in `WAS` screenshot ^^, value of 6 goes "above" the 6 tick mark. I didn't notice that when creating a chart with values like 63 and tick marks at 55, 60. I don't think the `yScale` needs to be adjusted.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of https://github.com/Recidiviz/covid19-dashboard/issues/372, Google doc

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
