### PR TITLE
Add Facility Rt Chart to Weekly Snapshot

### DIFF
--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -36,8 +36,13 @@ const ChartArea: React.FC<{
   projectionData?: CurveData;
   initialCurveToggles: CurveToggles;
   markColors: ProjectionColors;
-  alternateTitle?: boolean;
-}> = ({ projectionData, initialCurveToggles, markColors, alternateTitle }) => {
+  title?: string;
+}> = ({
+  projectionData,
+  initialCurveToggles,
+  markColors,
+  title = "Projection",
+}) => {
   const [groupStatus, setGroupStatus] = useState(initialCurveToggles);
 
   const toggleGroup = (groupName: keyof typeof groupStatus) => {
@@ -45,8 +50,6 @@ const ChartArea: React.FC<{
   };
 
   const chartData = useChartDataFromProjectionData(projectionData);
-
-  const title = alternateTitle ? "Estimated Impact" : "Projection";
 
   return (
     <Container>

--- a/src/impact-dashboard/ChartArea.tsx
+++ b/src/impact-dashboard/ChartArea.tsx
@@ -36,7 +36,8 @@ const ChartArea: React.FC<{
   projectionData?: CurveData;
   initialCurveToggles: CurveToggles;
   markColors: ProjectionColors;
-}> = ({ projectionData, initialCurveToggles, markColors }) => {
+  alternateTitle?: boolean;
+}> = ({ projectionData, initialCurveToggles, markColors, alternateTitle }) => {
   const [groupStatus, setGroupStatus] = useState(initialCurveToggles);
 
   const toggleGroup = (groupName: keyof typeof groupStatus) => {
@@ -45,10 +46,12 @@ const ChartArea: React.FC<{
 
   const chartData = useChartDataFromProjectionData(projectionData);
 
+  const title = alternateTitle ? "Estimated Impact" : "Projection";
+
   return (
     <Container>
       <LegendAndActions>
-        <LegendTitle>projection</LegendTitle>
+        <LegendTitle>{title}</LegendTitle>
         <LegendContainer>
           <CurveChartLegend
             markColors={markColors}

--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -89,7 +89,7 @@ const xAxisOptions: any[] = [
     orient: "bottom",
     tickLineGenerator: () => null,
     label: "Days",
-    tickValues: [0, 25, 50, 75, 100],
+    ticks: 5,
   },
   {
     tickLineGenerator: () => null,

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -178,7 +178,10 @@ export function curveInputsWithRt(
   return curveInputs;
 }
 
-function prepareCurveData(inputs: CurveFunctionInputs): CurveProjectionInputs {
+function prepareCurveData(
+  inputs: CurveFunctionInputs,
+  duration?: number,
+): CurveProjectionInputs {
   const {
     age0Cases,
     age20Cases,
@@ -199,7 +202,7 @@ function prepareCurveData(inputs: CurveFunctionInputs): CurveProjectionInputs {
     usePopulationSubsets,
   } = inputs;
 
-  const numDays = NUM_DAYS;
+  const numDays = duration ? duration : NUM_DAYS;
 
   const ageGroupPopulations = prepareAgeGroupPopulations(inputs);
   const ageGroupInitiallyInfected = Array(ageGroupIndex.__length).fill(0);
@@ -237,10 +240,13 @@ function prepareCurveData(inputs: CurveFunctionInputs): CurveProjectionInputs {
 
 export function calculateCurves(
   inputs?: CurveFunctionInputs,
+  numDays?: number,
 ): CurveData | undefined {
   if (!inputs) return;
 
-  const { projectionGrid } = getAllBracketCurves(prepareCurveData(inputs));
+  const { projectionGrid } = getAllBracketCurves(
+    prepareCurveData(inputs, numDays),
+  );
 
   // these will each produce a matrix with row = day and col = SEIR bucket,
   // collapsing all age brackets into a single sum

--- a/src/infection-model/index.tsx
+++ b/src/infection-model/index.tsx
@@ -180,7 +180,7 @@ export function curveInputsWithRt(
 
 function prepareCurveData(
   inputs: CurveFunctionInputs,
-  duration?: number,
+  numDays = NUM_DAYS,
 ): CurveProjectionInputs {
   const {
     age0Cases,
@@ -201,8 +201,6 @@ function prepareCurveData(
     staffCases,
     usePopulationSubsets,
   } = inputs;
-
-  const numDays = duration ? duration : NUM_DAYS;
 
   const ageGroupPopulations = prepareAgeGroupPopulations(inputs);
   const ageGroupInitiallyInfected = Array(ageGroupIndex.__length).fill(0);

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -53,7 +53,7 @@ export const useProjectionData = (
 
   useEffect(() => {
     updateCurves(getCurves(input, useRt, latestRt, numDays));
-  }, [input, latestRt, useRt]);
+  }, [input, latestRt, useRt, numDays]);
 
   return curves;
 };

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -21,11 +21,13 @@ function getCurves(
   input: EpidemicModelInputs,
   useRt?: boolean,
   latestRt?: number,
+  numDays?: number,
 ) {
   return calculateCurves(
     useRt
       ? curveInputsWithRt(input, latestRt)
       : curveInputsFromUserInputs(input),
+    numDays,
   );
 }
 
@@ -33,6 +35,7 @@ export const useProjectionData = (
   input: EpidemicModelInputs,
   useRt?: boolean,
   rtData?: RtValue,
+  numDays?: number,
 ): CurveData | undefined => {
   let latestRt: number | undefined;
 
@@ -44,10 +47,12 @@ export const useProjectionData = (
     }
   }
 
-  const [curves, updateCurves] = useState(getCurves(input, useRt, latestRt));
+  const [curves, updateCurves] = useState(
+    getCurves(input, useRt, latestRt, numDays),
+  );
 
   useEffect(() => {
-    updateCurves(getCurves(input, useRt, latestRt));
+    updateCurves(getCurves(input, useRt, latestRt, numDays));
   }, [input, latestRt, useRt]);
 
   return curves;

--- a/src/page-weekly-snapshot/FacilitySummaryRow.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryRow.tsx
@@ -123,14 +123,12 @@ interface ProjectionProps {
 
 const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   return (
-    <>
-      <ChartArea
-        projectionData={projectionData}
-        initialCurveToggles={initialPublicCurveToggles}
-        markColors={markColors}
-        alternateTitle={true}
-      />
-    </>
+    <ChartArea
+      projectionData={projectionData}
+      initialCurveToggles={initialPublicCurveToggles}
+      markColors={markColors}
+      title={"Estimated Impact"}
+    />
   );
 };
 

--- a/src/page-weekly-snapshot/FacilitySummaryRow.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryRow.tsx
@@ -65,8 +65,6 @@ const ProjectionContainer = styled.div`
   .axis-title text,
   .axis-label {
     fill: ${Colors.black};
-    font-weight: 400;
-    line
     font-family: "Libre Franklin";
   }
 `;
@@ -119,26 +117,22 @@ interface Props {
   rtData: RtData | RtError | undefined;
 }
 
-interface FacilityProps {
+interface ProjectionProps {
   projectionData: CurveData | undefined;
 }
 
-const FacilityProjections: React.FC<FacilityProps> = ({ projectionData }) => {
+const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   return (
     <>
       <ChartArea
         projectionData={projectionData}
         initialCurveToggles={initialPublicCurveToggles}
         markColors={markColors}
+        alternateTitle={true}
       />
     </>
   );
 };
-
-interface Props {
-  facility: Facility;
-  rtData: RtData | RtError | undefined;
-}
 
 const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
   const projectionData = useProjectionData(
@@ -158,7 +152,7 @@ const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
       Facility-Specific Projection
       <ProjectionSection>
         <ProjectionContainer>
-          <FacilityProjections projectionData={projectionData} />
+          <FacilityProjection projectionData={projectionData} />
         </ProjectionContainer>
 
         <Heading>Incarcerated Population Projection</Heading>

--- a/src/page-weekly-snapshot/FacilitySummaryRow.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryRow.tsx
@@ -145,6 +145,7 @@ const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
     useEpidemicModelState(),
     true,
     rtData,
+    DURATION,
   );
   if (!projectionData) return <Loading />;
   const { incarcerated, staff } = projectionData;

--- a/src/page-weekly-snapshot/FacilitySummaryRow.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryRow.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
+import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
+import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import {
   formatThousands,
@@ -12,15 +13,13 @@ import {
   buildIncarceratedData,
   buildStaffData,
 } from "../impact-dashboard/ImpactProjectionTableContainer";
+import { CurveData } from "../infection-model";
 import { RtData, RtError } from "../infection-model/rt";
+import { initialPublicCurveToggles } from "../page-multi-facility/curveToggles";
 import { useProjectionData } from "../page-multi-facility/projectionCurveHooks";
 import { Facility } from "../page-multi-facility/types";
 
-const FacilitySummaryRowContainer = styled.div`
-  font-size: 11px;
-  font-weight: 400;
-  font-family: "Libre Franklin";
-`;
+const DURATION = 21;
 
 const FacilityName = styled.div`
   font-size: 43px;
@@ -60,6 +59,16 @@ const BorderDiv = styled.div`
 const ProjectionSection = styled.div`
   margin-top: 10px;
   padding: 5px 0;
+`;
+
+const ProjectionContainer = styled.div`
+  .axis-title text,
+  .axis-label {
+    fill: ${Colors.black};
+    font-weight: 400;
+    line
+    font-family: "Libre Franklin";
+  }
 `;
 
 const TableCell = styled.td<{ label?: boolean }>`
@@ -110,6 +119,27 @@ interface Props {
   rtData: RtData | RtError | undefined;
 }
 
+interface FacilityProps {
+  projectionData: CurveData | undefined;
+}
+
+const FacilityProjections: React.FC<FacilityProps> = ({ projectionData }) => {
+  return (
+    <>
+      <ChartArea
+        projectionData={projectionData}
+        initialCurveToggles={initialPublicCurveToggles}
+        markColors={markColors}
+      />
+    </>
+  );
+};
+
+interface Props {
+  facility: Facility;
+  rtData: RtData | RtError | undefined;
+}
+
 const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
   const projectionData = useProjectionData(
     useEpidemicModelState(),
@@ -122,10 +152,14 @@ const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
   const incarceratedData = buildIncarceratedData(incarcerated);
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
   return (
-    <FacilitySummaryRowContainer>
+    <>
       <FacilityName>{facility.name}</FacilityName>
       Facility-Specific Projection
       <ProjectionSection>
+        <ProjectionContainer>
+          <FacilityProjections projectionData={projectionData} />
+        </ProjectionContainer>
+
         <Heading>Incarcerated Population Projection</Heading>
         <Table>
           <tbody>
@@ -143,7 +177,7 @@ const FacilitySummaryRow: React.FC<Props> = ({ facility, rtData }) => {
           </tbody>
         </Table>
       </ProjectionSection>
-    </FacilitySummaryRowContainer>
+    </>
   );
 };
 


### PR DESCRIPTION
## Add Facility Rt Chart to Weekly Snapshot

> Needed to shorten the duration of the projections to 3 weeks and change the fonts/colors according to the [mocks](https://www.figma.com/file/eDBdRECHwIwIo8APJlWTBN/Reports%2C-Weekly-snapshots?node-id=1%3A802) for the weekly snapshot

Testing: 
<img width="1194" alt="Screen Shot 2020-07-07 at 6 55 35 PM" src="https://user-images.githubusercontent.com/29155017/86857173-8d2ce580-c083-11ea-8a85-cd7379e07753.png">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #579

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
