### PR TITLE
Add Per Capita and State Stats to Weekly Snapshot

### DIFF
--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -349,7 +349,7 @@ const casesKeys: (keyof ModelInputsPopulationBrackets)[] = [
   "staffCases",
 ];
 
-const incarceratedPopulationKeys: (keyof ModelInputsPopulationBrackets)[] = [
+export const incarceratedPopulationKeys: (keyof ModelInputsPopulationBrackets)[] = [
   "age0Population",
   "age20Population",
   "age45Population",

--- a/src/locale-data-context/LocaleDataContext.tsx
+++ b/src/locale-data-context/LocaleDataContext.tsx
@@ -14,6 +14,7 @@ export type LocaleRecord = {
   icuBeds: number;
   totalPrisonPopulation?: number;
   totalJailPopulation?: number;
+  totalDeaths?: number;
 };
 
 export type LocaleData = Map<string, Map<string, LocaleRecord>>;
@@ -101,6 +102,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
               numeral(row["Total Incarcerated Population"]).value() || 0;
             const totalPopulation: number =
               numeral(row["Total Population"]).value() || 0;
+            const totalDeaths: number = numeral(row["deaths"]).value() || 0;
 
             return {
               county: row.County,
@@ -118,6 +120,7 @@ export const LocaleDataProvider: React.FC<{ children: React.ReactNode }> = ({
               icuBeds: numeral(row["ICU Beds"]).value() || 0,
               ...(totalPrisonPopulation && { totalPrisonPopulation }),
               ...(totalJailPopulation && { totalJailPopulation }),
+              totalDeaths: totalDeaths,
             };
           }).filter((row) => row !== undefined);
 

--- a/src/page-weekly-snapshot/LocaleSummary.tsx
+++ b/src/page-weekly-snapshot/LocaleSummary.tsx
@@ -34,12 +34,6 @@ type PerCapitaCountyCase = {
   casesIncreasePerCapita: number | undefined;
 };
 
-type StateMetrics = {
-  stateName: string;
-  casesPerCapita: number | undefined;
-  deathsPerCapita: number | undefined;
-};
-
 function getDay(nytData: NYTCountyRecord[] | NYTStateRecord[], day: number) {
   if (day === 1) {
     return minBy(nytData, (d: NYTCountyRecord | NYTStateRecord) => d.date);

--- a/src/page-weekly-snapshot/LocaleSummary.tsx
+++ b/src/page-weekly-snapshot/LocaleSummary.tsx
@@ -392,13 +392,7 @@ export default function LocaleSummary() {
                       ? formatNumber(totalBeds)
                       : "?"}
                   </li>
-                  {/* <li>Counties to watch: {countiesToWatch?.join(" ")}</li>
-                <li>cases per capita: {casesPerCapita}</li>
-                <li>cases per capita rank: {casesPerCapitaRank}</li>
-                <li>deaths per capita: {deathsPerCapita}</li>
-                <li>deaths per capita rank : {deathsPerCapitaRank}</li>
-                <li>incarcerated cases per capita: {incarceratedCasesPerCapita}</li>
-                <li>incarcerated deaths per capita: {incarceratedDeathsPerCapita}</li>                */}
+                  <li>Counties to watch: {countiesToWatch?.join(" ")}</li>
                 </LocaleStatsList>
               </LocaleStats>
             )}

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -1,0 +1,389 @@
+import { sum } from "d3-array";
+import { orderBy } from "lodash";
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import Colors, { MarkColors as markColors } from "../design-system/Colors";
+import { Column, PageContainer } from "../design-system/PageColumn";
+import { useFacilities } from "../facilities-context";
+import {
+  formatThousands,
+  TableRow,
+} from "../impact-dashboard/ImpactProjectionTable";
+import {
+  LocaleData,
+  LocaleDataProvider,
+  LocaleRecord,
+  useLocaleDataState,
+} from "../locale-data-context";
+import { Facility } from "../page-multi-facility/types";
+
+const HorizontalRule = styled.hr`
+  border-color: ${Colors.opacityGray};
+  margin: 10px 0;
+`;
+
+export const Table = styled.table`
+  color: ${Colors.black};
+  text-align: left;
+  width: 100%;
+  margin-top: 10px;
+`;
+
+const TableHeadingCell = styled.td`
+  font-family: "Poppins", sans serif;
+  line-height: 24px;
+  margin-right: 5px;
+  vertical-align: middle;
+`;
+
+const BorderDiv = styled.div`
+  border-top: 2px solid ${Colors.darkGray};
+  margin-right: 5px;
+`;
+
+const ProjectionSection = styled.div`
+  margin-top: 10px;
+  padding: 5px 0;
+`;
+
+const ProjectionContainer = styled.div`
+  .axis-title text,
+  .axis-label {
+    fill: ${Colors.black};
+    font-family: "Libre Franklin";
+  }
+`;
+
+const TableCell = styled.td<{ label?: boolean }>`
+    font-size: 13px;
+    line-height: 200%;
+    text-align: "left"};
+    opacity: 0.7;
+    border-top: 1px solid  ${Colors.darkGray};
+    vertical-align: middle;
+    width: ${(props) => (props.label ? "200px" : "auto")};
+    `;
+
+type StateMetrics = {
+  stateName: string;
+  casesPerCapita: number | undefined;
+  deathsPerCapita: number | undefined;
+};
+
+const POPULATION_SIZE = 100000;
+
+function getPerCapita(
+  numerator: number | undefined,
+  denominator: number | undefined,
+) {
+  let result = 0;
+  if (numerator && denominator) {
+    result = Math.round((numerator / denominator) * POPULATION_SIZE);
+  }
+  return result;
+}
+
+function getCurrentStateData(stateMetrics: StateMetrics[], stateName: string) {
+  for (let i = 0; i < stateMetrics.length; i++) {
+    if (stateMetrics[i].stateName === stateName) {
+      return stateMetrics[i];
+    }
+  }
+  return undefined;
+}
+
+function getAllStateData(localeData: LocaleData, stateNames: string[]) {
+  const stateMetrics: StateMetrics[] = [];
+  // D.C. isn't a state!
+  stateNames = stateNames.filter((item) => item !== "District of Columbia");
+
+  for (let i = 0; i < stateNames.length; i++) {
+    const localeDataStateTotal = localeData?.get(stateNames[i])?.get("Total");
+    // console.log(localeDataStateTotal);
+    if (localeDataStateTotal) {
+      const totalCases = localeDataStateTotal["reportedCases"];
+      const totalPopulation = localeDataStateTotal["totalPopulation"];
+      const totalDeaths = localeDataStateTotal["totalDeaths"];
+      const casesPerCapita = getPerCapita(totalCases, totalPopulation);
+      const deathsPerCapita = getPerCapita(totalDeaths, totalPopulation);
+      stateMetrics.push({
+        stateName: stateNames[i],
+        casesPerCapita: casesPerCapita,
+        deathsPerCapita: deathsPerCapita,
+      });
+    }
+  }
+  return stateMetrics;
+}
+
+function getStateTotalCasesRank(
+  stateTotals: StateMetrics[],
+  selectedState: string | undefined,
+) {
+  const rankedStates = orderBy(
+    stateTotals.filter((c) => !!c.casesPerCapita),
+    ["casesPerCapita"],
+    ["desc"],
+  );
+
+  for (let i = 0; i < rankedStates.length; i++) {
+    const currState = rankedStates[i];
+    if (
+      selectedState &&
+      currState.stateName === selectedState &&
+      currState.casesPerCapita
+    ) {
+      return [currState.casesPerCapita, i + 1];
+    }
+  }
+  return [undefined, undefined];
+}
+
+function getStateTotalDeathsRank(
+  stateTotals: StateMetrics[],
+  selectedState: string | undefined,
+) {
+  const rankedStates = orderBy(
+    stateTotals.filter((c) => !!c.deathsPerCapita),
+    ["deathsPerCapita"],
+    ["desc"],
+  );
+
+  for (let i = 0; i < rankedStates.length; i++) {
+    const currState = rankedStates[i];
+    if (
+      selectedState &&
+      currState.stateName === selectedState &&
+      currState.deathsPerCapita
+    ) {
+      return [currState.deathsPerCapita, i + 1];
+    }
+  }
+  return [undefined, undefined];
+}
+
+function getTotalIncarceratedPopulation(facilities: Facility[]) {
+  let result = 0;
+  let hasPopulationData = true;
+  for (let i = 0; i < facilities.length; i++) {
+    const {
+      ageUnknownPopulation,
+      age0Population,
+      age20Population,
+      age45Population,
+      age55Population,
+      age65Population,
+      age75Population,
+      age85Population,
+    } = facilities[i].modelInputs;
+    let ageKnownCaseData = [
+      ageUnknownPopulation,
+      age0Population,
+      age20Population,
+      age45Population,
+      age55Population,
+      age65Population,
+      age75Population,
+      age85Population,
+    ];
+    ageKnownCaseData = ageKnownCaseData.filter((data) => data !== undefined);
+    // TODO: user has no case data
+    if (ageKnownCaseData.length === 0) {
+      hasPopulationData = false;
+    }
+    result += sum(ageKnownCaseData);
+  }
+  return result;
+}
+
+function getTotalIncarceratedCases(facilities: Facility[]) {
+  let result = 0;
+  let hasCaseData = true;
+  for (let i = 0; i < facilities.length; i++) {
+    const {
+      ageUnknownCases,
+      age0Cases,
+      age20Cases,
+      age45Cases,
+      age55Cases,
+      age65Cases,
+      age75Cases,
+      age85Cases,
+    } = facilities[i].modelInputs;
+    let ageKnownCaseData = [
+      ageUnknownCases,
+      age0Cases,
+      age20Cases,
+      age45Cases,
+      age55Cases,
+      age65Cases,
+      age75Cases,
+      age85Cases,
+    ];
+    ageKnownCaseData = ageKnownCaseData.filter((data) => data !== undefined);
+    // TODO: user has no case data
+    if (ageKnownCaseData.length === 0) {
+      hasCaseData = false;
+    }
+    result += sum(ageKnownCaseData);
+  }
+  return result;
+}
+
+function getTotalIncarceratedDeaths(facilities: Facility[]) {
+  let result = 0;
+  let hasDeathData = true;
+  for (let i = 0; i < facilities.length; i++) {
+    const {
+      ageUnknownDeaths,
+      age0Deaths,
+      age20Deaths,
+      age45Deaths,
+      age55Deaths,
+      age65Deaths,
+      age75Deaths,
+      age85Deaths,
+    } = facilities[i].modelInputs;
+    let ageKnownCaseData = [
+      ageUnknownDeaths,
+      age0Deaths,
+      age20Deaths,
+      age45Deaths,
+      age55Deaths,
+      age65Deaths,
+      age75Deaths,
+      age85Deaths,
+    ];
+    ageKnownCaseData = ageKnownCaseData.filter((data) => data !== undefined);
+    // TODO: user has no case data
+    if (ageKnownCaseData.length === 0) {
+      hasDeathData = false;
+    }
+    result += sum(ageKnownCaseData);
+  }
+  return result;
+}
+
+const LocaleSummaryTable: React.FC<{
+  stateName: string | undefined;
+  stateNames: string[];
+}> = ({ stateName, stateNames }) => {
+  console.log("here");
+  const localeState = useLocaleDataState();
+  const localeData = localeState.data;
+  const {
+    state: { loading, facilities: facilitiesState, rtData },
+  } = useFacilities();
+  const facilities = Object.values(facilitiesState);
+
+  // const [casesPerCapita, setCasesPerCapita] = useState<number | undefined>();
+  // const [casesPerCapitaRank, setCasesPerCapitaRank] = useState<
+  //   number | undefined
+  // >();
+  // const [incarceratedCasesPerCapita, setIncarceratedCasesPerCapita] = useState<
+  //   number | undefined
+  // >();
+  // const [deathsPerCapita, setDeathsPerCapita] = useState<number | undefined>();
+  // const [deathsPerCapitaRank, setDeathsPerCapitaRank] = useState<
+  //   number | undefined
+  // >();
+  // const [
+  //   incarceratedDeathsPerCapita,
+  //   setIncarceratedDeathsPerCapita,
+  // ] = useState<number | undefined>();
+
+  let incarceratedCasesPerCapita = 0;
+
+  const allStateMetrics = getAllStateData(localeData, stateNames);
+  if (stateName) {
+    const currStateMetrics = getCurrentStateData(allStateMetrics, stateName);
+    const selectedStateCasesRank = getStateTotalCasesRank(
+      allStateMetrics,
+      stateName,
+    );
+
+    //   setCasesPerCapita(selectedStateCasesRank[0]);
+    //   setCasesPerCapitaRank(selectedStateCasesRank[1]);
+
+    const selectedStateDeathsRank = getStateTotalDeathsRank(
+      allStateMetrics,
+      stateName,
+    );
+    //   setDeathsPerCapita(selectedStateDeathsRank[0]);
+    //   setDeathsPerCapitaRank(selectedStateDeathsRank[1]);
+    const totalIncarceratedCases = getTotalIncarceratedCases(facilities);
+    const totalIncarceratedDeaths = getTotalIncarceratedDeaths(facilities);
+    const totalIncarceratedPopulation = getTotalIncarceratedPopulation(
+      facilities,
+    );
+    incarceratedCasesPerCapita = getPerCapita(
+      totalIncarceratedCases,
+      totalIncarceratedPopulation,
+    );
+    const incarceratedDeathsPerCapita = getPerCapita(
+      totalIncarceratedDeaths,
+      totalIncarceratedPopulation,
+    );
+    //   setIncarceratedCasesPerCapita(incarceratedCasesPerCapita);
+    //   setIncarceratedDeathsPerCapita(incarceratedDeathsPerCapita);
+  }
+
+  return (
+    <PageContainer>
+      <HorizontalRule />
+      <Column>
+        <Table>
+          <tbody>
+            <tr>
+              <td />
+              <TableHeadingCell>
+                Cases (per 100k)
+                <tr>
+                  <TableCell label>Incarcerated Cases</TableCell>
+                </tr>
+                <tr>
+                  <TableCell>
+                    {formatThousands(incarceratedCasesPerCapita)}
+                  </TableCell>
+                </tr>
+                <tr>
+                  <TableCell label>Overall State Cases</TableCell>
+                </tr>
+                {/* <tr>
+              <TableCell>{formatThousands(casesPerCapita)}</TableCell>
+            </tr> */}
+              </TableHeadingCell>
+            </tr>
+          </tbody>
+        </Table>
+      </Column>
+      <Column>
+        <Table>
+          <tbody>
+            <tr>
+              <td />
+              <TableHeadingCell>
+                Fatalities (per 100k)
+                <tr>
+                  <TableCell label>Incarcerated Fatalities</TableCell>
+                </tr>
+                {/* <tr>
+                <TableCell>{formatThousands(incarceratedDeathsPerCapita)}</TableCell>
+              </tr> */}
+                <tr>
+                  <TableCell label>Overall State Fatalities</TableCell>
+                </tr>
+                {/* <tr>
+                <TableCell>{formatThousands(deathsPerCapita)}</TableCell>
+              </tr> */}
+              </TableHeadingCell>
+            </tr>
+          </tbody>
+        </Table>
+      </Column>
+    </PageContainer>
+  );
+};
+
+export default LocaleSummaryTable;

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -79,7 +79,6 @@ const TableCell = styled.td<{ label?: boolean }>`
   font-size: 11px;
   line-height: 200%;
   text-align: "left";
-  opacity: 0.7;
   width: ${(props) => (props.label ? "200px" : "auto")};
 `;
 
@@ -145,7 +144,7 @@ function getAllStateData(localeData: LocaleData, stateNames: string[]) {
 
 function getStateRank(
   stateTotals: StateMetrics[],
-  selectedState: string | undefined,
+  selectedStateName: string | undefined,
   filterValue: string,
 ) {
   const rankedStates = orderBy(
@@ -158,8 +157,8 @@ function getStateRank(
     const currState = rankedStates[i];
     const currStateDataPerCapita = get(currState, filterValue);
     if (
-      selectedState &&
-      currState.stateName === selectedState &&
+      selectedStateName &&
+      currState.stateName === selectedStateName &&
       currStateDataPerCapita
     ) {
       return [currStateDataPerCapita, i + 1];
@@ -289,8 +288,8 @@ const LocaleSummaryTable: React.FC<{
 
   const allStateMetrics = getAllStateData(localeData, stateNames);
 
-  // TODO: currently getting state name from the drop down but might
-  // need to get this some other way when/if that changes
+  // TODO: currently getting state name from the drop down
+  // will need to update whenever that changes
   if (stateName) {
     const selectedStateCasesRank = getStateRank(
       allStateMetrics,

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -67,7 +67,7 @@ const RightRank = styled.div`
 
 const LeftRank = styled.div`
   text-align: left;
-  margin-top: 15px;
+  margin-top: 20px;
 `;
 
 const BorderDiv = styled.div`
@@ -149,8 +149,6 @@ function getAllStateData(localeData: LocaleData, stateNames: string[]) {
   }
   return stateMetrics;
 }
-
-// TODO: code cleanup in this function
 
 function getStateRank(
   stateTotals: StateMetrics[],

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -28,14 +28,28 @@ export const Table = styled.table`
 `;
 
 const TableHeadingCell = styled.td`
-  font-family: "Poppins", sans serif;
-  line-height: 24px;
-  margin-right: 5px;
+  font-family: "Libre Franklin";
+  font-weight: bold;
+  font-size: 11px;
+  line-height: 13px;
   vertical-align: middle;
 `;
 
+const Right = styled.div`
+  text-align: right;
+`;
+const Left = styled.div`
+  text-align: left;
+`;
+
+const TextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
 const BorderDiv = styled.div`
-  border-top: 2px solid ${Colors.darkGray};
+  border-top: 2px solid ${Colors.black};
   margin-right: 5px;
 `;
 
@@ -58,6 +72,15 @@ const TableCell = styled.td<{ label?: boolean }>`
     text-align: "left"};
     opacity: 0.7;
     border-top: 1px solid  ${Colors.darkGray};
+    vertical-align: middle;
+    width: ${(props) => (props.label ? "200px" : "auto")};
+    `;
+
+const TableNumberCell = styled.td<{ label?: boolean }>`
+    font-size: 24px;
+    font-family: "Libre Baskerville";
+    line-height: 200%;
+    text-align: "left"};
     vertical-align: middle;
     width: ${(props) => (props.label ? "200px" : "auto")};
     `;
@@ -123,7 +146,7 @@ function getStateRank(
   const rankedStates = orderBy(
     stateTotals.filter((c) => !!get(c, filterValue)),
     [filterValue],
-    ["desc"],
+    ["asc"],
   );
 
   for (let i = 0; i < rankedStates.length; i++) {
@@ -144,10 +167,9 @@ function getTotalIncarceratedValue(facilities: Facility[], value: string) {
   let result = 0;
   let hasData = false;
   const valueKeys = get(VALUE_MAPPING, value);
-  console.log(facilities);
   for (let i = 0; i < facilities.length; i++) {
     const modelInputs = facilities[i].modelInputs;
-    let data = omit(
+    const data = omit(
       pick(modelInputs, valueKeys),
       "staffDeaths",
       "staffRecovered",
@@ -158,7 +180,7 @@ function getTotalIncarceratedValue(facilities: Facility[], value: string) {
     }
     result += sum(values(data));
   }
-  const incarceratedData = {
+  const incarceratedData: incarceratedData = {
     incarceratedData: result,
     hasData: hasData,
   };
@@ -172,13 +194,15 @@ function makeIncarceratedDeathsRow(
   if (hasDeathData) {
     return (
       <tr>
-        <TableCell>{formatThousands(incarceratedDeathsPerCapita)}</TableCell>
+        <TableNumberCell>
+          {formatThousands(incarceratedDeathsPerCapita)}
+        </TableNumberCell>
       </tr>
     );
   } else {
     return (
       <tr>
-        <TableCell>???</TableCell>
+        <TableNumberCell>???</TableNumberCell>
       </tr>
     );
   }
@@ -241,7 +265,6 @@ const LocaleSummaryTable: React.FC<{
       totalIncarceratedCases.incarceratedData,
       totalIncarceratedPopulation.incarceratedData,
     );
-    console.log(totalIncarceratedDeaths);
     incarceratedDeathsPerCapita = getPerCapita(
       totalIncarceratedDeaths.incarceratedData,
       totalIncarceratedPopulation.incarceratedData,
@@ -251,31 +274,38 @@ const LocaleSummaryTable: React.FC<{
 
   return (
     <PageContainer>
-      <HorizontalRule />
       <Column>
         <Table>
           <tbody>
+            <td />
+            <TableHeadingCell>
+              <TextContainer>
+                <Right>Cases </Right>
+                <Left>(per 100k)</Left>
+              </TextContainer>
+            </TableHeadingCell>
             <tr>
-              <td />
-              <TableHeadingCell>
-                Cases (per 100k)
-                <tr>
-                  <TableCell label>Incarcerated Cases</TableCell>
-                </tr>
-                <tr>
-                  <TableCell>
-                    {formatThousands(incarceratedCasesPerCapita)}
-                  </TableCell>
-                </tr>
-                <tr>
-                  <TableCell label>Overall State Cases</TableCell>
-                </tr>
-                <tr>
-                  <TableCell>
-                    {formatThousands(casesPerCapita)} {casesPerCapitaRank} of 50
-                  </TableCell>
-                </tr>
-              </TableHeadingCell>
+              <TableCell>Incarcerated Cases</TableCell>
+            </tr>
+            <tr>
+              <TableNumberCell>
+                {formatThousands(incarceratedCasesPerCapita)}
+              </TableNumberCell>
+            </tr>
+            <tr>
+              <TableCell>Overall State Cases</TableCell>
+            </tr>
+            <tr>
+              <TableCell>
+                <TextContainer>
+                  <Right>
+                    <TableNumberCell>
+                      {formatThousands(casesPerCapita)}
+                    </TableNumberCell>
+                  </Right>
+                  <Left>{casesPerCapitaRank} lowest of 50</Left>
+                </TextContainer>
+              </TableCell>
             </tr>
           </tbody>
         </Table>
@@ -283,32 +313,37 @@ const LocaleSummaryTable: React.FC<{
       <Column>
         <Table>
           <tbody>
+            <td />
             <tr>
-              <td />
               <TableHeadingCell>
-                Fatalities (per 100k)
-                <tr>
-                  <TableCell label>Incarcerated Fatalities</TableCell>
-                </tr>
-                {makeIncarceratedDeathsRow(
-                  hasDeathData,
-                  incarceratedDeathsPerCapita,
-                )}
-                {/* <tr>
-                  <TableCell>
-                    {formatThousands(incarceratedDeathsPerCapita)}
-                  </TableCell>
-                </tr> */}
-                <tr>
-                  <TableCell label>Overall State Fatalities</TableCell>
-                </tr>
-                <tr>
-                  <TableCell>
-                    {formatThousands(deathsPerCapita)} {deathsPerCapitaRank} of
-                    50
-                  </TableCell>
-                </tr>
+                <TextContainer>
+                  <Right>Fatalities </Right>
+                  <Left>(per 100k)</Left>
+                </TextContainer>
               </TableHeadingCell>
+            </tr>
+
+            <tr>
+              <TableCell>Incarcerated Fatalities</TableCell>
+            </tr>
+            {makeIncarceratedDeathsRow(
+              hasDeathData,
+              incarceratedDeathsPerCapita,
+            )}
+            <tr>
+              <TableCell>Overall State Fatalities</TableCell>
+            </tr>
+            <tr>
+              <TableCell>
+                <TextContainer>
+                  <Right>
+                    <TableNumberCell>
+                      {formatThousands(deathsPerCapita)}
+                    </TableNumberCell>
+                  </Right>
+                  <Left>{deathsPerCapitaRank} lowest of 50</Left>
+                </TextContainer>
+              </TableCell>
             </tr>
           </tbody>
         </Table>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -15,16 +15,15 @@ import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import { Facility } from "../page-multi-facility/types";
 
-const HorizontalRule = styled.hr`
-  border-color: ${Colors.opacityGray};
-  margin: 10px 0;
-`;
-
 export const Table = styled.table`
   color: ${Colors.black};
   text-align: left;
   width: 100%;
   margin-top: 10px;
+`;
+
+const HorizontalRule = styled.hr`
+  border-color: ${Colors.opacityGray};
 `;
 
 const TableHeadingCell = styled.td`
@@ -37,44 +36,33 @@ const TableHeadingCell = styled.td`
 
 const Right = styled.div`
   text-align: right;
+  margin-bottom: -20px;
 `;
+
 const Left = styled.div`
   text-align: left;
+  margin-top: 20px;
 `;
 
 const TextContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 10px;
+  flex-direction: bottom;
 `;
 
 const BorderDiv = styled.div`
   border-top: 2px solid ${Colors.black};
-  margin-right: 5px;
-`;
-
-const ProjectionSection = styled.div`
-  margin-top: 10px;
-  padding: 5px 0;
-`;
-
-const ProjectionContainer = styled.div`
-  .axis-title text,
-  .axis-label {
-    fill: ${Colors.black};
-    font-family: "Libre Franklin";
-  }
 `;
 
 const TableCell = styled.td<{ label?: boolean }>`
-    font-size: 13px;
-    line-height: 200%;
-    text-align: "left"};
-    opacity: 0.7;
-    border-top: 1px solid  ${Colors.darkGray};
-    vertical-align: middle;
-    width: ${(props) => (props.label ? "200px" : "auto")};
-    `;
+  font-size: 13px;
+  line-height: 200%;
+  text-align: "left";
+  opacity: 0.7;
+  width: ${(props) => (props.label ? "200px" : "auto")};
+`;
 
 const TableNumberCell = styled.td<{ label?: boolean }>`
     font-size: 24px;
@@ -145,6 +133,8 @@ function getAllStateData(localeData: LocaleData, stateNames: string[]) {
   return stateMetrics;
 }
 
+// TODO: code cleanup in this function
+
 function getStateRank(
   stateTotals: StateMetrics[],
   selectedState: string | undefined,
@@ -194,15 +184,15 @@ function getTotalIncarceratedValue(facilities: Facility[], value: string) {
   return incarceratedData;
 }
 
-function makeIncarceratedDeathsRow(
-  hasDeathData: boolean,
-  incarceratedDeathsPerCapita: number,
+function makeIncarceratedDataRow(
+  hasData: boolean,
+  incarceratedDataPerCapita: number,
 ) {
-  if (hasDeathData) {
+  if (hasData) {
     return (
       <tr>
         <TableNumberCell>
-          {formatThousands(incarceratedDeathsPerCapita)}
+          {formatThousands(incarceratedDataPerCapita)}
         </TableNumberCell>
       </tr>
     );
@@ -214,6 +204,16 @@ function makeIncarceratedDeathsRow(
     );
   }
 }
+
+// function makeTableColumns(
+//   heading: string,
+//   incarceratedData: number,
+//   stateData: number,
+//   stateRank: number,
+//   isDeathColumn: boolean
+// ) {
+
+// }
 
 const LocaleSummaryTable: React.FC<{
   stateName: string | undefined;
@@ -293,16 +293,25 @@ const LocaleSummaryTable: React.FC<{
                 </TextContainer>
               </TableHeadingCell>
             </tr>
+            <BorderDiv />
+
             <tr>
-              <TableCell>Incarcerated Cases</TableCell>
+              <TableCell>
+                Incarcerated Cases
+                <HorizontalRule />
+              </TableCell>
             </tr>
             <tr>
               <TableNumberCell>
                 {formatThousands(incarceratedCasesPerCapita)}
               </TableNumberCell>
             </tr>
+            <BorderDiv />
             <tr>
-              <TableCell>Overall State Cases</TableCell>
+              <TableCell>
+                Overall State Cases
+                <HorizontalRule />
+              </TableCell>
             </tr>
             <tr>
               <TableCell>
@@ -333,16 +342,21 @@ const LocaleSummaryTable: React.FC<{
                 </TextContainer>
               </TableHeadingCell>
             </tr>
+            <BorderDiv />
+            <tr>
+              <TableCell>
+                Incarcerated Fatalities
+                <HorizontalRule />
+              </TableCell>
+            </tr>
+            {makeIncarceratedDataRow(hasDeathData, incarceratedDeathsPerCapita)}
+            <BorderDiv />
 
             <tr>
-              <TableCell>Incarcerated Fatalities</TableCell>
-            </tr>
-            {makeIncarceratedDeathsRow(
-              hasDeathData,
-              incarceratedDeathsPerCapita,
-            )}
-            <tr>
-              <TableCell>Overall State Fatalities</TableCell>
+              <TableCell>
+                Overall State Fatalities
+                <HorizontalRule />
+              </TableCell>
             </tr>
             <tr>
               <TableCell>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -97,12 +97,19 @@ type incarceratedData = {
 };
 
 const POPULATION_SIZE = 100000;
+const NUM_STATES = 50;
 
 const VALUE_MAPPING = {
   deaths: deathBracketKeys,
   cases: caseBracketKeys,
   population: incarceratedPopulationKeys,
 };
+
+function formatOrdinal(value: number) {
+  let suffix = ["th", "st", "nd", "rd"],
+    rem = value % 100;
+  return value + (suffix[(rem - 20) % 10] || suffix[rem] || suffix[0]);
+}
 
 function getPerCapita(
   numerator: number | undefined,
@@ -278,12 +285,14 @@ const LocaleSummaryTable: React.FC<{
         <Table>
           <tbody>
             <td />
-            <TableHeadingCell>
-              <TextContainer>
-                <Right>Cases </Right>
-                <Left>(per 100k)</Left>
-              </TextContainer>
-            </TableHeadingCell>
+            <tr>
+              <TableHeadingCell>
+                <TextContainer>
+                  <Right>Cases </Right>
+                  <Left>(per 100k)</Left>
+                </TextContainer>
+              </TableHeadingCell>
+            </tr>
             <tr>
               <TableCell>Incarcerated Cases</TableCell>
             </tr>
@@ -303,7 +312,9 @@ const LocaleSummaryTable: React.FC<{
                       {formatThousands(casesPerCapita)}
                     </TableNumberCell>
                   </Right>
-                  <Left>{casesPerCapitaRank} lowest of 50</Left>
+                  <Left>
+                    {formatOrdinal(casesPerCapitaRank)} lowest of {NUM_STATES}
+                  </Left>
                 </TextContainer>
               </TableCell>
             </tr>
@@ -341,7 +352,9 @@ const LocaleSummaryTable: React.FC<{
                       {formatThousands(deathsPerCapita)}
                     </TableNumberCell>
                   </Right>
-                  <Left>{deathsPerCapitaRank} lowest of 50</Left>
+                  <Left>
+                    {formatOrdinal(deathsPerCapitaRank)} lowest of {NUM_STATES}
+                  </Left>
                 </TextContainer>
               </TableCell>
             </tr>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -53,6 +53,7 @@ const TextContainer = styled.div`
 
 const TextContainerRank = styled.div`
   width: 100%;
+  margin-top: 15px;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
@@ -67,7 +68,7 @@ const RightRank = styled.div`
 
 const LeftRank = styled.div`
   text-align: left;
-  margin-top: 20px;
+  margin-bottom: -5px;
 `;
 
 const BorderDiv = styled.div`
@@ -75,7 +76,7 @@ const BorderDiv = styled.div`
 `;
 
 const TableCell = styled.td<{ label?: boolean }>`
-  font-size: 13px;
+  font-size: 11px;
   line-height: 200%;
   text-align: "left";
   opacity: 0.7;

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -83,14 +83,6 @@ const TableCell = styled.td<{ label?: boolean }>`
   width: ${(props) => (props.label ? "200px" : "auto")};
 `;
 
-const TableNumberCell = styled.td<{ label?: boolean }>`
-  font-size: 24px;
-  font-family: "Libre Baskerville";
-  line-height: 200%;
-  text-align: "left";
-  width: auto;
-`;
-
 type StateMetrics = {
   stateName: string;
   casesPerCapita: number | undefined;

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -36,39 +36,39 @@ const TableHeadingCell = styled.td`
   vertical-align: middle;
 `;
 
-const Right = styled.div`
+const RightHeading = styled.div`
   text-align: right;
 `;
 
-const Left = styled.div`
+const LeftHeading = styled.div`
   text-align: left;
 `;
 
-const TextContainer = styled.div`
+const TextContainerHeading = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;
 `;
 
-const TextContainerRank = styled.div`
+const TextContainer = styled.div`
   width: 100%;
-  margin-top: 15px;
+  margin: 15px 0 15px;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
   color: ${Colors.black};
 `;
 
-const RightRank = styled.div`
+const Right = styled.div`
   text-align: right;
-  font-size: 24px;
-  font-family: "Libre Baskerville";
+  margin-bottom: -5px;
 `;
 
-const LeftRank = styled.div`
+const Left = styled.div`
   text-align: left;
-  margin-bottom: -5px;
+  font-size: 24px;
+  font-family: "Libre Baskerville";
 `;
 
 const BorderDiv = styled.div`
@@ -207,15 +207,17 @@ function makeIncarceratedDataRow(
   if (hasData) {
     return (
       <tr>
-        <TableNumberCell>
-          {formatThousands(incarceratedDataPerCapita)}
-        </TableNumberCell>
+        <TextContainer>
+          <Left>{formatThousands(incarceratedDataPerCapita)}</Left>
+        </TextContainer>
       </tr>
     );
   } else {
     return (
       <tr>
-        <TableNumberCell>???</TableNumberCell>
+        <TextContainer>
+          <Left>???</Left>
+        </TextContainer>
       </tr>
     );
   }
@@ -236,10 +238,10 @@ function makeTableColumn(
     <>
       <tr>
         <TableHeadingCell>
-          <TextContainer>
-            <Right>{heading} </Right>
-            <Left>(per 100k)</Left>
-          </TextContainer>
+          <TextContainerHeading>
+            <RightHeading>{heading} </RightHeading>
+            <LeftHeading>(per 100k)</LeftHeading>
+          </TextContainerHeading>
         </TableHeadingCell>
       </tr>
       <BorderDiv />
@@ -259,12 +261,12 @@ function makeTableColumn(
       </tr>
       <tr>
         <TableCell>
-          <TextContainerRank>
-            <RightRank>{formatThousands(stateData)}</RightRank>
-            <LeftRank>
+          <TextContainer>
+            <Left>{formatThousands(stateData)}</Left>
+            <Right>
               {formatOrdinal(stateRank)} lowest of {NUM_STATES}
-            </LeftRank>
-          </TextContainerRank>
+            </Right>
+          </TextContainer>
         </TableCell>
       </tr>
     </>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -21,11 +21,10 @@ const Table = styled.table`
   width: 100%;
   margin-top: 10px;
 `;
-
-const HorizontalRule = styled.hr<{ width?: string; marginLeft?: string }>`
+const HorizontalRule = styled.hr`
   border-color: ${Colors.black};
-  width: ${(props) => props.width || "100%"};
-  margin-left: ${(props) => props.marginLeft || "0"};
+  width: 100%;
+  margin-bottom: 10px;
 `;
 
 const TableHeadingCell = styled.td`
@@ -238,6 +237,7 @@ function makeTableColumn(
     <>
       <tr>
         <TableHeadingCell>
+          <HorizontalRule />
           <TextContainerHeading>
             <Right>{heading} </Right>
             <LeftHeading>(per 100k)</LeftHeading>
@@ -345,7 +345,6 @@ const LocaleSummaryTable: React.FC<{
 
   return (
     <>
-      <HorizontalRule width={"93%"} />
       <PageContainer>
         <Column>
           <Table>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -137,7 +137,7 @@ function getStateTotalCasesRank(
       return [currState.casesPerCapita, i + 1];
     }
   }
-  return [undefined, undefined];
+  return [-1, -1];
 }
 
 function getStateTotalDeathsRank(
@@ -160,7 +160,7 @@ function getStateTotalDeathsRank(
       return [currState.deathsPerCapita, i + 1];
     }
   }
-  return [undefined, undefined];
+  return [-1, -1];
 }
 
 function getTotalIncarceratedPopulation(facilities: Facility[]) {
@@ -269,31 +269,20 @@ const LocaleSummaryTable: React.FC<{
   stateName: string | undefined;
   stateNames: string[];
 }> = ({ stateName, stateNames }) => {
-  console.log("here");
   const localeState = useLocaleDataState();
   const localeData = localeState.data;
   const {
-    state: { loading, facilities: facilitiesState, rtData },
+    state: { facilities: facilitiesState },
   } = useFacilities();
   const facilities = Object.values(facilitiesState);
 
-  // const [casesPerCapita, setCasesPerCapita] = useState<number | undefined>();
-  // const [casesPerCapitaRank, setCasesPerCapitaRank] = useState<
-  //   number | undefined
-  // >();
-  // const [incarceratedCasesPerCapita, setIncarceratedCasesPerCapita] = useState<
-  //   number | undefined
-  // >();
-  // const [deathsPerCapita, setDeathsPerCapita] = useState<number | undefined>();
-  // const [deathsPerCapitaRank, setDeathsPerCapitaRank] = useState<
-  //   number | undefined
-  // >();
-  // const [
-  //   incarceratedDeathsPerCapita,
-  //   setIncarceratedDeathsPerCapita,
-  // ] = useState<number | undefined>();
+  let casesPerCapita = 0;
+  let casesPerCapitaRank = 0;
+  let deathsPerCapita = 0;
+  let deathsPerCapitaRank = 0;
 
   let incarceratedCasesPerCapita = 0;
+  let incarceratedDeathsPerCapita = 0;
 
   const allStateMetrics = getAllStateData(localeData, stateNames);
   if (stateName) {
@@ -303,15 +292,17 @@ const LocaleSummaryTable: React.FC<{
       stateName,
     );
 
-    //   setCasesPerCapita(selectedStateCasesRank[0]);
-    //   setCasesPerCapitaRank(selectedStateCasesRank[1]);
+    casesPerCapita = selectedStateCasesRank?.[0];
+    casesPerCapitaRank = selectedStateCasesRank?.[1];
 
     const selectedStateDeathsRank = getStateTotalDeathsRank(
       allStateMetrics,
       stateName,
     );
-    //   setDeathsPerCapita(selectedStateDeathsRank[0]);
-    //   setDeathsPerCapitaRank(selectedStateDeathsRank[1]);
+
+    deathsPerCapita = selectedStateDeathsRank?.[0];
+    deathsPerCapitaRank = selectedStateDeathsRank?.[1];
+
     const totalIncarceratedCases = getTotalIncarceratedCases(facilities);
     const totalIncarceratedDeaths = getTotalIncarceratedDeaths(facilities);
     const totalIncarceratedPopulation = getTotalIncarceratedPopulation(
@@ -321,12 +312,10 @@ const LocaleSummaryTable: React.FC<{
       totalIncarceratedCases,
       totalIncarceratedPopulation,
     );
-    const incarceratedDeathsPerCapita = getPerCapita(
+    incarceratedDeathsPerCapita = getPerCapita(
       totalIncarceratedDeaths,
       totalIncarceratedPopulation,
     );
-    //   setIncarceratedCasesPerCapita(incarceratedCasesPerCapita);
-    //   setIncarceratedDeathsPerCapita(incarceratedDeathsPerCapita);
   }
 
   return (
@@ -350,9 +339,11 @@ const LocaleSummaryTable: React.FC<{
                 <tr>
                   <TableCell label>Overall State Cases</TableCell>
                 </tr>
-                {/* <tr>
-              <TableCell>{formatThousands(casesPerCapita)}</TableCell>
-            </tr> */}
+                <tr>
+                  <TableCell>
+                    {formatThousands(casesPerCapita)} {casesPerCapitaRank}
+                  </TableCell>
+                </tr>
               </TableHeadingCell>
             </tr>
           </tbody>
@@ -368,15 +359,19 @@ const LocaleSummaryTable: React.FC<{
                 <tr>
                   <TableCell label>Incarcerated Fatalities</TableCell>
                 </tr>
-                {/* <tr>
-                <TableCell>{formatThousands(incarceratedDeathsPerCapita)}</TableCell>
-              </tr> */}
+                <tr>
+                  <TableCell>
+                    {formatThousands(incarceratedDeathsPerCapita)}
+                  </TableCell>
+                </tr>
                 <tr>
                   <TableCell label>Overall State Fatalities</TableCell>
                 </tr>
-                {/* <tr>
-                <TableCell>{formatThousands(deathsPerCapita)}</TableCell>
-              </tr> */}
+                <tr>
+                  <TableCell>
+                    {formatThousands(deathsPerCapita)} {deathsPerCapitaRank}
+                  </TableCell>
+                </tr>
               </TableHeadingCell>
             </tr>
           </tbody>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -15,7 +15,7 @@ import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import { Facility } from "../page-multi-facility/types";
 
-export const Table = styled.table`
+const Table = styled.table`
   color: ${Colors.black};
   text-align: left;
   width: 100%;
@@ -56,7 +56,7 @@ const TextContainerRank = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  color: black;
+  color: ${Colors.black};
 `;
 
 const RightRank = styled.div`
@@ -165,13 +165,13 @@ function getStateRank(
 
   for (let i = 0; i < rankedStates.length; i++) {
     const currState = rankedStates[i];
-    const currStateCasesPerCapita = get(currState, filterValue);
+    const currStateDataPerCapita = get(currState, filterValue);
     if (
       selectedState &&
       currState.stateName === selectedState &&
-      currStateCasesPerCapita
+      currStateDataPerCapita
     ) {
-      return [currStateCasesPerCapita, i + 1];
+      return [currStateDataPerCapita, i + 1];
     }
   }
   return [-1, -1];

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -36,10 +36,6 @@ const TableHeadingCell = styled.td`
   vertical-align: middle;
 `;
 
-const RightHeading = styled.div`
-  text-align: right;
-`;
-
 const LeftHeading = styled.div`
   text-align: left;
 `;
@@ -56,13 +52,12 @@ const TextContainer = styled.div`
   margin: 15px 0 15px;
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: baseline;
   color: ${Colors.black};
 `;
 
 const Right = styled.div`
   text-align: right;
-  margin-bottom: -5px;
 `;
 
 const Left = styled.div`
@@ -230,7 +225,7 @@ function makeTableColumn(
       <tr>
         <TableHeadingCell>
           <TextContainerHeading>
-            <RightHeading>{heading} </RightHeading>
+            <Right>{heading} </Right>
             <LeftHeading>(per 100k)</LeftHeading>
           </TextContainerHeading>
         </TableHeadingCell>

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -23,7 +23,7 @@ const Table = styled.table`
 `;
 
 const HorizontalRule = styled.hr<{ width?: string; marginLeft?: string }>`
-  border-color: ${Colors.opacityGray};
+  border-color: ${Colors.black};
   width: ${(props) => props.width || "100%"};
   margin-left: ${(props) => props.marginLeft || "0"};
 `;

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -298,8 +298,8 @@ const LocaleSummaryTable: React.FC<{
 
   const allStateMetrics = getAllStateData(localeData, stateNames);
 
-  // TODO: currently getting state name from the drop down
-  // will need to update whenever that changes
+  // TODO (per 644): currently getting state name from the drop down;
+  // may need to update this depending on how the logic 644 is implemented
   if (stateName) {
     const selectedStateCasesRank = getStateRank(
       allStateMetrics,

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -22,8 +22,10 @@ export const Table = styled.table`
   margin-top: 10px;
 `;
 
-const HorizontalRule = styled.hr`
+const HorizontalRule = styled.hr<{ width?: string; marginLeft?: string }>`
   border-color: ${Colors.opacityGray};
+  width: ${(props) => props.width || "100%"};
+  margin-left: ${(props) => props.marginLeft || "0"};
 `;
 
 const TableHeadingCell = styled.td`
@@ -36,12 +38,10 @@ const TableHeadingCell = styled.td`
 
 const Right = styled.div`
   text-align: right;
-  margin-bottom: -20px;
 `;
 
 const Left = styled.div`
   text-align: left;
-  margin-top: 20px;
 `;
 
 const TextContainer = styled.div`
@@ -49,7 +49,25 @@ const TextContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 10px;
-  flex-direction: bottom;
+`;
+
+const TextContainerRank = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  color: black;
+`;
+
+const RightRank = styled.div`
+  text-align: right;
+  font-size: 24px;
+  font-family: "Libre Baskerville";
+`;
+
+const LeftRank = styled.div`
+  text-align: left;
+  margin-top: 15px;
 `;
 
 const BorderDiv = styled.div`
@@ -65,13 +83,12 @@ const TableCell = styled.td<{ label?: boolean }>`
 `;
 
 const TableNumberCell = styled.td<{ label?: boolean }>`
-    font-size: 24px;
-    font-family: "Libre Baskerville";
-    line-height: 200%;
-    text-align: "left"};
-    vertical-align: middle;
-    width: ${(props) => (props.label ? "200px" : "auto")};
-    `;
+  font-size: 24px;
+  font-family: "Libre Baskerville";
+  line-height: 200%;
+  text-align: "left";
+  width: auto;
+`;
 
 type StateMetrics = {
   stateName: string;
@@ -205,15 +222,55 @@ function makeIncarceratedDataRow(
   }
 }
 
-// function makeTableColumns(
-//   heading: string,
-//   incarceratedData: number,
-//   stateData: number,
-//   stateRank: number,
-//   isDeathColumn: boolean
-// ) {
-
-// }
+function makeTableColumn(
+  heading: string,
+  incarceratedData: number,
+  stateData: number,
+  stateRank: number,
+  hasData: boolean,
+) {
+  const incarceratedDataRow = makeIncarceratedDataRow(
+    hasData,
+    incarceratedData,
+  );
+  return (
+    <>
+      <tr>
+        <TableHeadingCell>
+          <TextContainer>
+            <Right>{heading} </Right>
+            <Left>(per 100k)</Left>
+          </TextContainer>
+        </TableHeadingCell>
+      </tr>
+      <BorderDiv />
+      <tr>
+        <TableCell>
+          Incarcerated {heading}
+          <HorizontalRule />
+        </TableCell>
+      </tr>
+      {incarceratedDataRow}
+      <BorderDiv />
+      <tr>
+        <TableCell>
+          Overall State {heading}
+          <HorizontalRule />
+        </TableCell>
+      </tr>
+      <tr>
+        <TableCell>
+          <TextContainerRank>
+            <RightRank>{formatThousands(stateData)}</RightRank>
+            <LeftRank>
+              {formatOrdinal(stateRank)} lowest of {NUM_STATES}
+            </LeftRank>
+          </TextContainerRank>
+        </TableCell>
+      </tr>
+    </>
+  );
+}
 
 const LocaleSummaryTable: React.FC<{
   stateName: string | undefined;
@@ -234,9 +291,13 @@ const LocaleSummaryTable: React.FC<{
   let incarceratedCasesPerCapita = 0;
   let incarceratedDeathsPerCapita = 0;
 
+  let hasCaseData = true;
   let hasDeathData = true;
 
   const allStateMetrics = getAllStateData(localeData, stateNames);
+
+  // TODO: currently getting state name from the drop down but might
+  // need to get this some other way when/if that changes
   if (stateName) {
     const selectedStateCasesRank = getStateRank(
       allStateMetrics,
@@ -272,6 +333,7 @@ const LocaleSummaryTable: React.FC<{
       totalIncarceratedCases.incarceratedData,
       totalIncarceratedPopulation.incarceratedData,
     );
+    hasCaseData = totalIncarceratedCases.hasData;
     incarceratedDeathsPerCapita = getPerCapita(
       totalIncarceratedDeaths.incarceratedData,
       totalIncarceratedPopulation.incarceratedData,
@@ -280,102 +342,39 @@ const LocaleSummaryTable: React.FC<{
   }
 
   return (
-    <PageContainer>
-      <Column>
-        <Table>
-          <tbody>
-            <td />
-            <tr>
-              <TableHeadingCell>
-                <TextContainer>
-                  <Right>Cases </Right>
-                  <Left>(per 100k)</Left>
-                </TextContainer>
-              </TableHeadingCell>
-            </tr>
-            <BorderDiv />
-
-            <tr>
-              <TableCell>
-                Incarcerated Cases
-                <HorizontalRule />
-              </TableCell>
-            </tr>
-            <tr>
-              <TableNumberCell>
-                {formatThousands(incarceratedCasesPerCapita)}
-              </TableNumberCell>
-            </tr>
-            <BorderDiv />
-            <tr>
-              <TableCell>
-                Overall State Cases
-                <HorizontalRule />
-              </TableCell>
-            </tr>
-            <tr>
-              <TableCell>
-                <TextContainer>
-                  <Right>
-                    <TableNumberCell>
-                      {formatThousands(casesPerCapita)}
-                    </TableNumberCell>
-                  </Right>
-                  <Left>
-                    {formatOrdinal(casesPerCapitaRank)} lowest of {NUM_STATES}
-                  </Left>
-                </TextContainer>
-              </TableCell>
-            </tr>
-          </tbody>
-        </Table>
-      </Column>
-      <Column>
-        <Table>
-          <tbody>
-            <td />
-            <tr>
-              <TableHeadingCell>
-                <TextContainer>
-                  <Right>Fatalities </Right>
-                  <Left>(per 100k)</Left>
-                </TextContainer>
-              </TableHeadingCell>
-            </tr>
-            <BorderDiv />
-            <tr>
-              <TableCell>
-                Incarcerated Fatalities
-                <HorizontalRule />
-              </TableCell>
-            </tr>
-            {makeIncarceratedDataRow(hasDeathData, incarceratedDeathsPerCapita)}
-            <BorderDiv />
-
-            <tr>
-              <TableCell>
-                Overall State Fatalities
-                <HorizontalRule />
-              </TableCell>
-            </tr>
-            <tr>
-              <TableCell>
-                <TextContainer>
-                  <Right>
-                    <TableNumberCell>
-                      {formatThousands(deathsPerCapita)}
-                    </TableNumberCell>
-                  </Right>
-                  <Left>
-                    {formatOrdinal(deathsPerCapitaRank)} lowest of {NUM_STATES}
-                  </Left>
-                </TextContainer>
-              </TableCell>
-            </tr>
-          </tbody>
-        </Table>
-      </Column>
-    </PageContainer>
+    <>
+      <HorizontalRule width={"93%"} marginLeft={"20px"} />
+      <PageContainer>
+        <Column>
+          <Table>
+            <tbody>
+              <td />
+              {makeTableColumn(
+                "Cases",
+                incarceratedCasesPerCapita,
+                casesPerCapita,
+                casesPerCapitaRank,
+                hasCaseData,
+              )}
+            </tbody>
+          </Table>
+        </Column>
+        <Column>
+          <Table>
+            <tbody>
+              <td />
+              {makeTableColumn(
+                "Fatalities",
+                incarceratedDeathsPerCapita,
+                deathsPerCapita,
+                deathsPerCapitaRank,
+                hasDeathData,
+              )}
+            </tbody>
+          </Table>
+        </Column>
+      </PageContainer>
+    </>
   );
 };
 

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -1,21 +1,13 @@
 import { sum } from "d3-array";
 import { orderBy } from "lodash";
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
-import Colors, { MarkColors as markColors } from "../design-system/Colors";
+import Colors from "../design-system/Colors";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import { useFacilities } from "../facilities-context";
-import {
-  formatThousands,
-  TableRow,
-} from "../impact-dashboard/ImpactProjectionTable";
-import {
-  LocaleData,
-  LocaleDataProvider,
-  LocaleRecord,
-  useLocaleDataState,
-} from "../locale-data-context";
+import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
+import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import { Facility } from "../page-multi-facility/types";
 
 const HorizontalRule = styled.hr`


### PR DESCRIPTION
## Add Per Capita and State Stats to Weekly Snapshot

> Add incarcerated/state cases and fatalities per capita to weekly snapshot.


test:

![image](https://user-images.githubusercontent.com/29155017/87476132-7d655200-c5eb-11ea-942b-9e8fe0c4b466.png)




## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #587

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
