### PR TITLE
Prevent chart peak from being cut off on home route 

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -131,7 +131,9 @@ const CurveChart: React.FC<CurveChartProps> = ({
     responsiveWidth: true,
     size: [450, 450],
     yExtent: { extent: yAxisExtent, includeAnnotations: false },
-    margin: hideAxes ? null : { left: 60, bottom: 60, right: 10, top: 10 },
+    margin: hideAxes
+      ? { top: 5 }
+      : { left: 60, bottom: 60, right: 10, top: 10 },
     lineStyle: ({ key }) => ({
       stroke: markColors[key],
       strokeWidth: 1,


### PR DESCRIPTION
## Description of the change

Add top margin to d3 charts on / 
* Will prevent chart from being cut off, was previously fixed on /facility

WAS:
![image](https://user-images.githubusercontent.com/1372946/83789524-b228d580-a64b-11ea-85cd-e5e9ae003726.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/83789541-bbb23d80-a64b-11ea-9484-22216d23dcfe.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes part of https://github.com/Recidiviz/covid19-dashboard/issues/372, Google doc

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
