### PR TITLE
Fix sorting/uniqueness error in model versions

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -4,12 +4,7 @@ import * as firebase from "firebase/app";
 import "firebase/auth";
 import "firebase/firestore";
 
-import {
-  format,
-  startOfDay,
-  startOfToday,
-  differenceInCalendarDays,
-} from "date-fns";
+import { format, startOfDay, differenceInCalendarDays } from "date-fns";
 import { pick, orderBy, uniqBy, findKey, maxBy, minBy } from "lodash";
 import { Optional } from "utility-types";
 
@@ -612,21 +607,20 @@ export const saveFacility = async (
     if (!scenarioRef) return;
 
     if (facility.modelInputs) {
-      // Ensures we don't store any attributres that our model does not know
+      // Ensures we don't store any attributes that our model does not know
       // about. This also makes a copy of modelInputs, since we shouldn't mutate
       // the original.
       facility.modelInputs = pick(facility.modelInputs, persistedKeys);
 
       facility.modelInputs.updatedAt = currrentTimestamp();
 
-      // Use observedAt if available. If it is not provided default to today. For dates
-      // observed in the past we'll have to assume the time portion of the
-      // timestamp is startOfDay** since we won't otherwise have any time
-      // information.
-      //
-      // ** https://date-fns.org/v1.29.0/docs/startOfDay
+      // Use observedAt if available. If it is not provided default to today.
       facility.modelInputs.observedAt =
-        facility.modelInputs.observedAt || startOfToday();
+        facility.modelInputs.observedAt || new Date();
+      // Normalize to the start of day in either case.
+      facility.modelInputs.observedAt = startOfDay(
+        facility.modelInputs.observedAt,
+      );
     }
 
     const db = await getDb();

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -40,6 +40,19 @@ export interface ModelInputsPopulationBrackets {
   staffCases?: number;
   staffPopulation?: number;
 }
+
+export const caseBracketKeys: Array<keyof ModelInputsPopulationBrackets> = [
+  "age0Cases",
+  "age20Cases",
+  "age45Cases",
+  "age55Cases",
+  "age65Cases",
+  "age75Cases",
+  "age85Cases",
+  "ageUnknownCases",
+  "staffCases",
+];
+
 interface ModelInputsPersistent extends ModelInputsPopulationBrackets {
   facilityDormitoryPct?: number;
   facilityCapacity?: number;

--- a/src/infection-model/__tests__/validateCumulativeCases.test.tsx
+++ b/src/infection-model/__tests__/validateCumulativeCases.test.tsx
@@ -79,4 +79,18 @@ describe("useCumulativeCaseValidation hook", () => {
     validInput.ageUnknownCases = 50;
     expect(validateCumulativeCases(validInput, compareTo)).toBe(true);
   });
+
+  it("should not be affected by the presence of irrelevant keys", () => {
+    const compareTo = {
+      previous: { ageUnknownCases: 40, ageUnknownPopulation: 1000 },
+      next: { ageUnknownCases: 50, ageUnknownPopulation: 950 },
+    };
+    const validInput: ModelInputsPopulationBrackets = {
+      ageUnknownCases: 45,
+      // this property violates monotonic increasing (as do previous and next) and we should not care
+      ageUnknownPopulation: 975,
+    };
+
+    expect(validateCumulativeCases(validInput, compareTo)).toBe(true);
+  });
 });

--- a/src/infection-model/validators.tsx
+++ b/src/infection-model/validators.tsx
@@ -1,4 +1,7 @@
-import { ModelInputsPopulationBrackets } from "../impact-dashboard/EpidemicModelContext";
+import {
+  caseBracketKeys,
+  ModelInputsPopulationBrackets,
+} from "../impact-dashboard/EpidemicModelContext";
 
 type ComparisonBounds = {
   previous?: ModelInputsPopulationBrackets;
@@ -12,35 +15,33 @@ export const validateCumulativeCases = (
   let valid = true;
 
   if (previous !== undefined) {
-    valid = (Object.keys(previous) as Array<keyof typeof previous>).reduce(
-      (valid, key) => {
-        const inputVal = inputs[key];
-        const prevVal = previous[key];
-        // this is kind of nonsense in practice, but because
-        // all these keys are optional, Typescript must be appeased
-        if (prevVal === undefined) {
-          return valid;
-        }
-        return valid && inputVal !== undefined && prevVal <= inputVal;
-      },
-      valid as boolean,
-    );
+    valid = (Object.keys(previous).filter((key) =>
+      caseBracketKeys.includes(key as any),
+    ) as Array<keyof ModelInputsPopulationBrackets>).reduce((valid, key) => {
+      const inputVal = inputs[key];
+      const prevVal = previous[key];
+      // this is kind of nonsense in practice, but because
+      // all these keys are optional, Typescript must be appeased
+      if (prevVal === undefined) {
+        return valid;
+      }
+      return valid && inputVal !== undefined && prevVal <= inputVal;
+    }, valid as boolean);
   }
 
   if (next !== undefined) {
-    valid = (Object.keys(next) as Array<keyof typeof next>).reduce(
-      (valid, key) => {
-        const inputVal = inputs[key];
-        const nextVal = next[key];
-        // this is kind of nonsense in practice, but because
-        // all these keys are optional, Typescript must be appeased
-        if (nextVal === undefined) {
-          return valid;
-        }
-        return valid && inputVal !== undefined && nextVal >= inputVal;
-      },
-      valid as boolean,
-    );
+    valid = (Object.keys(next).filter((key) =>
+      caseBracketKeys.includes(key as any),
+    ) as Array<keyof ModelInputsPopulationBrackets>).reduce((valid, key) => {
+      const inputVal = inputs[key];
+      const nextVal = next[key];
+      // this is kind of nonsense in practice, but because
+      // all these keys are optional, Typescript must be appeased
+      if (nextVal === undefined) {
+        return valid;
+      }
+      return valid && inputVal !== undefined && nextVal >= inputVal;
+    }, valid as boolean);
   }
 
   return valid;


### PR DESCRIPTION
## Description of the change

Detects cases where we have same-day but unequal timestamps among fetched model versions and re-sorts the versions to prepare them for our uniqueness-by-day filter. (Not every facility necessarily has this problem, so we skip the extra work for them.)

I also updated `saveFacility` to normalize all `observedAt` timestamps to the start of the day, which hopefully will avoid introducing this problem for new facilities. Patching the existing data is potentially tricky though, due to access and timezone issues, so I'm not actually doing this here for the moment. (We might want to actually consider changing the underlying datatype as part of that so it's kind of a larger conversation.)

There was also a bug in the recently merged historical case validation that I encountered during this work — it was requiring that _all_ fields in the model increase over time, not just the case counts (lol whoops 😎). I fixed that here too.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #515 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
