### PR TITLE
Only Allow Syncing of Reference Data on the Baseline Scenario

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -170,7 +170,7 @@ export const SCENARIO_DEFAULTS = {
   baseline: false,
   dailyReports: false,
   dataSharing: false,
-  useReferenceData: true,
+  useReferenceData: false,
   promoStatuses: {},
   baselinePopulations: [],
   [referenceFacilitiesProp]: {},

--- a/src/page-multi-facility/CreateBaselineScenarioPage.tsx
+++ b/src/page-multi-facility/CreateBaselineScenarioPage.tsx
@@ -42,6 +42,7 @@ const CreateBaselineScenarioPage: React.FC = () => {
       baseline: true,
       dataSharing: false,
       dailyReports: false,
+      useReferenceData: true,
       baselinePopulations: [],
       promoStatuses: {
         dataSharing: true,


### PR DESCRIPTION
## Description of the change

- Fixing the value of `useReferenceData` in the scenario defaults and instead only setting this value to true when we are creating a new Baseline Scenario.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes N/A

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
