### PR TITLE
Sort Facility Observed At Dates in Add Cases Modal

### DIFF
--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -27,6 +27,8 @@ function findMostRecentDate(
     const facilityObservedAtDates = facilityModelVersions.map(
       (facility) => facility.observedAt,
     );
+    // sort observed at dates
+    facilityObservedAtDates.sort((a, b) => a.getTime() - b.getTime());
     // filter to dates earlier than (or the same as) the current date
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
       return startOfDay(date) <= startOfDay(observedAtDate);


### PR DESCRIPTION
## Sort Facility Observed At Dates in Add Cases Modal

> In the original PR(https://github.com/Recidiviz/covid19-dashboard/pull/603) for this feature, we decided not to sort a facility's observedAt dates on the assumption that they arrived in chronological order. However, this isn't a safe assumption, which caused the logic for the pre-population to fail for some facilities. Sorting these dates should ensure that forward- and backward-looking pre-population now works per #523  

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #625

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
