### PR TITLE
Revert "#372 chart tooltip: replace People with Inmates & Staff (#564)"

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -38,9 +38,7 @@ const TooltipDatum = styled.li`
 const formatThousands = format(",.0f");
 
 interface TooltipProps {
-  countTotal: number;
-  countIncarcerated: number;
-  countStaff: number;
+  count: number;
   days: number;
   parentLine: {
     title: string;
@@ -50,8 +48,7 @@ interface TooltipProps {
 }
 
 const Tooltip: React.FC<TooltipProps> = ({
-  countIncarcerated,
-  countStaff,
+  count,
   days,
   parentLine: { title },
 }) => {
@@ -64,10 +61,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         <TooltipDatum>
           <DateMMMMdyyyy date={displayDate} />
         </TooltipDatum>
-        <TooltipDatum>
-          Incarcerated: {formatThousands(countIncarcerated)}
-        </TooltipDatum>
-        <TooltipDatum>Staff: {formatThousands(countStaff)}</TooltipDatum>
+        <TooltipDatum>People: {formatThousands(count)}</TooltipDatum>
       </TooltipDatalist>
     </ChartTooltip>
   );
@@ -125,16 +119,14 @@ const CurveChart: React.FC<CurveChartProps> = ({
       title: bucket,
       key: bucket,
       coordinates: values.map((count, index) => ({
-        countTotal: count.total,
-        countIncarcerated: count.incarcerated,
-        countStaff: count.staff,
+        count,
         days: index,
       })),
     })),
     renderKey: (d, i) => d.key || i,
     lineType: { type: "area", interpolator: curveCatmullRom },
     xAccessor: "days",
-    yAccessor: "countTotal",
+    yAccessor: "count",
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -57,13 +57,7 @@ function combinePopulations(data: CurveData, columnIndex: number) {
   return zip(
     getAllValues(getColView(data.incarcerated, columnIndex)),
     getAllValues(getColView(data.staff, columnIndex)),
-  ).map(([incarcerated, staff]) => {
-    return {
-      total: incarcerated + staff,
-      incarcerated,
-      staff,
-    };
-  });
+  ).map(([incarcerated, staff]) => incarcerated + staff);
 }
 
 type CurveDataMapping = {


### PR DESCRIPTION
## Description of the change

This reverts commit b898ee712f5351e41193a088c133811508236ea1 re: https://recidiviz.slack.com/archives/G010VACT8F2/p1592340694050400

I need to dig into the error separately, but this would make master clean

![image](https://user-images.githubusercontent.com/1372946/84830755-ec488e80-afde-11ea-8f69-e79de0dbc9ce.png)

IS: graphs appear on /impact
![image](https://user-images.githubusercontent.com/1372946/84830188-de463e00-afdd-11ea-8347-671bb91a0a46.png)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes broken seen on master 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
