### PR TITLE
Conditionally hide age vs unkonwn age input

### DIFF
--- a/src/design-system/TextLabel.tsx
+++ b/src/design-system/TextLabel.tsx
@@ -5,6 +5,7 @@ import Colors from "./Colors";
 interface TextLabelProps {
   softened?: boolean;
   padding?: boolean;
+  margin?: boolean;
 }
 
 const TextLabel = styled.span<TextLabelProps>((props: TextLabelProps) => {
@@ -16,11 +17,13 @@ const TextLabel = styled.span<TextLabelProps>((props: TextLabelProps) => {
   ${props.softened ? "" : "letter-spacing: 2px;"}
   color: ${Colors.darkForest};
   ${props.padding ? "padding-right: 5px;" : ""}
+  ${props.margin ? "margin-bottom: 15px;" : ""}
 `;
 });
 
 TextLabel.defaultProps = {
   padding: true,
+  margin: false,
 };
 
 export default TextLabel;

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -65,6 +65,41 @@ const FormHeaderRow: React.FC<FormHeaderRowProps> = (props) => (
   </LabelRow>
 );
 
+const passedAgesKnown = (model: Record<string, any> | undefined) => {
+  if (model !== undefined) {
+    let keys = Object.keys(model);
+    return keys.some(function (key) {
+      return RegExp(/age\d+/).test(key);
+    });
+  } else {
+    return true;
+  }
+};
+
+const passedAgesUnknown = (model: Record<string, any> | undefined) => {
+  if (model !== undefined) {
+    let keys = Object.keys(model);
+    return keys.some(function (key) {
+      return RegExp(/ageUnknown\w+/).test(key);
+    });
+  } else {
+    return true;
+  }
+};
+
+const collapseAgeInputs = (model: Record<string, any> | undefined) => {
+  if (passedAgesKnown(model)) {
+    return false;
+  } else if (
+    passedAgesKnown(model) === false &&
+    passedAgesUnknown(model) === true
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 interface AgeGroupGridProps {
   model: Partial<EpidemicModelState>;
   updateModel: (update: EpidemicModelUpdate) => void;
@@ -76,41 +111,6 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
   ...props
 }) => {
   const [collapsed, setCollapsed] = useState(collapsible);
-
-  const passedAgesKnown = (model: Record<string, any> | undefined) => {
-    if (model !== undefined) {
-      let keys = Object.keys(model);
-      return keys.some(function (key) {
-        return RegExp(/age\d+/).test(key);
-      });
-    } else {
-      return true;
-    }
-  };
-
-  const passedAgesUnknown = (model: Record<string, any> | undefined) => {
-    if (model !== undefined) {
-      let keys = Object.keys(model);
-      return keys.some(function (key) {
-        return RegExp(/ageUnknown\w+/).test(key);
-      });
-    } else {
-      return true;
-    }
-  };
-
-  const collapseAgeInputs = (model: Record<string, any> | undefined) => {
-    if (passedAgesKnown(model)) {
-      return false;
-    } else if (
-      passedAgesKnown(model) === false &&
-      passedAgesUnknown(model) === true
-    ) {
-      return true;
-    } else {
-      return false;
-    }
-  };
 
   useEffect(() => {
     setCollapsed(collapseAgeInputs(props.model));

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -114,7 +114,7 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
 
   useEffect(() => {
     setCollapsed(collapseAgeInputs(props.model));
-  }, []);
+  }, [props.model]);
 
   const ageSpecificCaseCounts = (
     <>

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -1,5 +1,5 @@
 import numeral from "numeral";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import InputTextNumeric from "../design-system/InputTextNumeric";
@@ -20,10 +20,6 @@ const FacilityInformationDiv = styled.div``;
 
 const LabelRow = styled(FormGridRow)`
   margin-bottom: 0;
-`;
-
-const CollapseIcon = styled.span`
-  font-size: xx-small;
 `;
 
 const LabelCell: React.FC = (props) => (
@@ -80,46 +76,86 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
   ...props
 }) => {
   const [collapsed, setCollapsed] = useState(collapsible);
+
+  const passedAgesKnown = (model: Record<string, any> | undefined) => {
+    if (model !== undefined) {
+      let keys = Object.keys(model);
+      return keys.some(function (key) {
+        return RegExp(/age\d+/).test(key);
+      });
+    } else {
+      return true;
+    }
+  };
+
+  const passedAgesUnknown = (model: Record<string, any> | undefined) => {
+    if (model !== undefined) {
+      let keys = Object.keys(model);
+      return keys.some(function (key) {
+        return RegExp(/ageUnknown\w+/).test(key);
+      });
+    } else {
+      return true;
+    }
+  };
+
+  const collapseAgeInputs = (model: Record<string, any> | undefined) => {
+    if (passedAgesKnown(model)) {
+      return false;
+    } else if (
+      passedAgesKnown(model) === false &&
+      passedAgesUnknown(model) === true
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  useEffect(() => {
+    setCollapsed(collapseAgeInputs(props.model));
+  }, []);
+
   const ageSpecificCaseCounts = (
     <>
       <AgeGroupRow
-        label="Ages 0-19"
+        label="Residents Ages 0-19"
         leftKey="age0Cases"
         rightKey="age0Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 20-44"
+        label="Residents Ages 20-44"
         leftKey="age20Cases"
         rightKey="age20Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 45-54"
+        label="Residents Ages 45-54"
         leftKey="age45Cases"
         rightKey="age45Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 55-64"
+        label="Residents Ages 55-64"
         leftKey="age55Cases"
         rightKey="age55Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 65-74"
+        label="Residents Ages 65-74"
         leftKey="age65Cases"
         rightKey="age65Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 75-84"
+        label="Residents Ages 75-84"
         leftKey="age75Cases"
         rightKey="age75Population"
         {...props}
       />
       <AgeGroupRow
-        label="Ages 85+"
+        label="Residents Ages 85+"
         leftKey="age85Cases"
         rightKey="age85Population"
         {...props}
@@ -139,24 +175,37 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
       {/* empty row for spacing */}
       <FormGridRow />
       <FormHeaderRow label="Total Population" />
-      <AgeGroupRow
-        label="Resident population (ages unknown)"
-        leftKey="ageUnknownCases"
-        rightKey="ageUnknownPopulation"
-        {...props}
-      />
       {collapsed ? (
-        <div
-          className="flex flex-row justify-center mt-8 cursor-pointer"
-          onClick={() => {
-            setCollapsed(false);
-          }}
-        >
-          <TextLabel>Add residents and cases by age</TextLabel>
-          <CollapseIcon>▾</CollapseIcon>
+        <div>
+          <AgeGroupRow
+            label="Resident population (ages unknown)"
+            leftKey="ageUnknownCases"
+            rightKey="ageUnknownPopulation"
+            {...props}
+          />
+          <div
+            className="flex flex-row justify-center mt-8 cursor-pointer"
+            onClick={() => {
+              setCollapsed(false);
+            }}
+          >
+            <TextLabel margin={true}>Add residents and cases by age</TextLabel>
+          </div>
         </div>
       ) : (
-        ageSpecificCaseCounts
+        <div>
+          {ageSpecificCaseCounts}
+          <div
+            className="flex flex-row justify-center mt-8 cursor-pointer"
+            onClick={() => {
+              setCollapsed(true);
+            }}
+          >
+            <TextLabel margin={true}>
+              Add residents and cases without ages
+            </TextLabel>
+          </div>
+        </div>
       )}
     </FormGrid>
   );


### PR DESCRIPTION
## Description of the change
Conditionally hides input boxes for age vs unknown age cases and population in AddCases modal and Facility Details page.

Giph from multi-facility view:
![multi-view](https://user-images.githubusercontent.com/8259050/84533607-18e26a80-acae-11ea-9a75-223019d639f2.gif)

Giph from Facility Details view:
![single-view](https://user-images.githubusercontent.com/8259050/84533610-1b44c480-acae-11ea-9830-9cc1b082ec51.gif)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes [#543 ]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
