### PR TITLE
Avoiding Button Nesting Warning

### DIFF
--- a/src/scenario-share/ScenarioShareLink.tsx
+++ b/src/scenario-share/ScenarioShareLink.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import iconLinkPath from "../design-system/icons/ic_link.svg";
 
-const Button = styled.button`
+const LinkContainer = styled.div`
   color: ${Colors.forest};
   font-family: "Poppins", sans-serif;
   font-size: 13px;
@@ -19,13 +19,13 @@ const IconLink = styled.img`
   width: 10px;
 `;
 
-const ScenarioShareButton: React.FC = () => {
+const ScenarioShareLink: React.FC = () => {
   return (
-    <Button>
+    <LinkContainer>
       <IconLink src={iconLinkPath} />
       Share Scenario
-    </Button>
+    </LinkContainer>
   );
 };
 
-export default ScenarioShareButton;
+export default ScenarioShareLink;

--- a/src/scenario-share/ScenarioShareModal.tsx
+++ b/src/scenario-share/ScenarioShareModal.tsx
@@ -100,7 +100,7 @@ const UserList: React.FC<{
   );
 };
 
-const ShareButtonContainer = styled.button`
+const ShareButtonContainer = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;

--- a/src/scenario-share/ScenarioShareModal.tsx
+++ b/src/scenario-share/ScenarioShareModal.tsx
@@ -19,7 +19,7 @@ import useRejectionToast from "../hooks/useRejectionToast";
 import { ScenarioUsers } from "../page-multi-facility/types";
 import useScenario from "../scenario-context/useScenario";
 import AvatarCluster from "./AvatarCluster";
-import ScenarioShareButton from "./ScenarioShareButton";
+import ScenarioShareLink from "./ScenarioShareLink";
 import UserAvatar from "./UserAvatar";
 
 const ShareForm = styled.form`
@@ -100,7 +100,7 @@ const UserList: React.FC<{
   );
 };
 
-const ShareButtonContainer = styled.div`
+const ShareButton = styled.button`
   align-items: center;
   display: flex;
   justify-content: space-between;
@@ -170,10 +170,10 @@ const ScenarioShareModal: React.FC = () => {
       open={modalOpen}
       setOpen={setModalOpen}
       trigger={
-        <ShareButtonContainer>
-          <ScenarioShareButton />
+        <ShareButton>
+          <ScenarioShareLink />
           <AvatarCluster users={users} />
-        </ShareButtonContainer>
+        </ShareButton>
       }
       width="450px"
     >


### PR DESCRIPTION
## Description of the change

- Previously the app was throwing a warning because we were trying to nest a button within a button.  I've updated the button container to instead be a div.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
