### PR TITLE
always fetch model versions along with facility

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -777,8 +777,19 @@ export const saveFacility = async (
       batch.set(newModelVersionDoc, facility.modelInputs);
     }
     await batch.commit();
-    const savedFacilityDoc = await facilityDoc.get();
-    return buildFacility(scenarioId, savedFacilityDoc);
+
+    // construct and return a Facility object with newly saved data
+    const [savedFacilityDoc, savedFacilityModelVersions] = await Promise.all([
+      facilityDoc.get(),
+      getFacilityModelVersions({
+        facilityId: facilityDoc.id,
+        scenarioId: scenarioId,
+        distinctByObservedAt: true,
+      }),
+    ]);
+    const savedFacility = buildFacility(scenarioId, savedFacilityDoc);
+    savedFacility.modelVersions = savedFacilityModelVersions;
+    return savedFacility;
   } catch (error) {
     console.error("Encountered error while attempting to save a facility:");
     console.error(error);

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -307,7 +307,7 @@ export const saveScenario = async (scenario: any): Promise<Scenario | null> => {
   }
 };
 
-export const getFacilityModelVersions = async ({
+const getFacilityModelVersions = async ({
   facilityId,
   scenarioId,
   distinctByObservedAt = false,

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -769,12 +769,12 @@ export const saveFacility = async (
 
     // If the facility's model inputs have been provided, store a new
     // versioned copy of those inputs.
-    if (facility.modelInputs) {
+    if (modelInputsToSave) {
       const newModelVersionDoc = facilityDoc
         .collection(modelVersionCollectionId)
         .doc();
 
-      batch.set(newModelVersionDoc, facility.modelInputs);
+      batch.set(newModelVersionDoc, modelInputsToSave);
     }
     await batch.commit();
 

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -56,22 +56,15 @@ export const buildModelInputs = (document: any): ModelInputs => {
 export const buildFacility = (
   scenarioId: string,
   document: firebase.firestore.DocumentData,
+  modelVersions?: ModelInputs[],
 ): Facility => {
   const documentData = document.data();
 
-  let {
-    createdAt,
-    updatedAt,
-    modelInputs,
-    name,
-    description,
-    systemType,
-  } = documentData;
+  let { name, description, systemType } = documentData;
   const id = document.id;
-  createdAt = timestampToDate(documentData.createdAt);
-  updatedAt = timestampToDate(documentData.updatedAt);
-  modelInputs = buildModelInputs(documentData.modelInputs);
-  const modelVersions: ModelInputs[] = [];
+  const createdAt = timestampToDate(documentData.createdAt);
+  const updatedAt = timestampToDate(documentData.updatedAt);
+  const modelInputs = buildModelInputs(documentData.modelInputs);
 
   return {
     createdAt,
@@ -82,7 +75,7 @@ export const buildFacility = (
     scenarioId,
     systemType,
     updatedAt,
-    modelVersions,
+    modelVersions: modelVersions || [],
   };
 };
 

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -6,11 +6,13 @@ import { PlannedRelease } from "../impact-dashboard/EpidemicModelContext";
 import {
   Facility,
   ModelInputs,
+  PERSISTED_FACILITY_KEYS,
   ReferenceFacility,
   ReferenceFacilityCovidCase,
   Scenario,
   User,
 } from "../page-multi-facility/types";
+import { FacilityDocUpdate } from "./types";
 
 const timestampToDate = (timestamp: firebase.firestore.Timestamp): Date => {
   return timestamp.toDate();
@@ -57,14 +59,37 @@ export const buildFacility = (
 ): Facility => {
   const documentData = document.data();
 
-  let facility: Facility = documentData;
-  facility.id = document.id;
-  facility.scenarioId = scenarioId;
-  facility.createdAt = timestampToDate(documentData.createdAt);
-  facility.updatedAt = timestampToDate(documentData.updatedAt);
-  facility.modelInputs = buildModelInputs(documentData.modelInputs);
+  let {
+    createdAt,
+    updatedAt,
+    modelInputs,
+    name,
+    description,
+    systemType,
+  } = documentData;
+  const id = document.id;
+  createdAt = timestampToDate(documentData.createdAt);
+  updatedAt = timestampToDate(documentData.updatedAt);
+  modelInputs = buildModelInputs(documentData.modelInputs);
+  const modelVersions: ModelInputs[] = [];
 
-  return facility;
+  return {
+    createdAt,
+    description,
+    id,
+    modelInputs,
+    name,
+    scenarioId,
+    systemType,
+    updatedAt,
+    modelVersions,
+  };
+};
+
+export const buildFacilityDocUpdate = (
+  facility: Partial<Facility>,
+): FacilityDocUpdate => {
+  return pick(facility, PERSISTED_FACILITY_KEYS);
 };
 
 export const buildScenario = (

--- a/src/database/types.tsx
+++ b/src/database/types.tsx
@@ -1,0 +1,24 @@
+import * as firebase from "firebase/app";
+import { Overwrite } from "utility-types";
+
+import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
+import { PersistedFacility } from "../page-multi-facility/types";
+
+type ServerDate = Date | firebase.firestore.FieldValue;
+
+export type ModelInputsUpdate = Overwrite<
+  EpidemicModelPersistent,
+  {
+    observedAt: Date;
+    updatedAt?: ServerDate;
+  }
+>;
+
+export type FacilityDocUpdate = Overwrite<
+  Partial<PersistedFacility>,
+  {
+    createdAt?: ServerDate;
+    updatedAt?: ServerDate;
+    modelInputs?: ModelInputsUpdate;
+  }
+>;

--- a/src/hooks/useFacilityModelVersions.tsx
+++ b/src/hooks/useFacilityModelVersions.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { getFacilityModelVersions } from "../database";
 import { Facility, ModelInputs } from "../page-multi-facility/types";
 import useError from "./useError";
 
@@ -14,11 +13,7 @@ const useFacilityModelVersions = (facility: Facility | undefined) => {
   const updateModelVersions = useCallback(async () => {
     if (!facility) return;
     try {
-      const modelVersions = await getFacilityModelVersions({
-        facilityId: facility.id,
-        scenarioId: facility.scenarioId,
-        distinctByObservedAt: true,
-      });
+      const { modelVersions } = facility;
       setFacilityModelVersions(modelVersions);
     } catch (e) {
       rethrowSync(e);

--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -8,7 +8,6 @@ import {
 import { has, mapValues, maxBy, minBy, pick } from "lodash";
 
 import { RateOfSpreadType } from "../constants/EpidemicModel";
-import { getFacilityModelVersions } from "../database";
 import { totalConfirmedCases } from "../impact-dashboard/EpidemicModelContext";
 import {
   Facilities,
@@ -90,19 +89,11 @@ export async function fetchRt(requestData: RtInputs): Promise<RawRtData> {
   return responseData;
 }
 
-const getRtInputsForFacility = async (
-  facility: Facility,
-): Promise<RtInputs> => {
-  let modelVersions = await getFacilityModelVersions({
-    scenarioId: facility.scenarioId,
-    facilityId: facility.id,
-    distinctByObservedAt: true,
-  });
-
+const getRtInputsForFacility = (facility: Facility): RtInputs => {
   const cases: number[] = [];
   const dates: string[] = [];
 
-  modelVersions.forEach((model) => {
+  facility.modelVersions.forEach((model) => {
     const seconds = model.observedAt.getTime() / 1000;
 
     dates.push(
@@ -133,7 +124,7 @@ export const getRtDataForFacility = async (
   facility: Facility,
 ): Promise<RtValue> => {
   try {
-    const { cases, dates } = await getRtInputsForFacility(facility);
+    const { cases, dates } = getRtInputsForFacility(facility);
     const fetchedData = await fetchRt({ dates, cases });
     return cleanRtData(fetchedData);
   } catch (error) {

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -4,22 +4,37 @@ import { RtData, RtError } from "../infection-model/rt";
 
 export interface ModelInputs extends EpidemicModelPersistent {
   observedAt: Date;
-  updatedAt: Date;
+  updatedAt?: Date;
 }
 
 export type FacilityReferenceMapping = {
   [key in Facility["id"]]: ReferenceFacility["id"];
 };
 
-export type Facility = {
-  id: string;
-  scenarioId: string;
+export interface PersistedFacility {
   name: string;
   description?: string | null;
   systemType?: string | null;
   modelInputs: ModelInputs;
   createdAt: Date;
   updatedAt: Date;
+}
+// only the keys enumerated here should be saved to the database
+export const PERSISTED_FACILITY_KEYS: (keyof PersistedFacility)[] = [
+  "name",
+  "description",
+  "systemType",
+  "modelInputs",
+  "createdAt",
+  "updatedAt",
+];
+
+export type Facility = PersistedFacility & {
+  id: string;
+  scenarioId: string;
+  modelVersions: ModelInputs[];
+  canonicalName?: string;
+  [key: string]: unknown;
 };
 
 export type Facilities = Facility[];

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -33,8 +33,6 @@ export type Facility = PersistedFacility & {
   id: string;
   scenarioId: string;
   modelVersions: ModelInputs[];
-  canonicalName?: string;
-  [key: string]: unknown;
 };
 
 export type Facilities = Facility[];

--- a/src/page-response-impact/responseChartData.tsx
+++ b/src/page-response-impact/responseChartData.tsx
@@ -82,6 +82,7 @@ export const originalProjection = (systemWideData: SystemWideData) => {
       updatedAt: new Date(),
       systemType: "State Prison",
       modelInputs: originalEpidemicModelInputs(systemWideData),
+      modelVersions: [],
     },
   ] as Facilities;
 };


### PR DESCRIPTION
## Description of the change

Makes `modelVersions` a property of the `Facility` type (mirroring the database structure) and updates our database functions to always fetch model input versions alongside facility documents, and to be slightly more rigorous with type definitions when assembling and saving facilities.

In practice we will never not want this data when we are fetching facilities from the database. By storing it in the FacilitiesContext we can avoid redundant fetches from the different components that use R(t) data.

In addition to cleaning up our facility state management some more, this is important table-setting for combining user data with reference data; those merges will go much more smoothly if all this user data is already available when we are ready to join it with reference data. I have broken this out as a separate PR first for easier reviewing.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #521.

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
