### PR TITLE
hook to read user's admin status

### DIFF
--- a/src/constants/auth.tsx
+++ b/src/constants/auth.tsx
@@ -1,0 +1,1 @@
+export const METADATA_NAMESPACE = "https://model.recidiviz.org/";

--- a/src/hooks/useAdminUser.tsx
+++ b/src/hooks/useAdminUser.tsx
@@ -1,0 +1,11 @@
+import { useAuth0 } from "../auth/react-auth0-spa";
+import { METADATA_NAMESPACE } from "../constants/auth";
+
+const adminKey = `${METADATA_NAMESPACE}admin`;
+
+const useAdminUser = (): boolean => {
+  const { user } = useAuth0() as any;
+  return !!(user && user[adminKey]);
+};
+
+export default useAdminUser;


### PR DESCRIPTION
## Description of the change

Adds a hook for determining a user's `admin` status, which is a property of the identity information we get from Auth0.

This is accompanied by a rule I added via the Auth0 console as follows:

```js
function (user, context, callback) {
  const namespace = "https://model.recidiviz.org/";
  user.app_metadata = user.app_metadata || {};
  context.idToken[namespace + 'admin'] = !!user.app_metadata.admin;
  callback(null, user, context);
}
```

With this we can manually whitelist users for admin access by editing their user profile in the Auth0 console. 

There is nowhere in the UI that is using this yet, but I did verify it locally with some console logs. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #183 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
