### PR TITLE
Remove undefined properties before saving scenario

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -264,6 +264,8 @@ export const saveScenario = async (scenario: any): Promise<Scenario | null> => {
     // If the scenario already has an id associated with it then we just need
     // to update that scenario. Otherwise, we are creating a new scenario.
     if (scenario.id) {
+      // remove any keys that are explicitly set to undefined or Firestore will object
+      scenario = pickBy(scenario, (value) => value !== undefined);
       const payload = buildUpdatePayload(scenario);
 
       await db


### PR DESCRIPTION
## Description of the change

@jovergaag and I noticed this bug today while trying to share a scenario. I hadn't checked the sharing scenario functionality when adding the `referenceDataObservedAt` property, and the function `addScenarioUser` throws an error for trying to save a scenario with an undefined value. 

This fix tries to follow the pattern in `saveFacility` by using `pickBy` and removing undefined values before saving. I also thought about moving this to the `buildUpdatePayload` function instead, if people like that more let me know and I can update this. 

I was able to test this with one of my scenarios that has an undefined `referenceDataObservedAt` property. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes [#XXXX]

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
