### PR TITLE
Add top margin to charts

### DIFF
--- a/src/page-multi-facility/HistoricalCasesChart/index.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/index.tsx
@@ -156,7 +156,7 @@ const HistoricalCasesChart: React.FC<Props> = ({ facility, onModalSave }) => {
         ticks: 5,
       },
     ],
-    margin: { top: 0, bottom: 50, left: 50, right: 25 },
+    margin: { top: 10, bottom: 50, left: 50, right: 25 },
     oAccessor: "observedAt",
     size: [400, 300],
     responsiveWidth: true,


### PR DESCRIPTION
## Description of the change

> Fixed issue with top of y-axis being cut off with adding a top margin to the HistoricalCasesChart.

**Before**
<img width="571" alt="Screenshot 2020-06-09 at 15 53 55" src="https://user-images.githubusercontent.com/7349784/84209213-738b8480-aa6a-11ea-918c-a1d126dbfff1.png">

**After**
<img width="542" alt="Screenshot 2020-06-09 at 15 53 21" src="https://user-images.githubusercontent.com/7349784/84209221-79816580-aa6a-11ea-991d-df4029cdfcb1.png">

## Type of change

- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues
> Original issue describes this bug happening to multiple kinds of charts - I believe #532 fixed it for CurveCharts.  CheckRtTimeseries already had a top margin set.  Please let me know if you think there are other charts in the product I have missed.
Closes [#486 ]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x ] This pull request has a descriptive title and information useful to a reviewer
- [ x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ x] Potential security implications or infrastructural changes have been considered, if relevant
