### PR TITLE
Prevent duplicate/conflicting age data on case entry

### DIFF
--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -1,9 +1,11 @@
+import { isUndefined, omitBy, pickBy } from "lodash";
 import numeral from "numeral";
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import InputTextNumeric from "../design-system/InputTextNumeric";
 import TextLabel from "../design-system/TextLabel";
+import { useToasts } from "../design-system/Toast";
 import {
   curveInputsFromUserInputs,
   getAdjustedTotalPopulation,
@@ -87,10 +89,35 @@ const pastAgesUnknown = (model: Record<string, any> | undefined) => {
   }
 };
 
+const includesKnownAges = (model: object) => {
+  let definedInputs = omitBy(model, isUndefined);
+  let ageKnownInputs = pickBy(definedInputs, (_, key) => {
+    return RegExp(/age\d+/).test(key);
+  });
+  let total = Object.values(ageKnownInputs).reduce((sum, n) => {
+    return sum + n;
+  }, 0);
+  return total > 0;
+};
+
+const includesUnknownAges = (model: object) => {
+  let definedInputs = omitBy(model, isUndefined);
+  let ageUnknownInputs = pickBy(definedInputs, (_, key) => {
+    return RegExp(/ageUnknown\w+/).test(key);
+  });
+  let array = Object.values(ageUnknownInputs);
+  let total = array.reduce((sum, n) => {
+    return sum + n;
+  }, 0);
+  return total > 0;
+};
+
 interface AgeGroupGridProps {
   model: Partial<EpidemicModelState>;
   updateModel: (update: EpidemicModelUpdate) => void;
   collapsible?: boolean;
+  warnedAt: number;
+  setWarnedAt: (warnedAt: number) => void;
 }
 
 export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
@@ -114,6 +141,8 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
 
   useEffect(() => {
     setCollapsed(collapseAgeInputs());
+    // only want to run this once, on initial mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const ageSpecificCaseCounts = (
@@ -217,11 +246,14 @@ interface AgeGroupRowProps {
   rightKey: keyof EpidemicModelUpdate;
   model: Partial<EpidemicModelState>;
   updateModel: (update: EpidemicModelUpdate) => void;
+  warnedAt: number;
+  setWarnedAt: (warnedAt: number) => void;
 }
 
 const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
   const { model, updateModel } = props;
   const [inputRelativityError, setInputRelativityError] = useState(false);
+  const { addToast } = useToasts();
 
   function checkInputRelativity(
     cases: number | undefined,
@@ -238,6 +270,18 @@ const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
     }
   }
 
+  const checkAgeConflict = (model: object) => {
+    if (Date.now() > props.warnedAt + 10000) {
+      if (includesUnknownAges(model) && includesKnownAges(model)) {
+        addToast(
+          "To prevent duplicate counting, known and unknown ages cannot be entered together. Please clear either the unknown age input or all age inputs.",
+          { appearance: "error" },
+        );
+        props.setWarnedAt(Date.now());
+      }
+    }
+  };
+
   return (
     <FormGridRow>
       <LabelCell>
@@ -251,6 +295,7 @@ const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
           onValueChange={(value) => {
             checkInputRelativity(value, model[props.rightKey] as number);
             updateModel({ [props.leftKey]: value });
+            checkAgeConflict(model);
           }}
         />
       </InputCell>
@@ -261,6 +306,7 @@ const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
           onValueChange={(value) => {
             checkInputRelativity(model[props.leftKey] as number, value);
             updateModel({ [props.rightKey]: value });
+            checkAgeConflict(model);
           }}
         />
       </InputCell>
@@ -270,11 +316,17 @@ const AgeGroupRow: React.FC<AgeGroupRowProps> = (props) => {
 
 const FacilityInformation: React.FC = () => {
   const [model, updateModel] = useModel();
+  const [warnedAt, setWarnedAt] = useState(0);
 
   return (
     <FacilityInformationDiv>
       <div>
-        <AgeGroupGrid model={model} updateModel={updateModel} />
+        <AgeGroupGrid
+          model={model}
+          updateModel={updateModel}
+          warnedAt={warnedAt}
+          setWarnedAt={setWarnedAt}
+        />
         <FormGrid>
           <FormRow
             inputs={[

--- a/src/impact-dashboard/FacilityInformation.tsx
+++ b/src/impact-dashboard/FacilityInformation.tsx
@@ -65,7 +65,7 @@ const FormHeaderRow: React.FC<FormHeaderRowProps> = (props) => (
   </LabelRow>
 );
 
-const passedAgesKnown = (model: Record<string, any> | undefined) => {
+const pastAgesKnown = (model: Record<string, any> | undefined) => {
   if (model !== undefined) {
     let keys = Object.keys(model);
     return keys.some(function (key) {
@@ -76,7 +76,7 @@ const passedAgesKnown = (model: Record<string, any> | undefined) => {
   }
 };
 
-const passedAgesUnknown = (model: Record<string, any> | undefined) => {
+const pastAgesUnknown = (model: Record<string, any> | undefined) => {
   if (model !== undefined) {
     let keys = Object.keys(model);
     return keys.some(function (key) {
@@ -84,19 +84,6 @@ const passedAgesUnknown = (model: Record<string, any> | undefined) => {
     });
   } else {
     return true;
-  }
-};
-
-const collapseAgeInputs = (model: Record<string, any> | undefined) => {
-  if (passedAgesKnown(model)) {
-    return false;
-  } else if (
-    passedAgesKnown(model) === false &&
-    passedAgesUnknown(model) === true
-  ) {
-    return true;
-  } else {
-    return false;
   }
 };
 
@@ -112,9 +99,22 @@ export const AgeGroupGrid: React.FC<AgeGroupGridProps> = ({
 }) => {
   const [collapsed, setCollapsed] = useState(collapsible);
 
+  const collapseAgeInputs = () => {
+    if (pastAgesKnown(props.model)) {
+      return false;
+    } else if (
+      pastAgesKnown(props.model) === false &&
+      pastAgesUnknown(props.model) === true
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   useEffect(() => {
-    setCollapsed(collapseAgeInputs(props.model));
-  }, [props.model]);
+    setCollapsed(collapseAgeInputs());
+  }, []);
 
   const ageSpecificCaseCounts = (
     <>

--- a/src/page-multi-facility/AddCasesModal/AddCasesModalContent.tsx
+++ b/src/page-multi-facility/AddCasesModal/AddCasesModalContent.tsx
@@ -1,7 +1,7 @@
 import { startOfToday } from "date-fns";
 import hexAlpha from "hex-alpha";
 import numeral from "numeral";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import styled from "styled-components";
 
 import Colors from "../../design-system/Colors";
@@ -117,6 +117,7 @@ const AddCasesModalContent: React.FC<Props> = ({
       ),
     [facilityModelVersions],
   );
+  const [warnedAt, setWarnedAt] = useState(0);
 
   const getTileClassName = useCallback(
     ({ date, view }: { date: Date; view: string }) => {
@@ -193,6 +194,8 @@ const AddCasesModalContent: React.FC<Props> = ({
         model={inputs}
         updateModel={updateInputs}
         collapsible={true}
+        warnedAt={warnedAt}
+        setWarnedAt={setWarnedAt}
       />
       <HorizRule />
       <InputButton label="Save" onClick={onSave} />


### PR DESCRIPTION
## Description of the change

Prevent entry of duplicated age data (known ages and unknown ages) submitted at the same time.

If a user enters more than 0 in both known and unknown age inputs in a form, the save is canceled and an error message appears. Error copy: "To prevent duplicate counting, known and unknown ages cannot be entered together. Please clear either the unknown age input or all age inputs."

Gif demos:
![facility-demo](https://user-images.githubusercontent.com/8259050/85594689-c2f6b680-b60d-11ea-9a3e-ea96397ced3a.gif)

![modal-demo](https://user-images.githubusercontent.com/8259050/85594672-bffbc600-b60d-11ea-8f3a-191847d766cb.gif)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #572 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
