### PR TITLE
partial fix for modal background color on IE11

### DIFF
--- a/src/design-system/ModalDialog.tsx
+++ b/src/design-system/ModalDialog.tsx
@@ -7,7 +7,7 @@ import ModalTitle, { TitleProps } from "./ModalTitle";
 
 const BackgroundAside = styled.aside`
   align-items: center;
-  background-color: rgb(214, 215, 215, 0.8);
+  background-color: rgba(214, 215, 215, 0.8);
   display: flex;
   height: 100%;
   justify-content: center;


### PR DESCRIPTION
## Description of the change

_Partial fix for issues in IE11._ 
Problem: as is, Add Cases modal is too far down and to the right on IE11 and the rest of the page is not grayed out. This PR fixes the background color of the rest of the page. _Further work needed to close issue._

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #426

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
