### PR TITLE
Update Rt calc to handle duplicate cases and smooth Rt result

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -132,7 +132,7 @@ def compute_r_t(historical_case_counts):
     # we need at least two days to represent change over time
     if len(smoothed) < 2:
         raise ValueError('Not enough data to compute R(t);'
-            ' at least two days of non-repeating case counts are required')
+            ' at least two days of data are required')
 
     # Note that we're fixing sigma to a value just for the example
     posteriors, _ = get_posteriors(smoothed, sigma=.25)

--- a/backend/python-functions/test.py
+++ b/backend/python-functions/test.py
@@ -67,7 +67,7 @@ class TestCalculateRt(TestCase):
         resp = self.get_response_json()
         self.assertNotIn('error', resp)
 
-    def test_exclude_duplicates(self):
+    def test_exclude_first_date(self):
         data = {
             'dates': ['2020-04-15', '2020-04-16', '2020-04-18', '2020-04-19'],
             'cases': [50, 66, 66, 129]
@@ -75,8 +75,8 @@ class TestCalculateRt(TestCase):
         self.req.get_json.return_value = data
 
         resp = self.get_response_json()
-        # duplicate case counts will be dropped
-        expected_response_dates = [data['dates'][1], data['dates'][3]]
+        # the first date will be dropped
+        expected_response_dates = data['dates'][1:]
         self.verify_response_data(resp, expected_response_dates)
 
     def test_ensure_cumulative(self):


### PR DESCRIPTION
## Description of the change

Make the Rt calculation more robust for scenarios with spotty testing that are going through an outbreak, and scenarios that are not. This includes 2 changes: removing the portion that excludes days with duplicate case counts, and smoothing the Rt result to reduce the noise caused by sporadic testing. 

I've tested this in my own research notebook locally, but have not tested this end to end in the covid app. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #608 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
