### PR TITLE
Update default information for "Add Historical Data" Modal

### DIFF
--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -18,26 +18,24 @@ export const getBracketData = (modelInputs: ModelInputs) => {
 };
 
 function findMostRecentDate(
-  defaultDate: Date,
+  currentDate: Date,
   facilityModelVersions: ModelInputs[] | undefined,
 ) {
-  let mostRecentDate = defaultDate;
+  let mostRecentDate = currentDate;
   if (facilityModelVersions) {
     // create array of dates with observed data at a given facility
-    let facilityDatesObservedAt = facilityModelVersions.map(
+    const facilityDatesObservedAt = facilityModelVersions.map(
       (observedAt) => observedAt.observedAt,
     );
     if (facilityDatesObservedAt.length > 0) {
-      // filter to dates earlier than (or the same as) the observed date
-      let earlierDates = facilityDatesObservedAt.filter(function (d) {
-        return d.valueOf() <= defaultDate.valueOf();
+      // filter to dates earlier than the current date
+      const earlierDates = facilityDatesObservedAt.filter(function (d) {
+        return d.valueOf() <= currentDate.valueOf();
       });
-      // if there is data for a prior date, use it
+      // if there is data for a prior date, use it, otherwise use the current date
       if (earlierDates.length > 0) {
         mostRecentDate = earlierDates[earlierDates.length - 1];
-      }
-      // there is no data for a prior date, so use the observed date
-      else {
+      } else {
         mostRecentDate = facilityDatesObservedAt[0];
       }
     }
@@ -85,9 +83,12 @@ const useAddCasesInputs = (
   >();
   // whenever observation date changes we should look for a new model version
   useEffect(() => {
-    const newDate = findMostRecentDate(observationDate, facilityModelVersions);
+    const mostRecentDate = findMostRecentDate(
+      observationDate,
+      facilityModelVersions,
+    );
     const newObservedAtVersion = findMatchingDay({
-      date: newDate,
+      date: mostRecentDate,
       facilityModelVersions,
     });
 
@@ -158,7 +159,6 @@ const useAddCasesInputs = (
 
           onSave(latestFacilityData);
           updateModelVersions();
-          //setObservationDate(defaultObservationDate);
           addToast("Data successfully saved!");
         }),
     );

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -1,4 +1,4 @@
-import { isToday, startOfDay } from "date-fns";
+import { startOfDay } from "date-fns";
 import { pick } from "lodash";
 import { useEffect, useState } from "react";
 
@@ -32,7 +32,7 @@ function findMostRecentDate(
       return startOfDay(date) <= startOfDay(observedAtDate);
     });
     // if there is data for prior dates, use the most recent one, otherwise use the current date
-    if (earlierDates?.length > 0) {
+    if (earlierDates && earlierDates.length > 0) {
       mostRecentDate = earlierDates[earlierDates.length - 1];
     } else {
       mostRecentDate = facilityObservedAtDates[0];

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -27,12 +27,12 @@ function findMostRecentDate(
     const facilityObservedAtDates = facilityModelVersions.map(
       (facility) => facility.observedAt,
     );
-    // filter to dates earlier than the current date
+    // filter to dates earlier than (or the same as) the current date
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
-      return startOfDay(date) < startOfDay(observedAtDate);
+      return startOfDay(date) <= startOfDay(observedAtDate);
     });
     // if there is data for prior dates, use the most recent one, otherwise use the current date
-    if (earlierDates.length > 0) {
+    if (earlierDates?.length > 0) {
       mostRecentDate = earlierDates[earlierDates.length - 1];
     } else {
       mostRecentDate = facilityObservedAtDates[0];

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -17,6 +17,38 @@ export const getBracketData = (modelInputs: ModelInputs) => {
   return pick(modelInputs, populationBracketKeys);
 };
 
+function findMostRecentDate(
+  defaultDate: Date,
+  facilityModelVersions: ModelInputs[] | undefined,
+) {
+  let mostRecentDate = defaultDate;
+  if (facilityModelVersions) {
+    console.log("facilittyModelVersions", facilityModelVersions);
+    let facilityDatesObservedAt = facilityModelVersions.map(
+      (observedAt) => observedAt.observedAt,
+    );
+    console.log(
+      "default Date",
+      defaultDate,
+      "dates observed",
+      facilityDatesObservedAt,
+    );
+    if (facilityDatesObservedAt.length > 0) {
+      let earlierDates = facilityDatesObservedAt.filter(function (d) {
+        console.log("d", d);
+        // TODO: why isn't june 17 earlier than june 18?
+        // console.log(d.toDateString(), defaultDate.toDateString());
+        return d.toDateString() <= defaultDate.toDateString();
+      });
+      console.log("earlier dates", earlierDates);
+      if (earlierDates.length > 0)
+        mostRecentDate = earlierDates[earlierDates.length - 1];
+    }
+  }
+  console.log(mostRecentDate);
+  return mostRecentDate;
+}
+
 const findMatchingDay = ({
   date,
   facilityModelVersions,
@@ -57,13 +89,17 @@ const useAddCasesInputs = (
   >();
   // whenever observation date changes we should look for a new model version
   useEffect(() => {
+    const newDate = findMostRecentDate(observationDate, facilityModelVersions);
     const newObservedAtVersion = findMatchingDay({
-      date: observationDate,
+      date: newDate,
       facilityModelVersions,
     });
 
+    // setObservedAtVersion(newObservedAtVersion);
+
     if (newObservedAtVersion) {
       setObservedAtVersion(newObservedAtVersion);
+      console.log(newObservedAtVersion);
     } else {
       setObservedAtVersion(defaultInputs);
     }

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -18,28 +18,24 @@ export const getBracketData = (modelInputs: ModelInputs) => {
 };
 
 function findMostRecentDate(
-  currentDate: Date,
+  observedAtDate: Date,
   facilityModelVersions: ModelInputs[] | undefined,
 ) {
-  let mostRecentDate = currentDate;
+  let mostRecentDate = observedAtDate;
   if (facilityModelVersions) {
     // create array of dates with observed data at a given facility
-    const facilityDatesObservedAt = facilityModelVersions.map(
+    const facilityObservedAtDates = facilityModelVersions.map(
       (facility) => facility.observedAt,
     );
     // filter to dates earlier than the current date
-    const earlierDates = facilityDatesObservedAt?.filter(function (date) {
-      return startOfDay(date) < startOfDay(currentDate);
+    const earlierDates = facilityObservedAtDates?.filter(function (date) {
+      return startOfDay(date) < startOfDay(observedAtDate);
     });
-    // if there is data for a prior date, use it, otherwise use the current date
+    // if there is data for prior dates, use the most recent one, otherwise use the current date
     if (earlierDates.length > 0) {
       mostRecentDate = earlierDates[earlierDates.length - 1];
-      // handles edge case where most recent date is today, but no data has been saved for today
-      if (isToday(mostRecentDate) === true && earlierDates.length > 1) {
-        mostRecentDate = earlierDates[earlierDates.length - 2];
-      }
     } else {
-      mostRecentDate = facilityDatesObservedAt[0];
+      mostRecentDate = facilityObservedAtDates[0];
     }
   }
   return mostRecentDate;

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -31,10 +31,11 @@ function findMostRecentDate(
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
       return startOfDay(date) <= startOfDay(observedAtDate);
     });
-    // if there is data for prior dates, use the most recent one, otherwise use the current date
+    // if there is data for prior dates, use the most recent one, otherwise use
+    // the next forward-looking date that we have for the facility
     if (earlierDates && earlierDates.length > 0) {
       mostRecentDate = earlierDates[earlierDates.length - 1];
-    } else {
+    } else if (facilityObservedAtDates) {
       mostRecentDate = facilityObservedAtDates[0];
     }
   }

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -23,29 +23,25 @@ function findMostRecentDate(
 ) {
   let mostRecentDate = defaultDate;
   if (facilityModelVersions) {
-    console.log("facilittyModelVersions", facilityModelVersions);
+    // create array of dates with observed data at a given facility
     let facilityDatesObservedAt = facilityModelVersions.map(
       (observedAt) => observedAt.observedAt,
     );
-    console.log(
-      "default Date",
-      defaultDate,
-      "dates observed",
-      facilityDatesObservedAt,
-    );
     if (facilityDatesObservedAt.length > 0) {
+      // filter to dates earlier than (or the same as) the observed date
       let earlierDates = facilityDatesObservedAt.filter(function (d) {
-        console.log("d", d);
-        // TODO: why isn't june 17 earlier than june 18?
-        // console.log(d.toDateString(), defaultDate.toDateString());
-        return d.toDateString() <= defaultDate.toDateString();
+        return d.valueOf() <= defaultDate.valueOf();
       });
-      console.log("earlier dates", earlierDates);
-      if (earlierDates.length > 0)
+      // if there is data for a prior date, use it
+      if (earlierDates.length > 0) {
         mostRecentDate = earlierDates[earlierDates.length - 1];
+      }
+      // there is no data for a prior date, so use the observed date
+      else {
+        mostRecentDate = facilityDatesObservedAt[0];
+      }
     }
   }
-  console.log(mostRecentDate);
   return mostRecentDate;
 }
 
@@ -95,11 +91,8 @@ const useAddCasesInputs = (
       facilityModelVersions,
     });
 
-    // setObservedAtVersion(newObservedAtVersion);
-
     if (newObservedAtVersion) {
       setObservedAtVersion(newObservedAtVersion);
-      console.log(newObservedAtVersion);
     } else {
       setObservedAtVersion(defaultInputs);
     }
@@ -165,6 +158,7 @@ const useAddCasesInputs = (
 
           onSave(latestFacilityData);
           updateModelVersions();
+          //setObservationDate(defaultObservationDate);
           addToast("Data successfully saved!");
         }),
     );


### PR DESCRIPTION
## Update default information for "Add Historical Data" Modal

> Add existing data to "add historical data" modal inputs depending on if backward-or forward-looking information already exists for the selected date. The specific behavior is detailed in the corresponding issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #523

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

Testing with scenario in #523:
 
Adding old data from 5/31:
<img width="546" alt="adding old data" src="https://user-images.githubusercontent.com/29155017/85085703-3330b280-b19e-11ea-95fd-e953b160e998.png">

Adding new data from 6/4:
<img width="539" alt="adding new data" src="https://user-images.githubusercontent.com/29155017/85085714-3b88ed80-b19e-11ea-97e1-12e57bf3ad7c.png">

Adding to facility without existing data:
<img width="547" alt="no data" src="https://user-images.githubusercontent.com/29155017/85085726-46438280-b19e-11ea-8304-a46c7c499505.png">


### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
