### PR TITLE
Merlin UI polish: Prevent y-axis from having dupe ticks

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -35,7 +35,10 @@ const TooltipDatum = styled.li`
   opacity: 0.8;
 `;
 
-const formatThousands = format(",.0f");
+// Note:
+// if tick value = 1,001.00, displays 1001
+// if tick value = 2.5, displays 2.5
+const formatThousands = format(",~g");
 
 interface TooltipProps {
   countTotal: number;


### PR DESCRIPTION
## Description of the change

Bug fix: If generated tick values = 2 and 2.5, ticks now display as 2 and 2.5, instead of previous duplicated 2 and 2

//

WAS (When the y-axis max = 3, the ticks were duplicating e.g. y-axis ticks were: 1, 1, 2, 2, 3, 3):
![image](https://user-images.githubusercontent.com/1372946/84616590-521f0400-ae81-11ea-9276-2cbc0e365040.png)

IS:
![image](https://user-images.githubusercontent.com/1372946/84728428-11d58980-af46-11ea-86ea-38a260b72de4.png)

![image](https://user-images.githubusercontent.com/1372946/84728360-e6eb3580-af45-11ea-8854-e5b844383db7.png)

~~👉 Question for @macfarlandian (saw you did a lot of the graph code) or others if you have time lmk here or Slack!~~ 

~~I'm not sure if there is a better way to do this e.g. if y-axis max <= 6, use different `timeFormat` in CurveChart. But I don't see a way to access that in https://github.com/Recidiviz/covid19-dashboard/blob/master/src/rt-timeseries/RtTimeseries.tsx e.g. no max on the yExtent. Any ideas?~~ 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes https://github.com/Recidiviz/covid19-dashboard/issues/372, is last issue in [Google doc](https://docs.google.com/document/d/15oREP0hXoQSnzL-mMp3fTYRLyomyhskLD38-l2t1v_E/edit) 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
