### PR TITLE
Update the Data Model to Support Determining Whether or not a Referen…

### DIFF
--- a/backend/python-functions/data_ingest.py
+++ b/backend/python-functions/data_ingest.py
@@ -136,7 +136,7 @@ def persist(facilities):
             # For new reference facility documents, set a createdAt timestamp.  This allows
             # us to know which reference facilities are "new" from the perspective of a given
             # user.
-            if (not existing_reference_facility):
+            if not existing_reference_facility:
                 facility['createdAt'] = firestore.SERVER_TIMESTAMP
 
             # Remove the Covid case data so that it can be stored separately in its own


### PR DESCRIPTION
…ce Facility is "New"

## Description of the change

- When importing reference facilities from our CSV data source we will need to set a `createdAt` timestamp on each new facility.  This will allow us to know which reference facilities are "new" from the perspective of any given user.  This "newness" determination will be made by comparing a timestamp that the user last observed the reference facility sync modal and this new `createdAt` field.  If the `createdAt` field is greater than the time the user last observed the sync config modal, we know that the reference facility is "new" to that user.  This will be important in driving certain user-facing features.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #604 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
