### PR TITLE
Simplify state management in Add Cases modal

### DIFF
--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -1,6 +1,6 @@
 import { startOfDay } from "date-fns";
 import { pick } from "lodash";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { saveFacility } from "../database";
 import { useToasts } from "../design-system/Toast";
@@ -31,8 +31,9 @@ const useAddCasesInputs = (
   >();
   // the current state of the facility is the default when we need to reset
   // If observedAt is provided and a version exists then use the version's inputs
-  const defaultInputs = getModelInputs(
-    observedAtVersion || facility.modelInputs,
+  const defaultInputs = useMemo(
+    () => getModelInputs(observedAtVersion || facility.modelInputs),
+    [facility.modelInputs, observedAtVersion],
   );
   // If observedAt is provided then set it as the default date
   const defaultObservationDate = observedAt || facility.modelInputs.observedAt;
@@ -55,18 +56,18 @@ const useAddCasesInputs = (
 
   useEffect(() => {
     if (observedAt) {
-      const observedAtVersion = findMatchingDay({ date: observedAt });
+      const newObservedAtVersion = findMatchingDay({ date: observedAt });
       setObservationDate(observedAt);
 
-      if (observedAtVersion) {
-        setInputs(getModelInputs(observedAtVersion));
-        setObservedAtVersion(observedAtVersion);
+      if (newObservedAtVersion) {
+        setInputs(getModelInputs(newObservedAtVersion));
+        setObservedAtVersion(newObservedAtVersion);
       } else {
-        setInputs({});
+        setInputs(defaultInputs);
         setObservedAtVersion(undefined);
       }
     }
-  }, [observedAt, findMatchingDay]);
+  }, [observedAt, findMatchingDay, defaultInputs]);
 
   const updateInputs = (update: ModelInputsPopulationBrackets) => {
     setInputs({ ...inputs, ...update });

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -1,6 +1,6 @@
 import { startOfDay } from "date-fns";
 import { pick } from "lodash";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { saveFacility } from "../database";
 import { useToasts } from "../design-system/Toast";
@@ -31,9 +31,8 @@ const useAddCasesInputs = (
   >();
   // the current state of the facility is the default when we need to reset
   // If observedAt is provided and a version exists then use the version's inputs
-  const defaultInputs = useMemo(
-    () => getModelInputs(observedAtVersion || facility.modelInputs),
-    [facility.modelInputs, observedAtVersion],
+  const defaultInputs = getModelInputs(
+    observedAtVersion || facility.modelInputs,
   );
   // If observedAt is provided then set it as the default date
   const defaultObservationDate = observedAt || facility.modelInputs.observedAt;
@@ -56,18 +55,18 @@ const useAddCasesInputs = (
 
   useEffect(() => {
     if (observedAt) {
-      const newObservedAtVersion = findMatchingDay({ date: observedAt });
+      const observedAtVersion = findMatchingDay({ date: observedAt });
       setObservationDate(observedAt);
 
-      if (newObservedAtVersion) {
-        setInputs(getModelInputs(newObservedAtVersion));
-        setObservedAtVersion(newObservedAtVersion);
+      if (observedAtVersion) {
+        setInputs(getModelInputs(observedAtVersion));
+        setObservedAtVersion(observedAtVersion);
       } else {
-        setInputs(defaultInputs);
+        setInputs({});
         setObservedAtVersion(undefined);
       }
     }
-  }, [observedAt, findMatchingDay, defaultInputs]);
+  }, [observedAt, findMatchingDay]);
 
   const updateInputs = (update: ModelInputsPopulationBrackets) => {
     setInputs({ ...inputs, ...update });

--- a/src/page-multi-facility/AddCasesModal/index.tsx
+++ b/src/page-multi-facility/AddCasesModal/index.tsx
@@ -12,15 +12,15 @@ export type Props = Pick<ModalProps, "trigger"> & {
 
 const AddCasesModal: React.FC<Props> = ({ facility, trigger, onSave }) => {
   const [modalOpen, setModalOpen] = useState(false);
+  const [observedAt, setObservedAt] = useState<Date | undefined>();
   const {
     inputs,
     observationDate,
-    onDateChange,
     facilityModelVersions,
     updateInputs,
     resetModalData,
     saveCases,
-  } = useAddCasesInputs(facility, onSave);
+  } = useAddCasesInputs(facility, onSave, observedAt);
 
   async function handleSave() {
     await saveCases();
@@ -37,7 +37,7 @@ const AddCasesModal: React.FC<Props> = ({ facility, trigger, onSave }) => {
     >
       <AddCasesModalContent
         observationDate={observationDate}
-        onValueChange={onDateChange}
+        onValueChange={setObservedAt}
         inputs={inputs}
         updateInputs={updateInputs}
         onSave={handleSave}

--- a/src/page-multi-facility/HistoricalCasesChart/HistoricalAddCasesModal.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/HistoricalAddCasesModal.tsx
@@ -11,6 +11,7 @@ interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
   observedAt: Date | undefined;
+  setObservedAt: (date: Date | undefined) => void;
   onModalSave: (f: Facility) => void;
 }
 
@@ -19,12 +20,12 @@ const HistoricalAddCasesModal: React.FC<Props> = ({
   open,
   setOpen,
   observedAt,
+  setObservedAt,
   onModalSave,
 }) => {
   const {
     inputs,
     observationDate,
-    onDateChange,
     facilityModelVersions,
     updateInputs,
     resetModalData,
@@ -47,7 +48,7 @@ const HistoricalAddCasesModal: React.FC<Props> = ({
     >
       <AddCasesModalContent
         observationDate={observationDate || startOfToday()}
-        onValueChange={onDateChange}
+        onValueChange={setObservedAt}
         inputs={inputs}
         updateInputs={updateInputs}
         onSave={handleSave}

--- a/src/page-multi-facility/HistoricalCasesChart/index.tsx
+++ b/src/page-multi-facility/HistoricalCasesChart/index.tsx
@@ -189,6 +189,7 @@ const HistoricalCasesChart: React.FC<Props> = ({ facility, onModalSave }) => {
         setOpen={setModalOpen}
         facility={facility}
         observedAt={observedAt}
+        setObservedAt={(date) => date && setObservedAt(date)}
         onModalSave={onModalSave}
       />
     </ChartWrapper>


### PR DESCRIPTION
## Description of the change

The bug referenced below was happening due to a discrepancy between initialization and reset of the modal, in the `useAddCasesInputs` hook. If no version matched the provided date, an effect hook would clear all the inputs. However, when the modal was closed, a reset function would set them to some default values rather than clearing them. The slightly convoluted result was that the inputs would only ever be blank the first time you opened the modal, if you didn't open it by clicking on a date in the historical cases chart that already had data (i.e. you clicked on a blank date or the "add historical data" button). 

I don't think we actually _ever_ want to clear the inputs — they should always either have either the values retrieved from the version history, or default values.

While the above issue was the proximate cause, rather than simply patch the issue what I have wound up doing (after some consultation with @daschi) is to clean up the state management in the hook function to make it less redundant and imperative, and thus (hopefully) less bug-prone. There is now a "one-way" cascade of side effects such that the `observedAt` argument triggers a series of state changes: the current date, then the user data for that date, then the desired form input values. Instead of returning a function for callers to change the internally stored date, it now requires a new `observedAt` argument to be passed.

This should fix the bug and also hopefully make this hook a bit easier to work with in general.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #541 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
