### PR TITLE
[Report automation] Admin page displaying stats for states and counties

### DIFF
--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -59,6 +59,7 @@ const InputSelect: React.FC<Props> = (props) => {
           onChange={props.onChange}
           value={props.value}
           name={props.label}
+          {...props}
         >
           {props.children}
         </StyledSelect>

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 export type LocaleRecord = {
   county: string;
+  totalPopulation: number;
   estimatedIncarceratedCases: number;
   hospitalBeds: number;
   reportedCases: number;
@@ -104,6 +105,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
             return {
               county: row.County,
               state: row.State,
+              totalPopulation: totalPopulation,
               hospitalBeds: numeral(row["Hospital Beds"]).value() || 0,
               totalIncarceratedPopulation,
               reportedCases,

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -94,13 +94,13 @@ async function fetchNYTData() {
     fetchHistoricalNYTStatesData(),
   ]);
 
-  const dayOne = latestStateData[0].date;
-  const daySeven = subWeeks(dayOne, 1);
+  const daySeven = latestStateData[0].date;
+  const dayOne = subWeeks(daySeven, 1);
   const filteredCountyData = historicalCountyData.filter((d) =>
-    isSameDay(d.date, daySeven),
+    isSameDay(d.date, dayOne),
   );
   const filteredStateData = historicalStateData.filter((d) =>
-    isSameDay(d.date, daySeven),
+    isSameDay(d.date, dayOne),
   );
   let data: { [key: string]: any } = {};
   for (const stateData of latestStateData) {

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -51,6 +51,36 @@ function transformRow(row: DSVRowString): NYTCountyRecord | NYTStateRecord {
   };
 }
 
+async function fetchCSVData(url: string) {
+  const response = await fetch(url);
+  const rawCSV = await response.text();
+  return csvParse(rawCSV, transformRow);
+}
+
+async function fetchLatestNYTCountyData() {
+  const latestCountyDataURL =
+    "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
+  return fetchCSVData(latestCountyDataURL);
+}
+
+async function fetchHistoricalNYTCountyData() {
+  const historicalCountyDataURL =
+    "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv";
+  return fetchCSVData(historicalCountyDataURL);
+}
+
+async function fetchLatestNYTStatesData() {
+  const latestStatesDataURL =
+    "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-states.csv";
+  return fetchCSVData(latestStatesDataURL);
+}
+
+async function fetchHistoricalNYTStatesData() {
+  const historicalStatesDataURL =
+    "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
+  return fetchCSVData(historicalStatesDataURL);
+}
+
 export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -61,36 +91,6 @@ export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
   });
 
   async function fetchNYTData() {
-    async function fetchCSVData(url: string) {
-      const response = await fetch(url);
-      const rawCSV = await response.text();
-      return csvParse(rawCSV, transformRow);
-    }
-
-    async function fetchLatestNYTCountyData() {
-      const latestCountyDataURL =
-        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
-      return fetchCSVData(latestCountyDataURL);
-    }
-
-    async function fetchHistoricalNYTCountyData() {
-      const historicalCountyDataURL =
-        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv";
-      return fetchCSVData(historicalCountyDataURL);
-    }
-
-    async function fetchLatestNYTStatesData() {
-      const latestStatesDataURL =
-        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-states.csv";
-      return fetchCSVData(latestStatesDataURL);
-    }
-
-    async function fetchHistoricalNYTStatesData() {
-      const historicalStatesDataURL =
-        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
-      return fetchCSVData(historicalStatesDataURL);
-    }
-
     const [
       latestCountyData,
       historicalCountyData,

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -131,12 +131,12 @@ export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     let mounted = true;
-    setState({ ...state, loading: true });
+    setState({ data: {}, error: null, loading: true });
     fetchNYTData()
       .then((data) => {
         if (mounted) {
           setState({
-            ...state,
+            error: null,
             data,
             loading: false,
           });
@@ -145,7 +145,7 @@ export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
       .catch((error) => {
         if (mounted) {
           setState({
-            ...state,
+            data: {},
             loading: false,
             error,
           });

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -1,0 +1,164 @@
+import { csvParse, DSVRowString } from "d3";
+import { addDays, isSameDay, startOfToday, subWeeks } from "date-fns";
+import numeral from "numeral";
+import React, { useEffect, useState } from "react";
+
+export type NYTStateRecord = {
+  date: Date;
+  state: string | undefined;
+  cases: number;
+  deaths: number;
+  confirmedCases?: number;
+  confirmedDeaths?: number;
+  probableCases?: number;
+  probableDeaths?: number;
+};
+
+export type NYTCountyRecord = NYTStateRecord & {
+  county: string;
+};
+
+export type NYTData = {
+  state: NYTStateRecord[];
+  counties: NYTCountyRecord[];
+};
+
+type NYTDataMapping = {
+  [stateName: string]: NYTData;
+};
+
+interface NYTDataContext {
+  loading: boolean;
+  error: any;
+  data: NYTDataMapping;
+}
+
+const NYTDataContext = React.createContext<NYTDataContext | undefined>(
+  undefined,
+);
+
+function transformRow(row: DSVRowString): NYTCountyRecord | NYTStateRecord {
+  return {
+    state: row.state,
+    county: row.county,
+    date: row.date ? addDays(new Date(row.date), 1) : startOfToday(),
+    cases: numeral(row["cases"]).value() || 0,
+    confirmedCases: numeral(row["confirmed_cases"]).value() || 0,
+    confirmedDeaths: numeral(row["confirmed_deaths"]).value() || 0,
+    deaths: numeral(row["deaths"]).value() || 0,
+    probableCases: numeral(row["probable_cases"]).value() || 0,
+    probableDeaths: numeral(row["probable_deaths"]).value() || 0,
+  };
+}
+
+export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [state, setState] = useState({
+    loading: false,
+    error: null,
+    data: {},
+  });
+
+  async function fetchNYTData() {
+    async function fetchCSVData(url: string) {
+      const response = await fetch(url);
+      const rawCSV = await response.text();
+      return csvParse(rawCSV, transformRow);
+    }
+
+    async function fetchLatestNYTCountyData() {
+      const latestCountyDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
+      return fetchCSVData(latestCountyDataURL);
+    }
+
+    async function fetchHistoricalNYTCountyData() {
+      const historicalCountyDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv";
+      return fetchCSVData(historicalCountyDataURL);
+    }
+
+    async function fetchLatestNYTStatesData() {
+      const latestStatesDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-states.csv";
+      return fetchCSVData(latestStatesDataURL);
+    }
+
+    async function fetchHistoricalNYTStatesData() {
+      const historicalStatesDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
+      return fetchCSVData(historicalStatesDataURL);
+    }
+
+    const [
+      latestCountyData,
+      historicalCountyData,
+      latestStateData,
+      historicalStateData,
+    ] = await Promise.all([
+      fetchLatestNYTCountyData(),
+      fetchHistoricalNYTCountyData(),
+      fetchLatestNYTStatesData(),
+      fetchHistoricalNYTStatesData(),
+    ]);
+
+    const dayOne = latestStateData[0].date;
+    const daySeven = subWeeks(dayOne, 1);
+    const filteredCountyData = historicalCountyData.filter((d) =>
+      isSameDay(d.date, daySeven),
+    );
+    const filteredStateData = historicalStateData.filter((d) =>
+      isSameDay(d.date, daySeven),
+    );
+    let data: { [key: string]: any } = {};
+    for (const stateData of latestStateData) {
+      if (stateData.state) {
+        data[stateData.state] = {
+          state: [
+            stateData,
+            ...filteredStateData.filter((d) => d.state === stateData.state),
+          ],
+          counties: [
+            ...latestCountyData.filter((d) => d.state === stateData.state),
+            ...filteredCountyData.filter((d) => d.state === stateData.state),
+          ],
+        };
+      }
+    }
+    console.log("feetch sdata: ", data);
+    return data;
+  }
+
+  useEffect(() => {
+    setState({ ...state, loading: true });
+    fetchNYTData()
+      .then((data) => {
+        setState({
+          ...state,
+          data,
+          loading: false,
+        });
+      })
+      .catch((error) => {
+        setState({
+          ...state,
+          loading: false,
+          error,
+        });
+      });
+  }, []);
+
+  return (
+    <NYTDataContext.Provider value={state}>{children}</NYTDataContext.Provider>
+  );
+};
+
+export function useNYTData() {
+  const context = React.useContext(NYTDataContext);
+  if (context === undefined) {
+    throw new Error("useNYTDataProvider must be used within a NYTDataProvider");
+  }
+
+  return context;
+}

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -126,27 +126,34 @@ export const NYTDataProvider: React.FC<{ children: React.ReactNode }> = ({
         };
       }
     }
-    console.log("feetch sdata: ", data);
     return data;
   }
 
   useEffect(() => {
+    let mounted = true;
     setState({ ...state, loading: true });
     fetchNYTData()
       .then((data) => {
-        setState({
-          ...state,
-          data,
-          loading: false,
-        });
+        if (mounted) {
+          setState({
+            ...state,
+            data,
+            loading: false,
+          });
+        }
       })
       .catch((error) => {
-        setState({
-          ...state,
-          loading: false,
-          error,
-        });
+        if (mounted) {
+          setState({
+            ...state,
+            loading: false,
+            error,
+          });
+        }
       });
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   return (

--- a/src/page-weekly-snapshot/NYTDataProvider.tsx
+++ b/src/page-weekly-snapshot/NYTDataProvider.tsx
@@ -1,5 +1,5 @@
 import { csvParse, DSVRowString } from "d3";
-import { addDays, isSameDay, startOfToday, subWeeks } from "date-fns";
+import { isSameDay, parse, startOfToday, subWeeks } from "date-fns";
 import numeral from "numeral";
 import React, { useEffect, useState } from "react";
 
@@ -41,7 +41,7 @@ function transformRow(row: DSVRowString): NYTCountyRecord | NYTStateRecord {
   return {
     state: row.state,
     county: row.county,
-    date: row.date ? addDays(new Date(row.date), 1) : startOfToday(),
+    date: row.date ? parse(row.date, "yyyy-MM-dd", new Date()) : startOfToday(),
     cases: numeral(row["cases"]).value() || 0,
     confirmedCases: numeral(row["confirmed_cases"]).value() || 0,
     confirmedDeaths: numeral(row["confirmed_deaths"]).value() || 0,

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -1,5 +1,159 @@
-import React from "react";
+import { csvParse, DSVRowAny, DSVRowString } from "d3";
+import { subWeeks } from "date-fns";
+import numeral from "numeral";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+
+import InputSelect from "../design-system/InputSelect";
+import Loading from "../design-system/Loading";
+import { LocaleDataProvider, useLocaleDataState } from "../locale-data-context";
+
+function transformRow(row: DSVRowString) {
+  return {
+    ...row,
+    cases: numeral(row["cases"]).value() || 0,
+    confirmedCases: numeral(row["confirmed_cases"]).value() || 0,
+    confirmedDeaths: numeral(row["confirmed_deaths"]).value() || 0,
+    deaths: numeral(row["deaths"]).value() || 0,
+    probableCases: numeral(row["probable_cases"]).value() || 0,
+    probableDeaths: numeral(row["probable_deaths"]).value() || 0,
+  };
+}
+
+const stateNamesFilter = (key: string) =>
+  !["US Total", "US Federal Prisons"].includes(key);
+const formatNumber = (number: number) => numeral(number).format("0,0");
+
+const LocaleStats = styled.div`
+  display: flex;
+`;
+const LocaleStatsList = styled.ul``;
 
 export default function WeeklySnapshotPage() {
-  return <div>hello</div>;
+  const [latestStatesData, setLatestStatesData] = useState<DSVRowAny[]>([]);
+  const [latestCountyData, setLatestCountyData] = useState<DSVRowAny[]>([]);
+  const [historicalStatesData, setHistoricalStatesData] = useState<DSVRowAny[]>(
+    [],
+  );
+  const [historicalCountyData, setHistoricalCountyData] = useState<DSVRowAny[]>(
+    [],
+  );
+  const [stateData, setStateData] = useState<DSVRowAny>({});
+  const { data: localeData, loading } = useLocaleDataState();
+  const stateNames = Array.from(localeData.keys()).filter(stateNamesFilter);
+
+  useEffect(() => {
+    async function fetchLatestNYTStatesData() {
+      const latestStatesDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-states.csv";
+      const response = await fetch(latestStatesDataURL);
+      const rawCSV = await response.text();
+      const data = csvParse(rawCSV, transformRow);
+      setLatestStatesData(data);
+    }
+
+    async function fetchLatestNYTCountyData() {
+      const latestCountyDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/live/us-counties.csv";
+      const response = await fetch(latestCountyDataURL);
+      const rawCSV = await response.text();
+      const data = csvParse(rawCSV, transformRow);
+      setLatestCountyData(data);
+    }
+
+    async function fetchHistoricalNYTStatesData() {
+      const historicalStatesDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
+
+      const response = await fetch(historicalStatesDataURL);
+      const rawCSV = await response.text();
+      const data = csvParse(rawCSV, transformRow);
+      setHistoricalStatesData(data);
+    }
+
+    async function fetchHistoricalNYTCountyData() {
+      const historicalCountyDataURL =
+        "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv";
+
+      const response = await fetch(historicalCountyDataURL);
+      const rawCSV = await response.text();
+      const data = csvParse(rawCSV, transformRow);
+      setHistoricalCountyData(data);
+    }
+
+    fetchLatestNYTStatesData();
+    fetchLatestNYTCountyData();
+    fetchHistoricalNYTStatesData();
+    fetchHistoricalNYTCountyData();
+  }, [setStateData]);
+
+  console.log("state data: ", {
+    stateData,
+    latestStatesData,
+    localeData,
+    stateNames,
+    historicalStatesData,
+    historicalCountyData,
+    latestCountyData,
+  });
+  console.log(new Date(stateData.date), subWeeks(new Date(stateData.date), 1));
+
+  const handleOnChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const stateName = event.target.value;
+    if (latestStatesData.length) {
+      const stateData = latestStatesData.find(
+        (state) => state.state === stateName,
+      );
+      stateData && setStateData(stateData);
+    }
+  };
+
+  // PSEUDOCODE STEPS
+  // getSevenDayDiff
+  // getDates
+  // get dayOne - latestStatesData date - 7 days
+  // get daySeven - latestStatesData date
+  // getCasesDiff - daySeven cases - dayOne cases
+  //
+  // number of ICU/hospital beds in state (localeData)
+  // add *** if county has a facility (cross reference with LocaleData)
+  // counties to watch - fetch county data
+
+  return (
+    <LocaleDataProvider>
+      {loading || !latestStatesData.length ? (
+        <Loading />
+      ) : (
+        <>
+          <InputSelect
+            label="State"
+            placeholder="Select a state"
+            onChange={handleOnChange}
+          >
+            <option value="">Select a state</option>
+            {stateNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </InputSelect>
+          {stateData.state && (
+            <LocaleStats>
+              <LocaleStatsList>
+                <li>
+                  Number of cases in the state: {formatNumber(stateData.cases)}
+                </li>
+                <li>
+                  Change in state cases since last week:{" "}
+                  {formatNumber(stateData.cases)}
+                </li>
+                <li>Number of ICU and hospital beds in state: </li>
+                <li>Counties to watch: </li>
+              </LocaleStatsList>
+            </LocaleStats>
+          )}
+        </>
+      )}
+    </LocaleDataProvider>
+  );
 }

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function WeeklySnapshotPage() {
+  return <div>hello</div>;
+}

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -1,13 +1,22 @@
-import { maxBy, minBy } from "lodash";
+import { maxBy, minBy, orderBy } from "lodash";
 import numeral from "numeral";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import InputSelect from "../design-system/InputSelect";
 import Loading from "../design-system/Loading";
-import { LocaleDataProvider, useLocaleDataState } from "../locale-data-context";
-import { NYTData, NYTStateRecord, useNYTData } from "./NYTDataProvider";
+import {
+  LocaleDataProvider,
+  LocaleRecord,
+  useLocaleDataState,
+} from "../locale-data-context";
+import {
+  NYTCountyRecord,
+  NYTData,
+  NYTStateRecord,
+  useNYTData,
+} from "./NYTDataProvider";
 
 const stateNamesFilter = (key: string) =>
   !["US Total", "US Federal Prisons"].includes(key);
@@ -18,13 +27,82 @@ const LocaleStats = styled.div`
 `;
 const LocaleStatsList = styled.ul``;
 
+type PerCapitaCountyCase = {
+  name: string;
+  perCapitaIncrease: number | undefined;
+};
+
+function getDay(nytData: NYTCountyRecord[] | NYTStateRecord[], day: number) {
+  if (day === 1) {
+    return minBy(nytData, (d: NYTCountyRecord | NYTStateRecord) => d.date);
+  } else {
+    return maxBy(nytData, (d: NYTCountyRecord | NYTStateRecord) => d.date);
+  }
+}
+
+function getCountyDataByName(counties: NYTCountyRecord[]) {
+  const dataByCounty: { [countyName: string]: NYTCountyRecord[] } = {};
+
+  counties.forEach((data: NYTCountyRecord) => {
+    if (dataByCounty[data.county]) {
+      dataByCounty[data.county] = [...dataByCounty[data.county], data];
+    } else {
+      dataByCounty[data.county] = [data];
+    }
+  });
+
+  return dataByCounty;
+}
+
+function calculatePerCapitaIncrease(
+  daySevenCases: number | undefined,
+  dayOneCases: number | undefined,
+  countyPopulation: number | undefined,
+) {
+  if (
+    (!daySevenCases && daySevenCases !== 0) ||
+    (!dayOneCases && dayOneCases !== 0) ||
+    !countyPopulation
+  )
+    return;
+  return (daySevenCases - dayOneCases) / countyPopulation;
+}
+
+function getPerCapitaCountyCases(
+  counties: NYTCountyRecord[],
+  stateLocaleData: Map<string, LocaleRecord> | undefined,
+) {
+  const dataByCounty = getCountyDataByName(counties);
+  const perCapitaCountyCases: PerCapitaCountyCase[] = [];
+
+  for (const countyName in dataByCounty) {
+    const dayOne = getDay(dataByCounty[countyName], 1);
+    const daySeven = getDay(dataByCounty[countyName], 7);
+    const countyPopulation = stateLocaleData?.get(countyName)?.totalPopulation;
+    perCapitaCountyCases.push({
+      name: countyName,
+      perCapitaIncrease: calculatePerCapitaIncrease(
+        daySeven?.cases,
+        dayOne?.cases,
+        countyPopulation,
+      ),
+    });
+  }
+  return perCapitaCountyCases;
+}
+
 export default function WeeklySnapshotPage() {
   const { data, loading: nytLoading } = useNYTData();
-  console.log({ data });
   const [selectedState, setSelectedState] = useState<NYTData | undefined>();
+  const [sevenDayDiffInCases, setSevenDayDiffInCases] = useState<
+    number | undefined
+  >();
+  const [countiesToWatch, setCountiesToWatch] = useState<string[] | undefined>(
+    [],
+  );
+  const [totalBeds, setTotalBeds] = useState<number | undefined>();
   const { data: localeData, loading } = useLocaleDataState();
   const stateNames = Array.from(localeData.keys()).filter(stateNamesFilter);
-
   const handleOnChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const stateName = event.target.value;
     if (!nytLoading) {
@@ -32,17 +110,38 @@ export default function WeeklySnapshotPage() {
     }
   };
 
-  const dayOne =
-    selectedState &&
-    minBy(selectedState.state, (state: NYTStateRecord) => state.date);
-  const daySeven =
-    selectedState &&
-    maxBy(selectedState.state, (state: NYTStateRecord) => state.date);
-  const sevenDayDiffInCases =
-    daySeven && dayOne && daySeven.cases - dayOne.cases;
-  const total =
-    dayOne && dayOne.state && localeData?.get(dayOne.state)?.get("Total");
-  const totalBeds = total && total.icuBeds + total.hospitalBeds;
+  const dayOne = getDay(selectedState?.state || [], 1);
+  const daySeven = getDay(selectedState?.state || [], 7);
+  useEffect(() => {
+    if (dayOne?.state && daySeven?.state && selectedState) {
+      const stateLocaleData = localeData?.get(dayOne.state);
+      const totalLocaleData = stateLocaleData?.get("Total");
+      const sevenDayDiffInCases = daySeven.cases - dayOne.cases;
+      const totalBeds =
+        totalLocaleData &&
+        totalLocaleData.icuBeds + totalLocaleData.hospitalBeds;
+
+      const perCapitaCountyCases = getPerCapitaCountyCases(
+        selectedState.counties,
+        stateLocaleData,
+      );
+      const highestFourCounties = orderBy(
+        perCapitaCountyCases.filter((c) => !!c.perCapitaIncrease),
+        ["perCapitaIncrease"],
+        ["desc"],
+      ).slice(0, 4);
+      const countiesToWatch = highestFourCounties.map((county) => {
+        const starred =
+          stateLocaleData && stateLocaleData.has(county.name) ? "***" : "";
+        return `${county.name}${starred}, ${numeral(
+          county.perCapitaIncrease,
+        ).format("0.000 %")};`;
+      });
+      setCountiesToWatch(countiesToWatch);
+      setTotalBeds(totalBeds);
+      setSevenDayDiffInCases(sevenDayDiffInCases);
+    }
+  }, [selectedState, localeData]);
 
   return (
     <LocaleDataProvider>
@@ -67,11 +166,13 @@ export default function WeeklySnapshotPage() {
               <LocaleStatsList>
                 <li>
                   Latest Date:{" "}
-                  {daySeven && <DateMMMMdyyyy date={daySeven.date} />}
+                  {daySeven?.date && <DateMMMMdyyyy date={daySeven.date} />}
                 </li>
                 <li>
                   Number of cases in the state:{" "}
-                  {daySeven ? formatNumber(daySeven.cases) : "?"}
+                  {daySeven?.cases || daySeven?.cases === 0
+                    ? formatNumber(daySeven.cases)
+                    : "?"}
                 </li>
                 <li>
                   Change in state cases since last week:{" "}
@@ -83,7 +184,7 @@ export default function WeeklySnapshotPage() {
                   Number of ICU and hospital beds in state:{" "}
                   {totalBeds || totalBeds === 0 ? formatNumber(totalBeds) : "?"}
                 </li>
-                <li>Counties to watch: </li>
+                <li>Counties to watch: {countiesToWatch?.join(" ")}</li>
               </LocaleStatsList>
             </LocaleStats>
           )}

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import InputSelect from "../design-system/InputSelect";
 import Loading from "../design-system/Loading";
+import { Column } from "../design-system/PageColumn";
 import {
   LocaleDataProvider,
   LocaleRecord,
@@ -112,6 +113,7 @@ export default function WeeklySnapshotPage() {
 
   const dayOne = getDay(selectedState?.state || [], 1);
   const daySeven = getDay(selectedState?.state || [], 7);
+
   useEffect(() => {
     if (dayOne?.state && daySeven?.state && selectedState) {
       const stateLocaleData = localeData?.get(dayOne.state);
@@ -131,11 +133,9 @@ export default function WeeklySnapshotPage() {
         ["desc"],
       ).slice(0, 4);
       const countiesToWatch = highestFourCounties.map((county) => {
-        const starred =
-          stateLocaleData && stateLocaleData.has(county.name) ? "***" : "";
-        return `${county.name}${starred}, ${numeral(
-          county.perCapitaIncrease,
-        ).format("0.000 %")};`;
+        return `${county.name}, ${numeral(county.perCapitaIncrease).format(
+          "0.000 %",
+        )};`;
       });
       setCountiesToWatch(countiesToWatch);
       setTotalBeds(totalBeds);
@@ -148,7 +148,7 @@ export default function WeeklySnapshotPage() {
       {loading || nytLoading ? (
         <Loading />
       ) : (
-        <>
+        <Column>
           <InputSelect
             label="State"
             placeholder="Select a state"
@@ -188,7 +188,7 @@ export default function WeeklySnapshotPage() {
               </LocaleStatsList>
             </LocaleStats>
           )}
-        </>
+        </Column>
       )}
     </LocaleDataProvider>
   );

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -30,7 +30,7 @@ const LocaleStatsList = styled.ul``;
 
 type PerCapitaCountyCase = {
   name: string;
-  perCapitaIncrease: number | undefined;
+  casesIncreasePerCapita: number | undefined;
 };
 
 function getDay(nytData: NYTCountyRecord[] | NYTStateRecord[], day: number) {
@@ -69,27 +69,27 @@ function calculatePerCapitaIncrease(
   return (daySevenCases - dayOneCases) / countyPopulation;
 }
 
-function getPerCapitaCountyCases(
+function getCountyIncreasePerCapita(
   counties: NYTCountyRecord[],
   stateLocaleData: Map<string, LocaleRecord> | undefined,
 ) {
   const dataByCounty = getCountyDataByName(counties);
-  const perCapitaCountyCases: PerCapitaCountyCase[] = [];
+  const countyCasesIncreasePerCapita: PerCapitaCountyCase[] = [];
 
   for (const countyName in dataByCounty) {
     const dayOne = getDay(dataByCounty[countyName], 1);
     const daySeven = getDay(dataByCounty[countyName], 7);
     const countyPopulation = stateLocaleData?.get(countyName)?.totalPopulation;
-    perCapitaCountyCases.push({
+    countyCasesIncreasePerCapita.push({
       name: countyName,
-      perCapitaIncrease: calculatePerCapitaIncrease(
+      casesIncreasePerCapita: calculatePerCapitaIncrease(
         daySeven?.cases,
         dayOne?.cases,
         countyPopulation,
       ),
     });
   }
-  return perCapitaCountyCases;
+  return countyCasesIncreasePerCapita;
 }
 
 export default function WeeklySnapshotPage() {
@@ -123,17 +123,17 @@ export default function WeeklySnapshotPage() {
         totalLocaleData &&
         totalLocaleData.icuBeds + totalLocaleData.hospitalBeds;
 
-      const perCapitaCountyCases = getPerCapitaCountyCases(
+      const perCapitaCountyCases = getCountyIncreasePerCapita(
         selectedState.counties,
         stateLocaleData,
       );
       const highestFourCounties = orderBy(
-        perCapitaCountyCases.filter((c) => !!c.perCapitaIncrease),
-        ["perCapitaIncrease"],
+        perCapitaCountyCases.filter((c) => !!c.casesIncreasePerCapita),
+        ["casesIncreasePerCapita"],
         ["desc"],
       ).slice(0, 4);
       const countiesToWatch = highestFourCounties.map((county) => {
-        return `${county.name}, ${numeral(county.perCapitaIncrease).format(
+        return `${county.name}, ${numeral(county.casesIncreasePerCapita).format(
           "0.000 %",
         )};`;
       });

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -141,7 +141,7 @@ export default function WeeklySnapshotPage() {
       setTotalBeds(totalBeds);
       setSevenDayDiffInCases(sevenDayDiffInCases);
     }
-  }, [selectedState, localeData]);
+  }, [selectedState, localeData, dayOne, daySeven]);
 
   return (
     <LocaleDataProvider>

--- a/src/page-weekly-snapshot/index.tsx
+++ b/src/page-weekly-snapshot/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./WeeklySnapshotPage";

--- a/src/pages/weekly-snapshot.tsx
+++ b/src/pages/weekly-snapshot.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import AuthWall from "../auth/AuthWall";
+import WeeklySnapshotPage from "../page-weekly-snapshot";
+import PageInfo from "../site-metadata/PageInfo";
+
+// eslint-disable-next-line react/display-name
+export default () => (
+  <>
+    <PageInfo title="Generate State-level Weekly Snapshot" />
+    <AuthWall>
+      <WeeklySnapshotPage />
+    </AuthWall>
+  </>
+);

--- a/src/pages/weekly-snapshot.tsx
+++ b/src/pages/weekly-snapshot.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import AuthWall from "../auth/AuthWall";
 import WeeklySnapshotPage from "../page-weekly-snapshot";
+import { NYTDataProvider } from "../page-weekly-snapshot/NYTDataProvider";
 import PageInfo from "../site-metadata/PageInfo";
 
 // eslint-disable-next-line react/display-name
@@ -9,7 +10,9 @@ export default () => (
   <>
     <PageInfo title="Generate State-level Weekly Snapshot" />
     <AuthWall>
-      <WeeklySnapshotPage />
+      <NYTDataProvider>
+        <WeeklySnapshotPage />
+      </NYTDataProvider>
     </AuthWall>
   </>
 );

--- a/src/pages/weekly-snapshot.tsx
+++ b/src/pages/weekly-snapshot.tsx
@@ -1,18 +1,29 @@
 import React from "react";
 
 import AuthWall from "../auth/AuthWall";
+import useAdminUser from "../hooks/useAdminUser";
 import WeeklySnapshotPage from "../page-weekly-snapshot";
 import { NYTDataProvider } from "../page-weekly-snapshot/NYTDataProvider";
 import PageInfo from "../site-metadata/PageInfo";
 
 // eslint-disable-next-line react/display-name
-export default () => (
-  <>
-    <PageInfo title="Generate State-level Weekly Snapshot" />
-    <AuthWall>
-      <NYTDataProvider>
-        <WeeklySnapshotPage />
-      </NYTDataProvider>
-    </AuthWall>
-  </>
-);
+export default () => {
+  const isAdminUser: boolean = useAdminUser();
+
+  return (
+    <>
+      {isAdminUser ? (
+        <>
+          <PageInfo title="Generate State-level Weekly Snapshot" />
+          <AuthWall>
+            <NYTDataProvider>
+              <WeeklySnapshotPage />
+            </NYTDataProvider>
+          </AuthWall>
+        </>
+      ) : (
+        <div>This page is only available for admin users</div>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## Description of the change

This adds an admin page at `/weekly-snapshot` which loads the states and counties CSV data from the NYT github repo and displays stats for the states and counties. The "***" feature which puts those stars next to counties that have a facility in or near the county is blocked by the facility metadata workstream so is skipped for now:

![image](https://user-images.githubusercontent.com/5402804/84405808-82368080-abbd-11ea-999c-c3327bda9d1e.png)

@macfarlandian I used the `useAdminUser` hook at the `pages/weekly-snapshot.tsx` level, but let me know if we want to use it to whitelist users for this page at a different level. 
 
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #531 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
