### PR TITLE
Update case distribution with active/recovered/deaths

### DIFF
--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -122,7 +122,7 @@ export const buildScenario = (
   // Runtime migration: make sure a default value is set for
   // promo status flags added since the last data shakeup
   // TODO: Remove this once automated migration is in place per #186
-  const newPromoStatuses = ["rtChart"];
+  const newPromoStatuses = ["rtChart", "newModelInputs"];
   newPromoStatuses.forEach((flagName) => {
     if (scenario.promoStatuses[flagName] === undefined) {
       scenario.promoStatuses[flagName] = true;

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -315,7 +315,7 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ).forEach(([pop, cases, recovered, deaths], index) => {
     // distribute cases across compartments proportionally
 
-    if ((typeof recovered !== 'undefined') & (typeof recovered !== 'undefined')) {
+    if ((typeof recovered !== 'undefined') && (typeof recovered !== 'undefined')) {
         const activeCases = Math.max(cases - recovered - deaths, 0);
 
         const infectious = activeCases * pInitiallyInfectious;

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -315,7 +315,7 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ).forEach(([pop, cases, recovered, deaths], index) => {
     // distribute cases across compartments proportionally
 
-    if ((typeof recovered !== 'undefined') && (typeof recovered !== 'undefined')) {
+    if ((typeof recovered !== 'undefined') && (typeof deaths !== 'undefined')) {
         const activeCases = Math.max(cases - recovered - deaths, 0);
 
         const infectious = activeCases * pInitiallyInfectious;

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -315,61 +315,79 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ).forEach(([pop, cases, recovered, deaths], index) => {
     // distribute cases across compartments proportionally
 
-    if ((typeof recovered !== 'undefined') && (typeof deaths !== 'undefined')) {
-        const activeCases = Math.max(cases - recovered - deaths, 0);
+    if (typeof recovered !== "undefined" && typeof deaths !== "undefined") {
+      const activeCases = Math.max(cases - recovered - deaths, 0);
 
-        const infectious = activeCases * pInitiallyInfectious;
-        // exposed is related to the number of infectious
-        // but it can't be more than the total uninfected population
-        const exposed = Math.min(infectious * ratioExposedToInfected, pop - cases);
+      const infectious = activeCases * pInitiallyInfectious;
+      // exposed is related to the number of infectious
+      // but it can't be more than the total uninfected population
+      const exposed = Math.min(
+        infectious * ratioExposedToInfected,
+        pop - cases,
+      );
 
-        singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
-        singleDayState.set(index, seirIndex.exposed, exposed);
-        singleDayState.set(index, seirIndex.infectious, infectious);
-        singleDayState.set(index, seirIndex.mild, activeCases * pInitiallyMild);
-        singleDayState.set(index, seirIndex.severe, activeCases * pInitiallySevere);
-        singleDayState.set(
-          index,
-          seirIndex.hospitalized,
-          activeCases * pInitiallyHospitalized,
-        );
-        singleDayState.set(
-          index,
-          seirIndex.mildRecovered,
-          recovered * pInitiallyMildRecovered,
-        );
-        singleDayState.set(
-          index,
-          seirIndex.severeRecovered,
-          recovered * pInitiallySevereRecovered,
-        );
-        singleDayState.set(index, seirIndex.fatalities, deaths);
+      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+      singleDayState.set(index, seirIndex.exposed, exposed);
+      singleDayState.set(index, seirIndex.infectious, infectious);
+      singleDayState.set(index, seirIndex.mild, activeCases * pInitiallyMild);
+      singleDayState.set(
+        index,
+        seirIndex.severe,
+        activeCases * pInitiallySevere,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.hospitalized,
+        activeCases * pInitiallyHospitalized,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.mildRecovered,
+        recovered * pInitiallyMildRecovered,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.severeRecovered,
+        recovered * pInitiallySevereRecovered,
+      );
+      singleDayState.set(index, seirIndex.fatalities, deaths);
     } else {
-        const infectious = cases * pInitiallyInfectiousCumulative;
-        // exposed is related to the number of infectious
-        // but it can't be more than the total uninfected population
-        const exposed = Math.min(infectious * ratioExposedToInfected, pop - cases);
+      const infectious = cases * pInitiallyInfectiousCumulative;
+      // exposed is related to the number of infectious
+      // but it can't be more than the total uninfected population
+      const exposed = Math.min(
+        infectious * ratioExposedToInfected,
+        pop - cases,
+      );
 
-        singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
-        singleDayState.set(index, seirIndex.exposed, exposed);
-        singleDayState.set(index, seirIndex.infectious, infectious);
-        singleDayState.set(index, seirIndex.mild, cases * pInitiallyMildCumulative);
-        singleDayState.set(index, seirIndex.severe, cases * pInitiallySevereCumulative);
-        singleDayState.set(
-          index,
-          seirIndex.hospitalized,
-          cases * pInitiallyHospitalizedCumulative,
-        );
-        singleDayState.set(
-          index,
-          seirIndex.mildRecovered,
-          cases * pInitiallyMildRecoveredCumulative,
-        );
-        singleDayState.set(
-          index,
-          seirIndex.severeRecovered,
-          cases * pInitiallySevereRecoveredCumulative,
-        );
+      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+      singleDayState.set(index, seirIndex.exposed, exposed);
+      singleDayState.set(index, seirIndex.infectious, infectious);
+      singleDayState.set(
+        index,
+        seirIndex.mild,
+        cases * pInitiallyMildCumulative,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.severe,
+        cases * pInitiallySevereCumulative,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.hospitalized,
+        cases * pInitiallyHospitalizedCumulative,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.mildRecovered,
+        cases * pInitiallyMildRecoveredCumulative,
+      );
+      singleDayState.set(
+        index,
+        seirIndex.severeRecovered,
+        cases * pInitiallySevereRecoveredCumulative,
+      );
     }
   });
 

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -104,6 +104,13 @@ const pInitiallyHospitalized = 0.216;
 // Distribution of recovered cases, based on curve ratios
 const pInitiallyMildRecovered = 0.856;
 const pInitiallySevereRecovered = 0.144;
+// Distribution of cumulative cases, based on curve ratios
+const pInitiallyInfectiousCumulative = 0.611;
+const pInitiallyMildCumulative = 0.231;
+const pInitiallySevereCumulative = 0.054;
+const pInitiallyHospitalizedCumulative = 0.043;
+const pInitiallyMildRecoveredCumulative = 0.057;
+const pInitiallySevereRecoveredCumulative = 0.004;
 
 function simulateOneDay(inputs: SimulationInputs & SingleDayInputs) {
   const {
@@ -308,34 +315,62 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ).forEach(([pop, cases, recovered, deaths], index) => {
     // distribute cases across compartments proportionally
 
-    const activeCases = cases - recovered - deaths;
+    if ((typeof recovered !== 'undefined') & (typeof recovered !== 'undefined')) {
+        const activeCases = Math.max(cases - recovered - deaths, 0);
 
-    const infectious = activeCases * pInitiallyInfectious;
-    // exposed is related to the number of infectious
-    // but it can't be more than the total uninfected population
-    const exposed = Math.min(infectious * ratioExposedToInfected, pop - cases);
+        const infectious = activeCases * pInitiallyInfectious;
+        // exposed is related to the number of infectious
+        // but it can't be more than the total uninfected population
+        const exposed = Math.min(infectious * ratioExposedToInfected, pop - cases);
 
-    singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
-    singleDayState.set(index, seirIndex.exposed, exposed);
-    singleDayState.set(index, seirIndex.infectious, infectious);
-    singleDayState.set(index, seirIndex.mild, activeCases * pInitiallyMild);
-    singleDayState.set(index, seirIndex.severe, activeCases * pInitiallySevere);
-    singleDayState.set(
-      index,
-      seirIndex.hospitalized,
-      activeCases * pInitiallyHospitalized,
-    );
-    singleDayState.set(
-      index,
-      seirIndex.mildRecovered,
-      recovered * pInitiallyMildRecovered,
-    );
-    singleDayState.set(
-      index,
-      seirIndex.severeRecovered,
-      recovered * pInitiallySevereRecovered,
-    );
-    singleDayState.set(index, seirIndex.fatalities, deaths);
+        singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+        singleDayState.set(index, seirIndex.exposed, exposed);
+        singleDayState.set(index, seirIndex.infectious, infectious);
+        singleDayState.set(index, seirIndex.mild, activeCases * pInitiallyMild);
+        singleDayState.set(index, seirIndex.severe, activeCases * pInitiallySevere);
+        singleDayState.set(
+          index,
+          seirIndex.hospitalized,
+          activeCases * pInitiallyHospitalized,
+        );
+        singleDayState.set(
+          index,
+          seirIndex.mildRecovered,
+          recovered * pInitiallyMildRecovered,
+        );
+        singleDayState.set(
+          index,
+          seirIndex.severeRecovered,
+          recovered * pInitiallySevereRecovered,
+        );
+        singleDayState.set(index, seirIndex.fatalities, deaths);
+    } else {
+        const infectious = cases * pInitiallyInfectiousCumulative;
+        // exposed is related to the number of infectious
+        // but it can't be more than the total uninfected population
+        const exposed = Math.min(infectious * ratioExposedToInfected, pop - cases);
+
+        singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+        singleDayState.set(index, seirIndex.exposed, exposed);
+        singleDayState.set(index, seirIndex.infectious, infectious);
+        singleDayState.set(index, seirIndex.mild, cases * pInitiallyMildCumulative);
+        singleDayState.set(index, seirIndex.severe, cases * pInitiallySevereCumulative);
+        singleDayState.set(
+          index,
+          seirIndex.hospitalized,
+          cases * pInitiallyHospitalizedCumulative,
+        );
+        singleDayState.set(
+          index,
+          seirIndex.mildRecovered,
+          cases * pInitiallyMildRecoveredCumulative,
+        );
+        singleDayState.set(
+          index,
+          seirIndex.severeRecovered,
+          cases * pInitiallySevereRecoveredCumulative,
+        );
+    }
   });
 
   // index expected population adjustments by day;

--- a/src/page-multi-facility/CreateBaselineScenarioPage.tsx
+++ b/src/page-multi-facility/CreateBaselineScenarioPage.tsx
@@ -47,6 +47,7 @@ const CreateBaselineScenarioPage: React.FC = () => {
         dataSharing: true,
         dailyReports: true,
         addFacilities: true,
+        newModelInputs: false,
       },
       description:
         "Welcome to your new scenario. To get started, add in facility data on the right-hand side of the page. Your initial scenario is also your 'Baseline' - meaning this is where you should keep real-world numbers about the current state of your facilities, their cases, and mitigation steps.",

--- a/src/page-multi-facility/ScenarioSidebar.tsx
+++ b/src/page-multi-facility/ScenarioSidebar.tsx
@@ -68,7 +68,9 @@ export function getEnabledPromoType(
 
   const { promoStatuses } = scenario;
 
-  return promoStatuses.rtChart
+  return promoStatuses.newModelInputs
+    ? "newModelInputs"
+    : promoStatuses.rtChart
     ? "rtChart"
     : numFacilities && numFacilities < 3 && promoStatuses?.addFacilities
     ? "addFacilities"
@@ -83,6 +85,12 @@ const promoTexts: { [promoType: string]: string } = {
     for that facility. To get an accurate Rt, enter case counts for previous
     days by clicking the number of cases on the right (in red) to update case
     numbers.`,
+  newModelInputs: `New! We’ve updated our model to factor in recoveries and 
+    deaths to enable more accurate projections based on active cases. This 
+    may have caused some of your projection values to change. You can input 
+    recoveries and deaths when you "Add Historical Data" for a facility.
+    Reach out to covid@recidiviz.org if you have questions about how this 
+    impacts your projection or how to get started.`,
 };
 
 export function getPromoText(promoType: string | null) {

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -63,6 +63,7 @@ export type PromoStatuses = {
   dailyReports: boolean;
   dataSharing: boolean;
   addFacilities: boolean;
+  newModelInputs: boolean;
 };
 
 export type RtValue = RtData | RtError;


### PR DESCRIPTION
## Description of the change

Use the recovered & death counts collected by the frontend to distribute cases for the SEIR model projection. I've updated the percentages based off Rt values that are more realistic for the facilities Zak has been working with (1.4 instead of 3.0). This shifts more of the active cases from the infectious group to the recovering groups. I've also split the "recovered" cases between our two recovered groups, and now initialize the fatalities set using the death count. I have not tested any of these changes!

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #607 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [ ] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
