### PR TITLE
Enhance Data Visualization in Scenario Library with Projection Graphs

### DIFF
--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -96,7 +96,7 @@ const FacilityChart: React.FC<{
 
   return (
     <>
-      {firstFacility && firstFacilityRtData ? (
+      {(firstFacility && firstFacilityRtData) ? (
         <EpidemicModelProvider
           facilityModel={firstFacility?.modelInputs}
           localeDataSource={localeDataSource}

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+
+import { getFacilities } from "../database";
+import Loading from "../design-system/Loading";
+import useRejectionToast from "../hooks/useRejectionToast";
+import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
+import { getRtDataForFacility } from "../infection-model/rt";
+import { useLocaleDataState } from "../locale-data-context";
+import FacilityRow from "./FacilityRow";
+import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
+import { Facility, RtValue, Scenario } from "./types";
+
+const FacilityChart: React.FC<{
+  scenarioId: string;
+}> = ({ scenarioId }) => {
+  const [firstFacility, setFirstFacility] = useState<Facility | null>();
+  const [
+    firstFacilityRtData,
+    setFirstFacilityRtData,
+  ] = useState<RtValue | null>();
+  const { data: localeDataSource } = useLocaleDataState();
+
+  const handleFacilitySave = (facility: Facility) => {
+    console.log(facility);
+  };
+
+  const fetchFacility = async () => {
+    const facilities = await getFacilities(scenarioId);
+    const firstFacility = facilities?.[0];
+    if (firstFacility) {
+      const firstFacilityRtData = await getRtDataForFacility(firstFacility);
+      setFirstFacility(firstFacility);
+      setFirstFacilityRtData(firstFacilityRtData);
+    }
+  };
+
+  useEffect(() => {
+    fetchFacility();
+  }, [fetchFacility]);
+
+  return (
+    <>
+      {firstFacility && firstFacilityRtData ? (
+        <FacilityRowPlaceholder key={firstFacility?.id}>
+          <EpidemicModelProvider
+            facilityModel={firstFacility?.modelInputs}
+            localeDataSource={localeDataSource}
+          >
+            <FacilityRow
+              facility={firstFacility}
+              facilityRtData={firstFacilityRtData}
+              onSave={handleFacilitySave}
+            />
+          </EpidemicModelProvider>
+        </FacilityRowPlaceholder>
+      ) : (
+        <Loading />
+      )}
+      ;
+    </>
+  );
+};
+
+export default FacilityChart;

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -125,9 +125,9 @@ const FacilityChart: React.FC<{
           localeDataSource={localeDataSource}
         >
           <FacilityChartWrapper
+            hasFacility={hasFacility}
             facility={facility}
             facilityRtData={facilityRtData}
-            hasFacility={hasFacility}
           />
         </EpidemicModelProvider>
       ) : (
@@ -139,4 +139,4 @@ const FacilityChart: React.FC<{
   );
 };
 
-export default FacilityChart;
+export default React.memo(FacilityChart);

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
 
 import { getFacilities } from "../database";
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
-import useRejectionToast from "../hooks/useRejectionToast";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import useModel from "../impact-dashboard/useModel";
@@ -14,14 +14,18 @@ import {
 } from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import { initialPublicCurveToggles } from "./curveToggles";
-import FacilityRow from "./FacilityRow";
-import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
-import FacilityRowRtValuePill from "./FacilityRowRtValuePill";
 import {
   useChartDataFromProjectionData,
   useProjectionData,
 } from "./projectionCurveHooks";
-import { Facility, RtValue, Scenario } from "./types";
+import { Facility, RtValue } from "./types";
+
+const LoadingWrapper = styled.div`
+  color: ${Colors.opacityGray};
+  display: flex;
+  height: 45%;
+  align-content: center;
+`;
 
 const FacilityChart: React.FC<{
   scenarioId: string;
@@ -33,34 +37,39 @@ const FacilityChart: React.FC<{
   ] = useState<RtValue | null>();
   const { data: localeDataSource } = useLocaleDataState();
 
-  const handleFacilitySave = (facility: Facility) => {
-    console.log(facility);
-  };
+  //   const fetchFacility = useCallback(async () => {
+  //     const facilities = await getFacilities(scenarioId);
+  //     let firstFacility = null;
+  //     let firstFacilityRtData = null;
+  //     if (facilities) {
+  //         firstFacility = facilities.[0];
+  //         firstFacilityRtData = await getRtDataForFacility(firstFacility);
+  //     }
+  //     if (firstFacility) {
+  //     //   setFirstFacility(firstFacility);
+  //     //   setFirstFacilityRtData(firstFacilityRtData);
+  //     }
+  //   }, []);
 
-  const fetchFacility = useCallback(async () => {
-    const facilities = await getFacilities(scenarioId);
-    const firstFacility = facilities?.[0];
-    if (firstFacility) {
-      const firstFacilityRtData = await getRtDataForFacility(firstFacility);
+  useEffect(() => {
+    let mounted = true;
+    async function fetchFacility() {
+      const facilities = await getFacilities(scenarioId);
+      let firstFacility = null;
+      let firstFacilityRtData = null;
+      if (facilities) {
+        firstFacility = facilities?.[0];
+        firstFacilityRtData = await getRtDataForFacility(firstFacility);
+      }
       setFirstFacility(firstFacility);
       setFirstFacilityRtData(firstFacilityRtData);
     }
-  }, []);
-
-  //   useEffect(() => {
-  //       let isMounted = true;
-  //     if (isMounted) {
-  //         fetchFacility();
-  //     }
-  //     return () => isMounted = false
-  //   }, [fetchFacility]);
-
-  useEffect(() => {
-    let isMounted = true;
-    if (isMounted) {
+    if (mounted) {
       fetchFacility();
     }
-    isMounted = false;
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const FacilityChartWrapper = (props: any) => {
@@ -98,7 +107,9 @@ const FacilityChart: React.FC<{
           />
         </EpidemicModelProvider>
       ) : (
-        <Loading styles={{ minHeight: 100, paddingBottom: 100 }} />
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
       )}
     </>
   );

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -8,6 +8,10 @@ import { getRtDataForFacility } from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import FacilityRow from "./FacilityRow";
 import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
+import {
+  useChartDataFromProjectionData,
+  useProjectionData,
+} from "./projectionCurveHooks";
 import { Facility, RtValue, Scenario } from "./types";
 
 const FacilityChart: React.FC<{
@@ -18,6 +22,7 @@ const FacilityChart: React.FC<{
     firstFacilityRtData,
     setFirstFacilityRtData,
   ] = useState<RtValue | null>();
+
   const { data: localeDataSource } = useLocaleDataState();
 
   const handleFacilitySave = (facility: Facility) => {

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -8,10 +8,6 @@ import { getRtDataForFacility } from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import FacilityRow from "./FacilityRow";
 import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
-import {
-  useChartDataFromProjectionData,
-  useProjectionData,
-} from "./projectionCurveHooks";
 import { Facility, RtValue, Scenario } from "./types";
 
 const FacilityChart: React.FC<{
@@ -22,7 +18,6 @@ const FacilityChart: React.FC<{
     firstFacilityRtData,
     setFirstFacilityRtData,
   ] = useState<RtValue | null>();
-
   const { data: localeDataSource } = useLocaleDataState();
 
   const handleFacilitySave = (facility: Facility) => {

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -7,7 +7,11 @@ import useRejectionToast from "../hooks/useRejectionToast";
 import CurveChartContainer from "../impact-dashboard/CurveChartContainer";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import useModel from "../impact-dashboard/useModel";
-import { getRtDataForFacility } from "../infection-model/rt";
+import {
+  getNewestRt,
+  getRtDataForFacility,
+  isRtData,
+} from "../infection-model/rt";
 import { useLocaleDataState } from "../locale-data-context";
 import { initialPublicCurveToggles } from "./curveToggles";
 import FacilityRow from "./FacilityRow";
@@ -43,9 +47,21 @@ const FacilityChart: React.FC<{
     }
   }, []);
 
+  //   useEffect(() => {
+  //       let isMounted = true;
+  //     if (isMounted) {
+  //         fetchFacility();
+  //     }
+  //     return () => isMounted = false
+  //   }, [fetchFacility]);
+
   useEffect(() => {
-    fetchFacility();
-  }, [fetchFacility]);
+    let isMounted = true;
+    if (isMounted) {
+      fetchFacility();
+    }
+    isMounted = false;
+  }, []);
 
   const FacilityChartWrapper = (props: any) => {
     const [model] = useModel();
@@ -56,9 +72,6 @@ const FacilityChart: React.FC<{
     return (
       <>
         <div>
-          {/* {props.facilityRtData !== undefined && (
-        <FacilityRowRtValuePill latestRt={latestRt} />
-        )} */}
           <CurveChartContainer
             curveData={chartData}
             chartHeight={144}
@@ -75,27 +88,18 @@ const FacilityChart: React.FC<{
   return (
     <>
       {firstFacility && firstFacilityRtData ? (
-        <FacilityRowPlaceholder key={firstFacility?.id}>
-          <EpidemicModelProvider
-            facilityModel={firstFacility?.modelInputs}
-            localeDataSource={localeDataSource}
-          >
-            <FacilityChartWrapper
-              facility={firstFacility}
-              facilityRtData={firstFacilityRtData}
-            />
-
-            {/* <FacilityRow
-              facility={firstFacility}
-              facilityRtData={firstFacilityRtData}
-              onSave={handleFacilitySave}
-            /> */}
-          </EpidemicModelProvider>
-        </FacilityRowPlaceholder>
+        <EpidemicModelProvider
+          facilityModel={firstFacility?.modelInputs}
+          localeDataSource={localeDataSource}
+        >
+          <FacilityChartWrapper
+            facility={firstFacility}
+            facilityRtData={firstFacilityRtData}
+          />
+        </EpidemicModelProvider>
       ) : (
-        <Loading />
+        <Loading styles={{ minHeight: 100, paddingBottom: 100 }} />
       )}
-      ;
     </>
   );
 };

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -119,7 +119,11 @@ const FacilityChart: React.FC<{
 
   return (
     <>
-      {!loading ? (
+      {loading ? (
+        <LoadingWrapper>
+          <Loading />
+        </LoadingWrapper>
+      ) : (
         <EpidemicModelProvider
           facilityModel={facility?.modelInputs}
           localeDataSource={localeDataSource}
@@ -130,13 +134,9 @@ const FacilityChart: React.FC<{
             facilityRtData={facilityRtData}
           />
         </EpidemicModelProvider>
-      ) : (
-        <LoadingWrapper>
-          <Loading />
-        </LoadingWrapper>
       )}
     </>
   );
 };
 
-export default React.memo(FacilityChart);
+export default FacilityChart;

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -50,9 +50,7 @@ const FacilityChart: React.FC<{
         const facilityRtData = await getRtDataForFacility(facility);
         if (mounted) {
           setFacility(facility);
-          if (facilityRtData) {
-            setFacilityRtData(facilityRtData);
-          }
+          setFacilityRtData(facilityRtData);
         }
       }
     }

--- a/src/page-multi-facility/FacilityChart.tsx
+++ b/src/page-multi-facility/FacilityChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { getFacilities } from "../database";
@@ -28,43 +28,31 @@ const LoadingWrapper = styled.div`
   align-content: center;
 `;
 
+interface FacilityChartProps {
+  facility: Facility | undefined;
+  facilityRtData: RtValue | undefined;
+}
+
 const FacilityChart: React.FC<{
   scenarioId: string;
-}> = ({ scenarioId }) => {
-  const [firstFacility, setFirstFacility] = useState<Facility | null>();
-  const [firstFacilityRtData, setFirstFacilityRtData] = useState<
-    RtValue | undefined
-  >();
+  indexOfFacility: number;
+}> = ({ scenarioId, indexOfFacility }) => {
+  const [facility, setFacility] = useState<Facility | undefined>();
+  const [facilityRtData, setFacilityRtData] = useState<RtValue | undefined>();
   const { data: localeDataSource } = useLocaleDataState();
-
-  //   const fetchFacility = useCallback(async () => {
-  //     const facilities = await getFacilities(scenarioId);
-  //     let firstFacility = null;
-  //     let firstFacilityRtData = null;
-  //     if (facilities) {
-  //         firstFacility = facilities.[0];
-  //         firstFacilityRtData = await getRtDataForFacility(firstFacility);
-  //     }
-  //     if (firstFacility) {
-  //     //   setFirstFacility(firstFacility);
-  //     //   setFirstFacilityRtData(firstFacilityRtData);
-  //     }
-  //   }, []);
 
   useEffect(() => {
     let mounted = true;
     async function fetchFacility() {
       const facilities = await getFacilities(scenarioId);
-      let firstFacility = null;
-      let firstFacilityRtData = null;
       if (facilities) {
-        firstFacility = facilities?.[0];
-        firstFacilityRtData = await getRtDataForFacility(firstFacility);
-      }
-      if (mounted) {
-        setFirstFacility(firstFacility);
-        if (firstFacilityRtData) {
-          setFirstFacilityRtData(firstFacilityRtData);
+        const facility = facilities[indexOfFacility];
+        const facilityRtData = await getRtDataForFacility(facility);
+        if (mounted) {
+          setFacility(facility);
+          if (facilityRtData) {
+            setFacilityRtData(facilityRtData);
+          }
         }
       }
     }
@@ -74,7 +62,7 @@ const FacilityChart: React.FC<{
     };
   }, []);
 
-  const FacilityChartWrapper = (props: any) => {
+  const FacilityChartWrapper = (props: FacilityChartProps) => {
     const [model] = useModel();
     const latestRt = isRtData(props.facilityRtData)
       ? getNewestRt(props.facilityRtData.Rt)?.value
@@ -104,14 +92,14 @@ const FacilityChart: React.FC<{
 
   return (
     <>
-      {firstFacility && firstFacilityRtData ? (
+      {facility && facilityRtData ? (
         <EpidemicModelProvider
-          facilityModel={firstFacility?.modelInputs}
+          facilityModel={facility?.modelInputs}
           localeDataSource={localeDataSource}
         >
           <FacilityChartWrapper
-            facility={firstFacility}
-            facilityRtData={firstFacilityRtData}
+            facility={facility}
+            facilityRtData={facilityRtData}
           />
         </EpidemicModelProvider>
       ) : (

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -15,7 +15,6 @@ import useCurrentUserId from "../hooks/useCurrentUserId";
 import useRejectionToast from "../hooks/useRejectionToast";
 import useScenario from "../scenario-context/useScenario";
 import CreateNewScenarioModal from "../scenario-create-new/CreateNewScenarioModal";
-import FacilityChart from "./FacilityChart";
 import { Scenario } from "./types";
 
 const ModalContents = styled.div`
@@ -331,10 +330,9 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
                     />
                     <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
                   </ScenarioHeader>
-                  <FacilityChart scenarioId={scenario.id} />
-                  {/* <ScenarioDataViz>
+                  <ScenarioDataViz>
                     <IconRecidviz alt="Recidiviz" src={iconSrcRecidiviz} />
-                  </ScenarioDataViz> */}
+                  </ScenarioDataViz>
                   <ScenarioDescription>
                     {scenario.description}
                   </ScenarioDescription>

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -5,7 +5,6 @@ import { deleteScenario, duplicateScenario, getScenarios } from "../database";
 import Colors from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
 import iconSrcCheck from "../design-system/icons/ic_check.svg";
-import iconSrcRecidiviz from "../design-system/icons/ic_recidiviz.svg";
 import { StyledButton } from "../design-system/InputButton";
 import Loading from "../design-system/Loading";
 import Modal, { Props as ModalProps } from "../design-system/Modal";
@@ -318,7 +317,7 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
                     />
                     <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
                   </ScenarioHeader>
-                  <FacilityChart scenarioId={scenario.id} indexOfFacility={0} />
+                  <FacilityChart scenarioId={scenario.id} />
                   <ScenarioDescription>
                     {scenario.description}
                   </ScenarioDescription>

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -167,6 +167,78 @@ const CancelButton = styled(ModalButton)`
 
 type Props = Pick<ModalProps, "trigger">;
 
+interface ScenarioLibraryWrapperProps {
+  scenarios: {
+    data: Scenario[];
+    loading: boolean;
+  };
+  ownedFlag: boolean;
+  copyScenario: (scenarioId: string) => void;
+  openDeleteModal: (scenarioId: string) => void;
+  changeScenario: (scenario: Scenario) => void;
+}
+
+const ScenarioLibraryWrapper = (props: ScenarioLibraryWrapperProps) => {
+  return (
+    <>
+      {props.scenarios?.loading ? (
+        <Loading />
+      ) : (
+        <ScenarioLibrary>
+          {props.ownedFlag && <CreateNewScenarioModal />}
+          {props.scenarios?.data.map((scenario: any) => {
+            const popupItems = [
+              {
+                name: "Duplicate",
+                onClick: () => {
+                  props.copyScenario(scenario.id);
+                },
+              },
+            ];
+
+            // Only show the Delete option for non-baseline & owned scenarios
+            if (!scenario.baseline && props.ownedFlag) {
+              popupItems.push({
+                name: "Delete",
+                onClick: () => {
+                  props.openDeleteModal(scenario.id);
+                },
+              });
+            }
+            return (
+              <ScenarioCard
+                key={scenario.id}
+                onClick={() => {
+                  props.changeScenario(scenario);
+                }}
+              >
+                <ScenarioHeader>
+                  <IconCheck
+                    alt="check"
+                    src={iconSrcCheck}
+                    baseline={scenario.baseline}
+                  />
+                  <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
+                </ScenarioHeader>
+                <FacilityChart scenarioId={scenario.id} />
+                <ScenarioDescription>
+                  {scenario.description}
+                </ScenarioDescription>
+                <ScenarioFooter>
+                  <LastUpdatedLabel>
+                    Last Update: <DateMMMMdyyyy date={scenario.updatedAt} />
+                  </LastUpdatedLabel>
+                  <PopUpMenu items={popupItems} />
+                </ScenarioFooter>
+              </ScenarioCard>
+            );
+          })}
+        </ScenarioLibrary>
+      )}
+    </>
+  );
+};
+
 const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [currentScenario, dispatchScenarioUpdate] = useScenario();
@@ -281,61 +353,6 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
     closeDeleteModal(event);
   };
 
-  const ScenarioLibraryWrapper = (props: any) => {
-    return (
-      <>
-        {props.scenarios?.loading ? (
-          <Loading />
-        ) : (
-          <ScenarioLibrary>
-            {props.ownedFlag && <CreateNewScenarioModal />}
-            {props.scenarios?.data.map((scenario: any) => {
-              const popupItems = [
-                {
-                  name: "Duplicate",
-                  onClick: () => copyScenario(scenario.id),
-                },
-              ];
-
-              // Only show the Delete option for non-baseline & owned scenarios
-              if (!scenario.baseline && props.ownedFlag) {
-                popupItems.push({
-                  name: "Delete",
-                  onClick: () => openDeleteModal(scenario.id),
-                });
-              }
-              return (
-                <ScenarioCard
-                  key={scenario.id}
-                  onClick={() => changeScenario(scenario)}
-                >
-                  <ScenarioHeader>
-                    <IconCheck
-                      alt="check"
-                      src={iconSrcCheck}
-                      baseline={scenario.baseline}
-                    />
-                    <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
-                  </ScenarioHeader>
-                  <FacilityChart scenarioId={scenario.id} />
-                  <ScenarioDescription>
-                    {scenario.description}
-                  </ScenarioDescription>
-                  <ScenarioFooter>
-                    <LastUpdatedLabel>
-                      Last Update: <DateMMMMdyyyy date={scenario.updatedAt} />
-                    </LastUpdatedLabel>
-                    <PopUpMenu items={popupItems} />
-                  </ScenarioFooter>
-                </ScenarioCard>
-              );
-            })}
-          </ScenarioLibrary>
-        )}
-      </>
-    );
-  };
-
   return (
     <Modal
       modalTitle="Library"
@@ -346,13 +363,22 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
       width="756px"
     >
       <ModalContents>
-        <ScenarioLibraryWrapper scenarios={ownedScenarios} ownedFlag={true} />
+        <ScenarioLibraryWrapper
+          scenarios={ownedScenarios}
+          openDeleteModal={openDeleteModal}
+          copyScenario={copyScenario}
+          changeScenario={changeScenario}
+          ownedFlag={true}
+        />
 
         {sharedScenarios?.data?.length !== 0 && (
           <div>
             <h3>Shared Scenarios</h3>
             <ScenarioLibraryWrapper
               scenarios={sharedScenarios}
+              openDeleteModal={openDeleteModal}
+              copyScenario={copyScenario}
+              changeScenario={changeScenario}
               ownedFlag={false}
             />
           </div>

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -15,6 +15,7 @@ import useCurrentUserId from "../hooks/useCurrentUserId";
 import useRejectionToast from "../hooks/useRejectionToast";
 import useScenario from "../scenario-context/useScenario";
 import CreateNewScenarioModal from "../scenario-create-new/CreateNewScenarioModal";
+import FacilityChart from "./FacilityChart";
 import { Scenario } from "./types";
 
 const ModalContents = styled.div`
@@ -330,9 +331,10 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
                     />
                     <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
                   </ScenarioHeader>
-                  <ScenarioDataViz>
+                  <FacilityChart scenarioId={scenario.id} />
+                  {/* <ScenarioDataViz>
                     <IconRecidviz alt="Recidiviz" src={iconSrcRecidiviz} />
-                  </ScenarioDataViz>
+                  </ScenarioDataViz> */}
                   <ScenarioDescription>
                     {scenario.description}
                   </ScenarioDescription>

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -71,13 +71,6 @@ const ScenarioHeaderText = styled.h1`
   white-space: nowrap;
 `;
 
-const ScenarioDataViz = styled.div`
-  color: ${Colors.opacityGray};
-  display: flex;
-  height: 45%;
-  background-color: ${Colors.gray};
-`;
-
 const ScenarioDescription = styled.div`
   color: ${Colors.opacityForest};
   font-family: "Poppins";
@@ -135,12 +128,6 @@ const IconCheck = styled.img<IconCheckProps>`
   width: 20px;
   height: 20px;
   margin-right: 8px;
-`;
-
-const IconRecidviz = styled.img`
-  width: 50px;
-  height: 50px;
-  margin: auto;
 `;
 
 const DeleteModalContents = styled.div`
@@ -331,10 +318,7 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
                     />
                     <ScenarioHeaderText>{scenario.name}</ScenarioHeaderText>
                   </ScenarioHeader>
-                  <FacilityChart scenarioId={scenario.id} />
-                  {/* <ScenarioDataViz>
-                    <IconRecidviz alt="Recidiviz" src={iconSrcRecidiviz} />
-                  </ScenarioDataViz> */}
+                  <FacilityChart scenarioId={scenario.id} indexOfFacility={0} />
                   <ScenarioDescription>
                     {scenario.description}
                   </ScenarioDescription>


### PR DESCRIPTION
## Description of the change

> The Scenario Library now displays the projection graph and Rt value for the first facility in a scenario instead of the Recidiviz logo. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #347

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

Basic testing: 
<img width="755" alt="Screen Shot 2020-06-24 at 4 30 53 PM" src="https://user-images.githubusercontent.com/29155017/85630369-1a5e4c00-b639-11ea-9b55-6ebe3e4c2d62.png">


### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
