### PR TITLE
Merlin UI polish: Scenario modal tweaks

### DIFF
--- a/src/design-system/PopUpMenu.tsx
+++ b/src/design-system/PopUpMenu.tsx
@@ -18,17 +18,21 @@ interface ItemProps {
   toggleMenu: (event: React.MouseEvent<Element>) => void;
 }
 
+// Note: `margin` is present to offset extra click room in PopUpMenuIcon
 const PopUpMenuDiv = styled.div`
   position: relative;
   cursor: pointer;
   height: min-content;
+  margin: 0 -14px -14px 0;
 `;
 
+// Note: `padding` is present to allow for extra click room, see PopUpMenuDiv margin to offset
 const PopUpMenuIcon = styled.div`
   font-family: "Rubik", sans-serif;
   font-size: 16px;
   font-weight: 600;
   color: ${Colors.forest};
+  padding: 0 14px 14px 0;
 `;
 
 const PopUpMenuContents = styled.div`

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -338,8 +338,8 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
       open={modalOpen}
       setOpen={setModalOpen}
       trigger={trigger}
-      height="90vh"
-      width="45vw"
+      height="90vmin"
+      width="756px"
     >
       <ModalContents>
         <ScenarioLibraryWrapper scenarios={ownedScenarios} ownedFlag={true} />


### PR DESCRIPTION
## Description of the change

* Fix modal layout by adjusting modal dimensions 
  * Use a fixed width. Note: This is not responsive
  * Use vmin instead of vh, to account for case when browser window is smaller than viewport height
* Increase click target area of "..." menu for UX
  * Note: No visual change

WAS:
![image](https://user-images.githubusercontent.com/1372946/84233368-119d4000-aaa7-11ea-87d2-efe38185bb9f.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/84233356-0a763200-aaa7-11ea-8aaa-3ddfb5e89817.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes part of https://github.com/Recidiviz/covid19-dashboard/issues/372, Google doc

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
