### PR TITLE
Merlin UI polish: Fix bug in % input

### DIFF
--- a/src/design-system/InputTextNumeric.tsx
+++ b/src/design-system/InputTextNumeric.tsx
@@ -31,7 +31,10 @@ const InputTextNumeric: React.FC<Props> = (props) => {
     if (value == null) return undefined;
 
     if (props.type === "percent") {
-      return `${value * 100}`;
+      const valueIsNumber = (value * 100).toFixed(0);
+      const valueIsString = `${valueIsNumber}`;
+
+      return valueIsString;
     } else {
       return `${value}`;
     }


### PR DESCRIPTION
## Description of the change

Bug was: If deleted existing value and entered "7" in "Bunk-style housing" % field, number would display with several decimals e.g. "7.000000001"

WAS:
![percent](https://user-images.githubusercontent.com/1372946/83838557-6b1ffc00-a6ae-11ea-9f49-30bf205c2ef5.gif)

IS:
![percent-is](https://user-images.githubusercontent.com/1372946/83838567-707d4680-a6ae-11ea-9e1b-6d45ef5a27cb.gif)

cc @macfarlandian I was greatly overcomplicating this before 🤦‍♀️

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes part of https://github.com/Recidiviz/covid19-dashboard/issues/372, Google doc

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
