### PR TITLE
Always navigate to root after duplicate scenario

### DIFF
--- a/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
+++ b/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
@@ -1,3 +1,4 @@
+import { navigate } from "gatsby";
 import React, { useState } from "react";
 import styled from "styled-components";
 
@@ -66,10 +67,12 @@ const ReadOnlyScenarioBanner: React.FC<Props> = (props) => {
 
   const duplicate = (scenarioId: string) => {
     setModalOpen(true);
-    duplicateScenario(scenarioId).then((scenario) => {
-      setModalOpen(false);
-      dispatchScenarioUpdate(scenario);
-    });
+    duplicateScenario(scenarioId)
+      .then((scenario) => {
+        setModalOpen(false);
+        dispatchScenarioUpdate(scenario);
+      })
+      .then(() => navigate("/"));
   };
 
   return (


### PR DESCRIPTION
## Description of the change
Explicitly navigate to root path (Scenario Detail view) after duplicating a facility from ViewOnlyBanner button.

Note in giph, the app navigates to the newly created (copied) Scenario when duplicate button is pressed while in Facility Details view.

![explicit-render-home](https://user-images.githubusercontent.com/8259050/84204702-50180800-aa71-11ea-8a44-3cf35884839d.gif)

The original error was that clicking "duplicate" button while viewing Facility Details of a shared Scenario would leave the view on Facility Details of that Shared Scenario, so edits would rase errors.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #544

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
