### PR TITLE
Add Facility Summary Stats to Weekly Snapshot

### DIFF
--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -20,6 +20,7 @@ export const getBracketData = (modelInputs: ModelInputs) => {
 export function findMostRecentDate(
   observedAtDate: Date,
   facilityModelVersions: ModelInputs[] | undefined,
+  includeCurrentDate = true,
 ) {
   let mostRecentDate = observedAtDate;
   if (facilityModelVersions) {
@@ -31,7 +32,11 @@ export function findMostRecentDate(
     facilityObservedAtDates.sort((a, b) => a.getTime() - b.getTime());
     // filter to dates earlier than (or the same as) the current date
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
-      return startOfDay(date) < startOfDay(observedAtDate);
+      if (includeCurrentDate) {
+        return startOfDay(date) <= startOfDay(observedAtDate);
+      } else {
+        return startOfDay(date) < startOfDay(observedAtDate);
+      }
     });
     // if there is data for prior dates, use the most recent one, otherwise use
     // the next forward-looking date that we have for the facility

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -17,11 +17,12 @@ export const getBracketData = (modelInputs: ModelInputs) => {
   return pick(modelInputs, populationBracketKeys);
 };
 
-function findMostRecentDate(
+export function findMostRecentDate(
   observedAtDate: Date,
   facilityModelVersions: ModelInputs[] | undefined,
 ) {
   let mostRecentDate = observedAtDate;
+  console.log(mostRecentDate);
   if (facilityModelVersions) {
     // create array of dates with observed data at a given facility
     const facilityObservedAtDates = facilityModelVersions.map(
@@ -31,8 +32,9 @@ function findMostRecentDate(
     facilityObservedAtDates.sort((a, b) => a.getTime() - b.getTime());
     // filter to dates earlier than (or the same as) the current date
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
-      return startOfDay(date) <= startOfDay(observedAtDate);
+      return startOfDay(date) < startOfDay(observedAtDate);
     });
+    console.log(earlierDates);
     // if there is data for prior dates, use the most recent one, otherwise use
     // the next forward-looking date that we have for the facility
     if (earlierDates && earlierDates.length > 0) {
@@ -44,7 +46,7 @@ function findMostRecentDate(
   return mostRecentDate;
 }
 
-const findMatchingDay = ({
+export const findMatchingDay = ({
   date,
   facilityModelVersions,
 }: {

--- a/src/hooks/useAddCasesInputs.tsx
+++ b/src/hooks/useAddCasesInputs.tsx
@@ -22,7 +22,6 @@ export function findMostRecentDate(
   facilityModelVersions: ModelInputs[] | undefined,
 ) {
   let mostRecentDate = observedAtDate;
-  console.log(mostRecentDate);
   if (facilityModelVersions) {
     // create array of dates with observed data at a given facility
     const facilityObservedAtDates = facilityModelVersions.map(
@@ -34,7 +33,6 @@ export function findMostRecentDate(
     const earlierDates = facilityObservedAtDates?.filter(function (date) {
       return startOfDay(date) < startOfDay(observedAtDate);
     });
-    console.log(earlierDates);
     // if there is data for prior dates, use the most recent one, otherwise use
     // the next forward-looking date that we have for the facility
     if (earlierDates && earlierDates.length > 0) {

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -360,7 +360,7 @@ export const incarceratedPopulationKeys: (keyof ModelInputsPopulationBrackets)[]
   "ageUnknownPopulation",
 ];
 
-const populationKeys: (keyof ModelInputsPopulationBrackets)[] = [
+export const populationKeys: (keyof ModelInputsPopulationBrackets)[] = [
   ...incarceratedPopulationKeys,
   "staffPopulation",
 ];

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -1,22 +1,11 @@
-import { get, omit, pick, sum, values } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
-import { Column, PageContainer } from "../design-system/PageColumn";
-import {
-  findMatchingDay,
-  findMostRecentDate,
-} from "../hooks/useAddCasesInputs";
+import { PageContainer } from "../design-system/PageColumn";
 import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
-import {
-  caseBracketKeys,
-  deathBracketKeys,
-  incarceratedPopulationKeys,
-  recoveredBracketKeys,
-} from "../impact-dashboard/EpidemicModelContext";
 import {
   formatThousands,
   TableRow,
@@ -29,23 +18,11 @@ import { CurveData } from "../infection-model";
 import { RtData, RtError } from "../infection-model/rt";
 import { initialPublicCurveToggles } from "../page-multi-facility/curveToggles";
 import { useProjectionData } from "../page-multi-facility/projectionCurveHooks";
-import { Facility, ModelInputs } from "../page-multi-facility/types";
+import { Facility } from "../page-multi-facility/types";
+import FacilitySummaryTable from "./FacilitySummaryTable";
 import SnapshotPage from "./SnapshotPage";
 
-const VALUE_MAPPING = {
-  cases: caseBracketKeys,
-  deaths: deathBracketKeys,
-  population: incarceratedPopulationKeys,
-  recovered: recoveredBracketKeys,
-};
-
 const DURATION = 21;
-
-const DELTA_DIRECTION_MAPPING = {
-  positive: "↑ ",
-  negative: "↓ ",
-  same: "↑ ",
-};
 
 const Heading = styled.div`
   font-weight: 700;
@@ -68,7 +45,7 @@ const TableHeadingCell = styled.td`
   vertical-align: middle;
 `;
 
-const BorderDiv = styled.div<{ marginRight?: string }>`
+export const BorderDiv = styled.div<{ marginRight?: string }>`
   border-top: 2px solid ${Colors.darkGray};
   margin-right: ${(props) => props.marginRight || "5px"};
   margin-bottom: 5px;
@@ -87,7 +64,7 @@ const ProjectionContainer = styled.div`
   }
 `;
 
-const HorizontalRule = styled.hr`
+export const HorizontalRule = styled.hr`
   border-color: ${Colors.opacityGray};
   margin: 10px 0;
 `;
@@ -102,39 +79,14 @@ const TableCell = styled.td<{ label?: boolean }>`
   width: ${(props) => (props.label ? "200px" : "auto")};
 `;
 
-const TextContainer = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-`;
+interface Props {
+  facility: Facility;
+  rtData: RtData | RtError | undefined;
+}
 
-const Right = styled.div`
-  text-align: right;
-  font-family: "Libre Baskerville";
-  font-size: 17px;
-`;
-
-const DeltaContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`;
-
-const Left = styled.div`
-  text-align: left;
-  font-family: "Libre Franklin";
-  font-size: 11px;
-`;
-
-// TODO: use standard colors
-const Delta = styled.div<{ deltaDirection?: string }>`
-  color: ${(props) =>
-    props.deltaDirection == "positive"
-      ? "#cb2500"
-      : props.deltaDirection == "negative"
-      ? "#006c67"
-      : "#c8d3d3"};
-`;
+interface ProjectionProps {
+  projectionData: CurveData | undefined;
+}
 
 function makeTableRow(row: TableRow) {
   const { label, week1, week2, week3, overall } = row;
@@ -169,16 +121,6 @@ function makeHeadingRow() {
   );
 }
 
-interface ProjectionProps {
-  projectionData: CurveData | undefined;
-}
-
-interface FacilitySummaryData {
-  incarceratedCases: number;
-  incarceratedCasesDelta: number;
-  incarceratedCasesDeltaDirection: string;
-}
-
 const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   return (
     <ChartArea
@@ -189,83 +131,6 @@ const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
     />
   );
 };
-
-function makeSummaryRow(
-  heading: string,
-  total: number,
-  deltaDirection: string,
-  delta: number,
-) {
-  return (
-    <>
-      <BorderDiv marginRight={"0px"} />
-      {heading}
-      <HorizontalRule />
-      <TextContainer>
-        <Right>{formatThousands(total)}</Right>
-        <DeltaContainer>
-          <Delta deltaDirection={deltaDirection}>
-            {get(DELTA_DIRECTION_MAPPING, deltaDirection)}
-          </Delta>
-          <Left>{formatThousands(delta)}</Left>
-        </DeltaContainer>
-      </TextContainer>
-    </>
-  );
-}
-
-function makeSummaryColumns(facilitySummaryData: FacilitySummaryData) {
-  return (
-    <>
-      <Column>
-        {makeSummaryRow("Incarcerated Population", 15687, "positive", 25)}
-      </Column>
-      <Column>
-        {makeSummaryRow(
-          "Incarcerated Cases",
-          facilitySummaryData.incarceratedCases,
-          facilitySummaryData.incarceratedCasesDeltaDirection,
-          facilitySummaryData.incarceratedCasesDelta,
-        )}
-      </Column>
-      <Column>
-        <BorderDiv marginRight={"0px"} />
-        Staff Population
-        <HorizontalRule />
-      </Column>
-      <Column>
-        <BorderDiv marginRight={"0px"} />
-        Staff Cases
-        <HorizontalRule />
-      </Column>
-    </>
-  );
-}
-
-// function getMostRecentTotalIncarceratedValues(facility: Facility, value: string) {
-
-// }
-
-function getTotalIncarceratedValues(modelInputs: ModelInputs, value: string) {
-  let result = 0;
-  const valueKeys = get(VALUE_MAPPING, value);
-  const data = omit(
-    pick(modelInputs, valueKeys),
-    "staffDeaths",
-    "staffRecovered",
-    "staffCases",
-  );
-  // if (keys(data).length > 0) {
-  //   hasData = true;
-  // }
-  result += sum(values(data));
-  return result;
-}
-
-interface Props {
-  facility: Facility;
-  rtData: RtData | RtError | undefined;
-}
 
 const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
   const projectionData = useProjectionData(
@@ -278,65 +143,6 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
   const { incarcerated, staff } = projectionData;
   const incarceratedData = buildIncarceratedData(incarcerated);
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
-  const hasEarlierData = facility.modelVersions.length > 1;
-
-  const incarceratedCases = getTotalIncarceratedValues(
-    facility.modelInputs,
-    "cases",
-  );
-  const incarceratedRecoveredCases = getTotalIncarceratedValues(
-    facility.modelInputs,
-    "recovered",
-  );
-  const incarceratedDeaths = getTotalIncarceratedValues(
-    facility.modelInputs,
-    "deaths",
-  );
-  const incarceratedActiveCases =
-    incarceratedCases - incarceratedRecoveredCases - incarceratedDeaths;
-
-  let delta = 0;
-  let deltaDirection = "same";
-
-  if (hasEarlierData) {
-    const currentDate = facility.updatedAt;
-    const mostRecentDate = findMostRecentDate(
-      currentDate,
-      facility.modelVersions,
-    );
-    const mostRecentData = findMatchingDay({
-      date: mostRecentDate,
-      facilityModelVersions: facility.modelVersions,
-    });
-    if (mostRecentData) {
-      console.log(facility.modelInputs);
-      console.log(mostRecentData);
-      const mostRecentIncarceratedCases = getTotalIncarceratedValues(
-        mostRecentData,
-        "cases",
-      );
-      const mostRecentIncarceratedRecoveredCases = getTotalIncarceratedValues(
-        mostRecentData,
-        "recovered",
-      );
-      const mostRecentIncarceratedDeaths = getTotalIncarceratedValues(
-        mostRecentData,
-        "deaths",
-      );
-      const mostRecentIncarceratedActiveCases =
-        mostRecentIncarceratedCases -
-        mostRecentIncarceratedRecoveredCases -
-        mostRecentIncarceratedDeaths;
-      console.log(incarceratedActiveCases, mostRecentIncarceratedActiveCases);
-      delta = mostRecentIncarceratedActiveCases - incarceratedActiveCases;
-      deltaDirection = delta > 0 ? "positive" : delta < 0 ? "negative" : "same";
-    }
-  }
-  const facilitySummaryData: FacilitySummaryData = {
-    incarceratedCases: incarceratedActiveCases,
-    incarceratedCasesDelta: delta,
-    incarceratedCasesDeltaDirection: deltaDirection,
-  };
 
   return (
     <SnapshotPage header={facility.name}>
@@ -345,7 +151,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
         <ProjectionContainer>
           <HorizontalRule />
           <PageContainer>
-            {makeSummaryColumns(facilitySummaryData)}
+            <FacilitySummaryTable facility={facility} />
           </PageContainer>
           <HorizontalRule />
         </ProjectionContainer>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -47,6 +47,7 @@ const TableHeadingCell = styled.td`
 const BorderDiv = styled.div`
   border-top: 2px solid ${Colors.darkGray};
   margin-right: 5px;
+  margin-bottom: 5px;
 `;
 
 const ProjectionSection = styled.div`
@@ -75,6 +76,38 @@ const TableCell = styled.td<{ label?: boolean }>`
   border-top: 1px solid  ${Colors.darkGray};
   vertical-align: middle;
   width: ${(props) => (props.label ? "200px" : "auto")};
+`;
+
+const TextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+const Right = styled.div`
+  text-align: right;
+  font-family: "Libre Baskerville";
+  font-size: 17px;
+`;
+
+const DeltaContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const Left = styled.div`
+  text-align: left;
+  font-family: "Libre Franklin";
+  font-size: 11px;
+`;
+const Red = styled.div`
+  color: #cb2500;
+`;
+
+// TODO: use standard colors
+const Delta = styled.div<{ isPositive?: boolean }>`
+  color: ${(props) => (props.isPositive ? "#cb2500" : "#006c67")};
 `;
 
 function makeTableRow(row: TableRow) {
@@ -125,23 +158,35 @@ const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   );
 };
 
-function makeSummaryColumns() {
+function makeSummaryColumns(incarceratedData: TableRow[]) {
   return (
     <>
       <Column>
-        {" "}
         <BorderDiv />
         Incarcerated Population
+        <HorizontalRule />
+        <TextContainer>
+          <Right>hi</Right>
+          <DeltaContainer>
+            <Red>↑ </Red>
+            <Left>there</Left>
+          </DeltaContainer>
+        </TextContainer>
       </Column>
       <Column>
-        <BorderDiv /> Incarcerated Cases
+        <BorderDiv />
+        Incarcerated Cases
+        <HorizontalRule />
       </Column>
       <Column>
-        <BorderDiv /> Staff Population
+        <BorderDiv />
+        Staff Population
+        <HorizontalRule />
       </Column>
       <Column>
         <BorderDiv />
         Staff Cases
+        <HorizontalRule />
       </Column>
     </>
   );
@@ -162,6 +207,8 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
   if (!projectionData) return <Loading />;
   const { incarcerated, staff } = projectionData;
 
+  console.log(facility);
+
   const incarceratedData = buildIncarceratedData(incarcerated);
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
   return (
@@ -170,7 +217,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
       <ProjectionSection>
         <ProjectionContainer>
           <HorizontalRule />
-          <PageContainer>{makeSummaryColumns()}</PageContainer>
+          <PageContainer>{makeSummaryColumns(incarceratedData)}</PageContainer>
           <HorizontalRule />
         </ProjectionContainer>
       </ProjectionSection>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -150,9 +150,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
       <ProjectionSection>
         <ProjectionContainer>
           <HorizontalRule />
-          <PageContainer>
-            <FacilitySummaryTable facility={facility} />
-          </PageContainer>
+          <FacilitySummaryTable facility={facility} />
           <HorizontalRule />
         </ProjectionContainer>
       </ProjectionSection>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -110,11 +110,11 @@ const Left = styled.div`
 `;
 
 // TODO: use standard colors
-const Delta = styled.div<{ changeDirection?: string }>`
+const Delta = styled.div<{ deltaDirection?: string }>`
   color: ${(props) =>
-    props.changeDirection == "positive"
+    props.deltaDirection == "positive"
       ? "#cb2500"
-      : props.changeDirection == "negative"
+      : props.deltaDirection == "negative"
       ? "#006c67"
       : "#c8d3d3"};
 `;
@@ -180,7 +180,7 @@ function makeSummaryColumns(
         <TextContainer>
           <Right>hi</Right>
           <DeltaContainer>
-            <Delta changeDirection={rateOfChange}>
+            <Delta deltaDirection={rateOfChange}>
               {get(CHANGE_DIRECTION_MAPPING, rateOfChange)}{" "}
             </Delta>
             <Left>there</Left>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -24,7 +24,7 @@ import SnapshotPage from "./SnapshotPage";
 
 const DURATION = 21;
 
-const CHANGE_DIRECTION_MAPPING = {
+const DELTA_DIRECTION_MAPPING = {
   positive: "↑ ",
   negative: "↓ ",
   same: "-- ",
@@ -181,7 +181,7 @@ function makeSummaryColumns(
           <Right>hi</Right>
           <DeltaContainer>
             <Delta deltaDirection={rateOfChange}>
-              {get(CHANGE_DIRECTION_MAPPING, rateOfChange)}{" "}
+              {get(DELTA_DIRECTION_MAPPING, rateOfChange)}
             </Delta>
             <Left>there</Left>
           </DeltaContainer>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
-import { PageContainer } from "../design-system/PageColumn";
 import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import {

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -47,7 +47,7 @@ const TableHeadingCell = styled.td`
 export const BorderDiv = styled.div<{ marginRight?: string }>`
   border-top: 1px solid ${Colors.black};
   margin-right: ${(props) => props.marginRight || "5px"};
-  margin-bottom: 5px;
+  margin-bottom: 10px;
 `;
 
 const ProjectionSection = styled.div`
@@ -63,9 +63,10 @@ const ProjectionContainer = styled.div`
   }
 `;
 
-export const HorizontalRule = styled.hr`
+export const HorizontalRule = styled.hr<{ marginRight?: string }>`
   border-color: ${Colors.opacityGray};
-  margin: 10px 0;
+  margin-top: 10px;
+  margin-right: ${(props) => props.marginRight || "0px"};
 `;
 
 const TableCell = styled.td<{ label?: boolean }>`

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import Colors, { MarkColors as markColors } from "../design-system/Colors";
 import Loading from "../design-system/Loading";
+import { Column, PageContainer } from "../design-system/PageColumn";
 import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import {
@@ -59,6 +60,11 @@ const ProjectionContainer = styled.div`
     fill: ${Colors.black};
     font-family: "Libre Franklin";
   }
+`;
+
+const HorizontalRule = styled.hr`
+  border-color: ${Colors.opacityGray};
+  margin: 10px 0;
 `;
 
 const TableCell = styled.td<{ label?: boolean }>`
@@ -119,6 +125,28 @@ const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   );
 };
 
+function makeSummaryColumns() {
+  return (
+    <>
+      <Column>
+        {" "}
+        <BorderDiv />
+        Incarcerated Population
+      </Column>
+      <Column>
+        <BorderDiv /> Incarcerated Cases
+      </Column>
+      <Column>
+        <BorderDiv /> Staff Population
+      </Column>
+      <Column>
+        <BorderDiv />
+        Staff Cases
+      </Column>
+    </>
+  );
+}
+
 interface Props {
   facility: Facility;
   rtData: RtData | RtError | undefined;
@@ -138,6 +166,14 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
   return (
     <SnapshotPage header={facility.name}>
+      Facility Summary
+      <ProjectionSection>
+        <ProjectionContainer>
+          <HorizontalRule />
+          <PageContainer>{makeSummaryColumns()}</PageContainer>
+          <HorizontalRule />
+        </ProjectionContainer>
+      </ProjectionSection>
       Facility-Specific Projection
       <ProjectionSection>
         <ProjectionContainer>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -1,3 +1,4 @@
+import { get } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
@@ -23,6 +24,12 @@ import SnapshotPage from "./SnapshotPage";
 
 const DURATION = 21;
 
+const CHANGE_DIRECTION_MAPPING = {
+  positive: "↑ ",
+  negative: "↓ ",
+  same: "-- ",
+};
+
 const Heading = styled.div`
   font-weight: 700;
   line-height: 13px;
@@ -44,9 +51,9 @@ const TableHeadingCell = styled.td`
   vertical-align: middle;
 `;
 
-const BorderDiv = styled.div`
+const BorderDiv = styled.div<{ marginRight?: string }>`
   border-top: 2px solid ${Colors.darkGray};
-  margin-right: 5px;
+  margin-right: ${(props) => props.marginRight || "5px"};
   margin-bottom: 5px;
 `;
 
@@ -101,13 +108,15 @@ const Left = styled.div`
   font-family: "Libre Franklin";
   font-size: 11px;
 `;
-const Red = styled.div`
-  color: #cb2500;
-`;
 
 // TODO: use standard colors
-const Delta = styled.div<{ isPositive?: boolean }>`
-  color: ${(props) => (props.isPositive ? "#cb2500" : "#006c67")};
+const Delta = styled.div<{ changeDirection?: string }>`
+  color: ${(props) =>
+    props.changeDirection == "positive"
+      ? "#cb2500"
+      : props.changeDirection == "negative"
+      ? "#006c67"
+      : "#c8d3d3"};
 `;
 
 function makeTableRow(row: TableRow) {
@@ -158,33 +167,38 @@ const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
   );
 };
 
-function makeSummaryColumns(incarceratedData: TableRow[]) {
+function makeSummaryColumns(
+  incarceratedData: TableRow[],
+  rateOfChange: string,
+) {
   return (
     <>
       <Column>
-        <BorderDiv />
+        <BorderDiv marginRight={"0px"} />
         Incarcerated Population
         <HorizontalRule />
         <TextContainer>
           <Right>hi</Right>
           <DeltaContainer>
-            <Red>↑ </Red>
+            <Delta changeDirection={rateOfChange}>
+              {get(CHANGE_DIRECTION_MAPPING, rateOfChange)}{" "}
+            </Delta>
             <Left>there</Left>
           </DeltaContainer>
         </TextContainer>
       </Column>
       <Column>
-        <BorderDiv />
+        <BorderDiv marginRight={"0px"} />
         Incarcerated Cases
         <HorizontalRule />
       </Column>
       <Column>
-        <BorderDiv />
+        <BorderDiv marginRight={"0px"} />
         Staff Population
         <HorizontalRule />
       </Column>
       <Column>
-        <BorderDiv />
+        <BorderDiv marginRight={"0px"} />
         Staff Cases
         <HorizontalRule />
       </Column>
@@ -217,7 +231,9 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
       <ProjectionSection>
         <ProjectionContainer>
           <HorizontalRule />
-          <PageContainer>{makeSummaryColumns(incarceratedData)}</PageContainer>
+          <PageContainer>
+            {makeSummaryColumns(incarceratedData, "positive")}
+          </PageContainer>
           <HorizontalRule />
         </ProjectionContainer>
       </ProjectionSection>

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -27,7 +27,7 @@ const Heading = styled.div`
   font-weight: 700;
   line-height: 13px;
   border-top: 1px solid ${Colors.darkGray};
-  padding: 5px 0;
+  padding: 10px 0;
 `;
 
 export const Table = styled.table`
@@ -45,7 +45,7 @@ const TableHeadingCell = styled.td`
 `;
 
 export const BorderDiv = styled.div<{ marginRight?: string }>`
-  border-top: 2px solid ${Colors.darkGray};
+  border-top: 1px solid ${Colors.black};
   margin-right: ${(props) => props.marginRight || "5px"};
   margin-bottom: 5px;
 `;
@@ -104,18 +104,10 @@ function makeHeadingRow() {
   return (
     <tr>
       <td />
-      <TableHeadingCell>
-        <BorderDiv>Week 1</BorderDiv>
-      </TableHeadingCell>
-      <TableHeadingCell>
-        <BorderDiv>Week 2</BorderDiv>
-      </TableHeadingCell>
-      <TableHeadingCell>
-        <BorderDiv>Week 3</BorderDiv>
-      </TableHeadingCell>
-      <TableHeadingCell>
-        <BorderDiv>Overall</BorderDiv>
-      </TableHeadingCell>
+      <TableHeadingCell>Week 1</TableHeadingCell>
+      <TableHeadingCell>Week 2</TableHeadingCell>
+      <TableHeadingCell>Week 3</TableHeadingCell>
+      <TableHeadingCell>Overall</TableHeadingCell>
     </tr>
   );
 }
@@ -145,10 +137,9 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
 
   return (
     <SnapshotPage header={facility.name}>
-      Facility Summary
       <ProjectionSection>
         <ProjectionContainer>
-          <HorizontalRule />
+          <Heading>Facility Summary</Heading>
           <FacilitySummaryTable facility={facility} />
           <HorizontalRule />
         </ProjectionContainer>
@@ -160,6 +151,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
         </ProjectionContainer>
 
         <Heading>Incarcerated Population Projection</Heading>
+        <BorderDiv />
         <Table>
           <tbody>
             {makeHeadingRow()}
@@ -169,6 +161,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
       </ProjectionSection>
       <ProjectionSection>
         <Heading>Staff Projection</Heading>
+        <BorderDiv />
         <Table>
           <tbody>
             {makeHeadingRow()}

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -290,14 +290,6 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
   const incarceratedActiveCases =
     incarceratedCases - incarceratedRecoveredCases - incarceratedDeaths;
 
-  console.log(
-    facility.name,
-    incarceratedActiveCases,
-    incarceratedRecoveredCases,
-    incarceratedDeaths,
-    incarceratedPopulation,
-  );
-
   let incarceratedCasesDelta = {
     delta: 0,
     deltaDirection: "same",
@@ -340,14 +332,6 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
         mostRecentIncarceratedCases -
         mostRecentIncarceratedRecoveredCases -
         mostRecentIncarceratedDeaths;
-
-      console.log(
-        facility.name,
-        mostRecentIncarceratedActiveCases,
-        mostRecentIncarceratedRecoveredCases,
-        mostRecentIncarceratedDeaths,
-        mostRecentIncarceratedPopulation,
-      );
 
       incarceratedCasesDelta = getDelta(
         mostRecentIncarceratedActiveCases,

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -1,7 +1,8 @@
-import { get, omit, pick, pickBy, sum, values } from "lodash";
+import { get, omit, pick, pickBy, startsWith, sum, values } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
+import Colors from "../design-system/Colors";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import {
   findMatchingDay,
@@ -58,10 +59,10 @@ const Left = styled.div`
 const Delta = styled.div<{ deltaDirection?: string }>`
   color: ${(props) =>
     props.deltaDirection == "positive"
-      ? "#cb2500"
+      ? Colors.red
       : props.deltaDirection == "negative"
-      ? "#006c67"
-      : "#c8d3d3"};
+      ? Colors.green
+      : Colors.gray};
 `;
 
 interface IncarceratedFacilitySummaryData {
@@ -159,12 +160,8 @@ function makeSummaryColumns(facilitySummaryData: FacilitySummaryData) {
 function getTotalIncarceratedValues(modelInputs: ModelInputs, value: string) {
   let result = 0;
   const valueKeys = get(VALUE_MAPPING, value);
-  const data = omit(
-    pick(modelInputs, valueKeys),
-    "staffDeaths",
-    "staffRecovered",
-    "staffCases",
-  );
+  const allData = pick(modelInputs, valueKeys);
+  const data = pickBy(allData, (value, key) => key.startsWith("age"));
   result += sum(values(data));
   return result;
 }
@@ -222,6 +219,7 @@ function buildStaffFacilitySummaryData(facility: Facility) {
     const mostRecentDate = findMostRecentDate(
       currentDate,
       facility.modelVersions,
+      false,
     );
     const mostRecentData = findMatchingDay({
       date: mostRecentDate,
@@ -305,6 +303,7 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
     const mostRecentDate = findMostRecentDate(
       currentDate,
       facility.modelVersions,
+      false,
     );
     const mostRecentData = findMatchingDay({
       date: mostRecentDate,

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -187,9 +187,9 @@ function getActiveCases(
   deaths: number,
 ) {
   if (totalCases <= recoveredCases + deaths) {
-    return totalCases - recoveredCases - deaths;
+    return totalCases;
   }
-  return totalCases;
+  return totalCases - recoveredCases - deaths;
 }
 
 function getTotalValues(

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -1,0 +1,218 @@
+import { get, omit, pick, sum, values } from "lodash";
+import React from "react";
+import styled from "styled-components";
+
+import { Column, PageContainer } from "../design-system/PageColumn";
+import {
+  findMatchingDay,
+  findMostRecentDate,
+} from "../hooks/useAddCasesInputs";
+import {
+  caseBracketKeys,
+  deathBracketKeys,
+  incarceratedPopulationKeys,
+  recoveredBracketKeys,
+} from "../impact-dashboard/EpidemicModelContext";
+import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
+import { Facility, ModelInputs } from "../page-multi-facility/types";
+import { BorderDiv, HorizontalRule } from "./FacilityPage";
+
+const VALUE_MAPPING = {
+  cases: caseBracketKeys,
+  deaths: deathBracketKeys,
+  population: incarceratedPopulationKeys,
+  recovered: recoveredBracketKeys,
+};
+
+const DELTA_DIRECTION_MAPPING = {
+  positive: "↑ ",
+  negative: "↓ ",
+  same: "↑ ",
+};
+
+const TextContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+const Right = styled.div`
+  text-align: right;
+  font-family: "Libre Baskerville";
+  font-size: 17px;
+`;
+
+const DeltaContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const Left = styled.div`
+  text-align: left;
+  font-family: "Libre Franklin";
+  font-size: 11px;
+`;
+
+// TODO: use standard colors
+const Delta = styled.div<{ deltaDirection?: string }>`
+  color: ${(props) =>
+    props.deltaDirection == "positive"
+      ? "#cb2500"
+      : props.deltaDirection == "negative"
+      ? "#006c67"
+      : "#c8d3d3"};
+`;
+
+interface FacilitySummaryData {
+  incarceratedPopulation: number;
+  incarceratedPopulationDelta: number;
+  incarceratedPopulationDeltaDirection: string;
+  incarceratedCases: number;
+  incarceratedCasesDelta: number;
+  incarceratedCasesDeltaDirection: string;
+}
+function makeSummaryRow(
+  heading: string,
+  total: number,
+  deltaDirection: string,
+  delta: number,
+) {
+  return (
+    <>
+      <BorderDiv marginRight={"0px"} />
+      {heading}
+      <HorizontalRule />
+      <TextContainer>
+        <Right>{formatThousands(total)}</Right>
+        <DeltaContainer>
+          <Delta deltaDirection={deltaDirection}>
+            {get(DELTA_DIRECTION_MAPPING, deltaDirection)}
+          </Delta>
+          <Left>{formatThousands(delta)}</Left>
+        </DeltaContainer>
+      </TextContainer>
+    </>
+  );
+}
+
+function makeSummaryColumns(facilitySummaryData: FacilitySummaryData) {
+  return (
+    <>
+      <Column>
+        {makeSummaryRow("Incarcerated Population", 15687, "positive", 25)}
+      </Column>
+      <Column>
+        {makeSummaryRow(
+          "Incarcerated Cases",
+          facilitySummaryData.incarceratedCases,
+          facilitySummaryData.incarceratedCasesDeltaDirection,
+          facilitySummaryData.incarceratedCasesDelta,
+        )}
+      </Column>
+      <Column>
+        <BorderDiv marginRight={"0px"} />
+        Staff Population
+        <HorizontalRule />
+      </Column>
+      <Column>
+        <BorderDiv marginRight={"0px"} />
+        Staff Cases
+        <HorizontalRule />
+      </Column>
+    </>
+  );
+}
+
+function getTotalIncarceratedValues(modelInputs: ModelInputs, value: string) {
+  let result = 0;
+  const valueKeys = get(VALUE_MAPPING, value);
+  const data = omit(
+    pick(modelInputs, valueKeys),
+    "staffDeaths",
+    "staffRecovered",
+    "staffCases",
+  );
+  result += sum(values(data));
+  return result;
+}
+
+function buildFacilitySummaryData(facility: Facility) {
+  const hasEarlierData = facility.modelVersions.length > 1;
+
+  const incarceratedCases = getTotalIncarceratedValues(
+    facility.modelInputs,
+    "cases",
+  );
+  const incarceratedRecoveredCases = getTotalIncarceratedValues(
+    facility.modelInputs,
+    "recovered",
+  );
+  const incarceratedDeaths = getTotalIncarceratedValues(
+    facility.modelInputs,
+    "deaths",
+  );
+
+  const incarceratedPopulation = getTotalIncarceratedValues(
+    facility.modelInputs,
+    "population",
+  );
+
+  const incarceratedActiveCases =
+    incarceratedCases - incarceratedRecoveredCases - incarceratedDeaths;
+
+  let delta = 0;
+  let deltaDirection = "same";
+
+  if (hasEarlierData) {
+    const currentDate = facility.updatedAt;
+    const mostRecentDate = findMostRecentDate(
+      currentDate,
+      facility.modelVersions,
+    );
+    const mostRecentData = findMatchingDay({
+      date: mostRecentDate,
+      facilityModelVersions: facility.modelVersions,
+    });
+    if (mostRecentData) {
+      const mostRecentIncarceratedCases = getTotalIncarceratedValues(
+        mostRecentData,
+        "cases",
+      );
+      const mostRecentIncarceratedRecoveredCases = getTotalIncarceratedValues(
+        mostRecentData,
+        "recovered",
+      );
+      const mostRecentIncarceratedDeaths = getTotalIncarceratedValues(
+        mostRecentData,
+        "deaths",
+      );
+      const mostRecentIncarceratedActiveCases =
+        mostRecentIncarceratedCases -
+        mostRecentIncarceratedRecoveredCases -
+        mostRecentIncarceratedDeaths;
+      console.log(incarceratedActiveCases, mostRecentIncarceratedActiveCases);
+      delta = mostRecentIncarceratedActiveCases - incarceratedActiveCases;
+      deltaDirection = delta > 0 ? "positive" : delta < 0 ? "negative" : "same";
+    }
+  }
+  const facilitySummaryData: FacilitySummaryData = {
+    incarceratedPopulation: incarceratedPopulation,
+    incarceratedPopulationDelta: 0,
+    incarceratedPopulationDeltaDirection: "same",
+    incarceratedCases: incarceratedActiveCases,
+    incarceratedCasesDelta: delta,
+    incarceratedCasesDeltaDirection: deltaDirection,
+  };
+  return facilitySummaryData;
+}
+
+const FacilitySummaryTable: React.FC<{
+  facility: Facility;
+}> = ({ facility }) => {
+  const facilitySummaryData = buildFacilitySummaryData(facility);
+
+  return <>{makeSummaryColumns(facilitySummaryData)}</>;
+};
+
+export default FacilitySummaryTable;

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -58,6 +58,10 @@ const Left = styled.div`
   margin-right: ${COLUMN_SPACING};
 `;
 
+const TableHeading = styled.th`
+  width 25%;
+`;
+
 const Delta = styled.div<{ deltaDirection?: string }>`
   color: ${(props) =>
     props.deltaDirection == "positive"
@@ -152,26 +156,26 @@ function makeTableHeadings() {
   return (
     <>
       <tr>
-        <th>
+        <TableHeading>
           <BorderDiv marginRight={COLUMN_SPACING} />
           Incarcerated population
           <HorizontalRule marginRight={COLUMN_SPACING} />
-        </th>
-        <th>
+        </TableHeading>
+        <TableHeading>
           <BorderDiv marginRight={COLUMN_SPACING} />
           Incarcerated cases
           <HorizontalRule marginRight={COLUMN_SPACING} />
-        </th>
-        <th>
+        </TableHeading>
+        <TableHeading>
           <BorderDiv marginRight={COLUMN_SPACING} />
           Staff population
           <HorizontalRule marginRight={COLUMN_SPACING} />
-        </th>
-        <th>
+        </TableHeading>
+        <TableHeading>
           <BorderDiv marginRight={COLUMN_SPACING} />
           Staff cases
           <HorizontalRule marginRight={COLUMN_SPACING} />
-        </th>
+        </TableHeading>
       </tr>
     </>
   );

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -238,7 +238,7 @@ function buildStaffFacilitySummaryData(facility: Facility) {
         "deaths",
       );
       const mostRecentStaffPopulation = getTotalStaffValues(
-        facility.modelInputs,
+        mostRecentData,
         "population",
       );
 
@@ -332,7 +332,7 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
         "deaths",
       );
       const mostRecentIncarceratedPopulation = getTotalIncarceratedValues(
-        facility.modelInputs,
+        mostRecentData,
         "population",
       );
 

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -1,13 +1,4 @@
-import {
-  get,
-  omit,
-  omitBy,
-  pick,
-  pickBy,
-  startsWith,
-  sum,
-  values,
-} from "lodash";
+import { get, omit, pick, pickBy, sum, values } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
@@ -19,7 +10,7 @@ import {
 import {
   caseBracketKeys,
   deathBracketKeys,
-  incarceratedPopulationKeys,
+  populationKeys,
   recoveredBracketKeys,
 } from "../impact-dashboard/EpidemicModelContext";
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
@@ -29,7 +20,7 @@ import { BorderDiv, HorizontalRule } from "./FacilityPage";
 const VALUE_MAPPING = {
   cases: caseBracketKeys,
   deaths: deathBracketKeys,
-  population: incarceratedPopulationKeys,
+  population: populationKeys,
   recovered: recoveredBracketKeys,
 };
 
@@ -299,6 +290,14 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
   const incarceratedActiveCases =
     incarceratedCases - incarceratedRecoveredCases - incarceratedDeaths;
 
+  console.log(
+    facility.name,
+    incarceratedActiveCases,
+    incarceratedRecoveredCases,
+    incarceratedDeaths,
+    incarceratedPopulation,
+  );
+
   let incarceratedCasesDelta = {
     delta: 0,
     deltaDirection: "same",
@@ -341,6 +340,14 @@ function buildIncarceratedFacilitySummaryData(facility: Facility) {
         mostRecentIncarceratedCases -
         mostRecentIncarceratedRecoveredCases -
         mostRecentIncarceratedDeaths;
+
+      console.log(
+        facility.name,
+        mostRecentIncarceratedActiveCases,
+        mostRecentIncarceratedRecoveredCases,
+        mostRecentIncarceratedDeaths,
+        mostRecentIncarceratedPopulation,
+      );
 
       incarceratedCasesDelta = getDelta(
         mostRecentIncarceratedActiveCases,

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -115,69 +115,64 @@ function makeSummaryRow(total: number, deltaDirection: string, delta: number) {
 
 function makeSummaryColumns(facilitySummaryData: FacilitySummaryData) {
   return (
-    <>
-      <tr>
-        <td>
-          {makeSummaryRow(
-            facilitySummaryData.incarceratedData.incarceratedPopulation,
-            facilitySummaryData.incarceratedData
-              .incarceratedPopulationDeltaDirection,
-            facilitySummaryData.incarceratedData.incarceratedPopulationDelta,
-          )}
-        </td>
-        <td>
-          {makeSummaryRow(
-            facilitySummaryData.incarceratedData.incarceratedCases,
-            facilitySummaryData.incarceratedData
-              .incarceratedCasesDeltaDirection,
-            facilitySummaryData.incarceratedData.incarceratedCasesDelta,
-          )}
-        </td>
-        <td>
-          {makeSummaryRow(
-            facilitySummaryData.staffData.staffPopulation,
-            facilitySummaryData.staffData.staffPopulationDeltaDirection,
-            facilitySummaryData.staffData.staffPopulationDelta,
-          )}
-        </td>
-        <td>
-          {makeSummaryRow(
-            facilitySummaryData.staffData.staffCases,
-            facilitySummaryData.staffData.staffCasesDeltaDirection,
-            facilitySummaryData.staffData.staffCasesDelta,
-          )}
-        </td>
-      </tr>
-    </>
+    <tr>
+      <td>
+        {makeSummaryRow(
+          facilitySummaryData.incarceratedData.incarceratedPopulation,
+          facilitySummaryData.incarceratedData
+            .incarceratedPopulationDeltaDirection,
+          facilitySummaryData.incarceratedData.incarceratedPopulationDelta,
+        )}
+      </td>
+      <td>
+        {makeSummaryRow(
+          facilitySummaryData.incarceratedData.incarceratedCases,
+          facilitySummaryData.incarceratedData.incarceratedCasesDeltaDirection,
+          facilitySummaryData.incarceratedData.incarceratedCasesDelta,
+        )}
+      </td>
+      <td>
+        {makeSummaryRow(
+          facilitySummaryData.staffData.staffPopulation,
+          facilitySummaryData.staffData.staffPopulationDeltaDirection,
+          facilitySummaryData.staffData.staffPopulationDelta,
+        )}
+      </td>
+      <td>
+        {makeSummaryRow(
+          facilitySummaryData.staffData.staffCases,
+          facilitySummaryData.staffData.staffCasesDeltaDirection,
+          facilitySummaryData.staffData.staffCasesDelta,
+        )}
+      </td>
+    </tr>
   );
 }
 
 function makeTableHeadings() {
   return (
-    <>
-      <tr>
-        <TableHeading>
-          <BorderDiv marginRight={COLUMN_SPACING} />
-          Incarcerated population
-          <HorizontalRule marginRight={COLUMN_SPACING} />
-        </TableHeading>
-        <TableHeading>
-          <BorderDiv marginRight={COLUMN_SPACING} />
-          Incarcerated cases
-          <HorizontalRule marginRight={COLUMN_SPACING} />
-        </TableHeading>
-        <TableHeading>
-          <BorderDiv marginRight={COLUMN_SPACING} />
-          Staff population
-          <HorizontalRule marginRight={COLUMN_SPACING} />
-        </TableHeading>
-        <TableHeading>
-          <BorderDiv marginRight={COLUMN_SPACING} />
-          Staff cases
-          <HorizontalRule marginRight={COLUMN_SPACING} />
-        </TableHeading>
-      </tr>
-    </>
+    <tr>
+      <TableHeading>
+        <BorderDiv marginRight={COLUMN_SPACING} />
+        Incarcerated population
+        <HorizontalRule marginRight={COLUMN_SPACING} />
+      </TableHeading>
+      <TableHeading>
+        <BorderDiv marginRight={COLUMN_SPACING} />
+        Incarcerated cases
+        <HorizontalRule marginRight={COLUMN_SPACING} />
+      </TableHeading>
+      <TableHeading>
+        <BorderDiv marginRight={COLUMN_SPACING} />
+        Staff population
+        <HorizontalRule marginRight={COLUMN_SPACING} />
+      </TableHeading>
+      <TableHeading>
+        <BorderDiv marginRight={COLUMN_SPACING} />
+        Staff cases
+        <HorizontalRule marginRight={COLUMN_SPACING} />
+      </TableHeading>
+    </tr>
   );
 }
 

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -1,9 +1,8 @@
-import { get, omit, pick, pickBy, startsWith, sum, values } from "lodash";
+import { get, pick, pickBy, sum, values } from "lodash";
 import React from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
-import { Column, PageContainer } from "../design-system/PageColumn";
 import {
   findMatchingDay,
   findMostRecentDate,
@@ -16,7 +15,7 @@ import {
 } from "../impact-dashboard/EpidemicModelContext";
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { Facility, ModelInputs } from "../page-multi-facility/types";
-import { BorderDiv, HorizontalRule } from "./FacilityPage";
+import { BorderDiv, HorizontalRule, Table } from "./FacilityPage";
 
 const VALUE_MAPPING = {
   cases: caseBracketKeys,
@@ -31,11 +30,14 @@ const DELTA_DIRECTION_MAPPING = {
   same: "↑ ",
 };
 
+const COLUMN_SPACING = "20px";
+
 const TextContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  padding-top: 10px;
 `;
 
 const Right = styled.div`
@@ -53,6 +55,7 @@ const Left = styled.div`
   text-align: left;
   font-family: "Libre Franklin";
   font-size: 11px;
+  margin-right: ${COLUMN_SPACING};
 `;
 
 const Delta = styled.div<{ deltaDirection?: string }>`
@@ -92,66 +95,84 @@ interface DeltaData {
   deltaDirection: string;
 }
 
-function makeSummaryRow(
-  heading: string,
-  total: number,
-  deltaDirection: string,
-  delta: number,
-) {
+function makeSummaryRow(total: number, deltaDirection: string, delta: number) {
   return (
-    <>
-      <BorderDiv marginRight={"0px"} />
-      {heading}
-      <HorizontalRule />
-      <TextContainer>
-        <Right>{formatThousands(total)}</Right>
-        <DeltaContainer>
-          <Delta deltaDirection={deltaDirection}>
-            {get(DELTA_DIRECTION_MAPPING, deltaDirection)}
-          </Delta>
-          <Left>{formatThousands(delta)}</Left>
-        </DeltaContainer>
-      </TextContainer>
-    </>
+    <TextContainer>
+      <Right>{formatThousands(total)}</Right>
+      <DeltaContainer>
+        <Delta deltaDirection={deltaDirection}>
+          {get(DELTA_DIRECTION_MAPPING, deltaDirection)}
+        </Delta>
+        <Left>{formatThousands(delta)}</Left>
+      </DeltaContainer>
+    </TextContainer>
   );
 }
 
 function makeSummaryColumns(facilitySummaryData: FacilitySummaryData) {
   return (
     <>
-      <Column>
-        {makeSummaryRow(
-          "Incarcerated Population",
-          facilitySummaryData.incarceratedData.incarceratedPopulation,
-          facilitySummaryData.incarceratedData
-            .incarceratedPopulationDeltaDirection,
-          facilitySummaryData.incarceratedData.incarceratedPopulationDelta,
-        )}
-      </Column>
-      <Column>
-        {makeSummaryRow(
-          "Incarcerated Cases",
-          facilitySummaryData.incarceratedData.incarceratedCases,
-          facilitySummaryData.incarceratedData.incarceratedCasesDeltaDirection,
-          facilitySummaryData.incarceratedData.incarceratedCasesDelta,
-        )}
-      </Column>
-      <Column>
-        {makeSummaryRow(
-          "Staff Population",
-          facilitySummaryData.staffData.staffPopulation,
-          facilitySummaryData.staffData.staffPopulationDeltaDirection,
-          facilitySummaryData.staffData.staffPopulationDelta,
-        )}
-      </Column>
-      <Column>
-        {makeSummaryRow(
-          "Staff Cases",
-          facilitySummaryData.staffData.staffCases,
-          facilitySummaryData.staffData.staffCasesDeltaDirection,
-          facilitySummaryData.staffData.staffCasesDelta,
-        )}
-      </Column>
+      <tr>
+        <td>
+          {makeSummaryRow(
+            facilitySummaryData.incarceratedData.incarceratedPopulation,
+            facilitySummaryData.incarceratedData
+              .incarceratedPopulationDeltaDirection,
+            facilitySummaryData.incarceratedData.incarceratedPopulationDelta,
+          )}
+        </td>
+        <td>
+          {makeSummaryRow(
+            facilitySummaryData.incarceratedData.incarceratedCases,
+            facilitySummaryData.incarceratedData
+              .incarceratedCasesDeltaDirection,
+            facilitySummaryData.incarceratedData.incarceratedCasesDelta,
+          )}
+        </td>
+        <td>
+          {makeSummaryRow(
+            facilitySummaryData.staffData.staffPopulation,
+            facilitySummaryData.staffData.staffPopulationDeltaDirection,
+            facilitySummaryData.staffData.staffPopulationDelta,
+          )}
+        </td>
+        <td>
+          {makeSummaryRow(
+            facilitySummaryData.staffData.staffCases,
+            facilitySummaryData.staffData.staffCasesDeltaDirection,
+            facilitySummaryData.staffData.staffCasesDelta,
+          )}
+        </td>
+      </tr>
+    </>
+  );
+}
+
+function makeTableHeadings() {
+  return (
+    <>
+      <tr>
+        <th>
+          <BorderDiv marginRight={COLUMN_SPACING} />
+          Incarcerated population
+          <HorizontalRule marginRight={COLUMN_SPACING} />
+        </th>
+        <th>
+          <BorderDiv marginRight={COLUMN_SPACING} />
+          Incarcerated cases
+          <HorizontalRule marginRight={COLUMN_SPACING} />
+        </th>
+        <th>
+          <BorderDiv marginRight={COLUMN_SPACING} />
+          Staff population
+          <HorizontalRule marginRight={COLUMN_SPACING} />
+        </th>
+        <th>
+          <BorderDiv marginRight={COLUMN_SPACING} />
+          Staff cases
+          <HorizontalRule marginRight={COLUMN_SPACING} />
+        </th>
+      </tr>
     </>
   );
 }
@@ -364,7 +385,10 @@ const FacilitySummaryTable: React.FC<{
   } as FacilitySummaryData;
 
   return (
-    <PageContainer>{makeSummaryColumns(facilitySummaryData)}</PageContainer>
+    <Table>
+      <thead>{makeTableHeadings()}</thead>
+      <tbody>{makeSummaryColumns(facilitySummaryData)}</tbody>
+    </Table>
   );
 };
 

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -181,6 +181,17 @@ function makeTableHeadings() {
   );
 }
 
+function getActiveCases(
+  totalCases: number,
+  recoveredCases: number,
+  deaths: number,
+) {
+  if (totalCases <= recoveredCases + deaths) {
+    return totalCases - recoveredCases - deaths;
+  }
+  return totalCases;
+}
+
 function getTotalValues(
   modelInputs: ModelInputs,
   value: string,
@@ -227,7 +238,11 @@ function buildStaffFacilitySummaryData(
     "staff",
   );
 
-  const staffActiveCases = staffCases - staffRecoveredCases - staffDeaths;
+  const staffActiveCases = getActiveCases(
+    staffCases,
+    staffRecoveredCases,
+    staffDeaths,
+  );
 
   let staffCasesDelta = {
     delta: 0,
@@ -262,10 +277,11 @@ function buildStaffFacilitySummaryData(
       "staff",
     );
 
-    const mostRecentStaffActiveCases =
-      mostRecentStaffCases -
-      mostRecentStaffRecoveredCases -
-      mostRecentStaffDeaths;
+    const mostRecentStaffActiveCases = getActiveCases(
+      mostRecentStaffCases,
+      mostRecentStaffRecoveredCases,
+      mostRecentStaffDeaths,
+    );
 
     staffCasesDelta = getDelta(mostRecentStaffActiveCases, staffActiveCases);
 
@@ -299,8 +315,11 @@ function buildIncarceratedFacilitySummaryData(
     "population",
   );
 
-  const incarceratedActiveCases =
-    incarceratedCases - incarceratedRecoveredCases - incarceratedDeaths;
+  const incarceratedActiveCases = getActiveCases(
+    incarceratedCases,
+    incarceratedRecoveredCases,
+    incarceratedDeaths,
+  );
 
   let incarceratedCasesDelta = {
     delta: 0,
@@ -327,10 +346,11 @@ function buildIncarceratedFacilitySummaryData(
       "population",
     );
 
-    const mostRecentIncarceratedActiveCases =
-      mostRecentIncarceratedCases -
-      mostRecentIncarceratedRecoveredCases -
-      mostRecentIncarceratedDeaths;
+    const mostRecentIncarceratedActiveCases = getActiveCases(
+      mostRecentIncarceratedCases,
+      mostRecentIncarceratedRecoveredCases,
+      mostRecentIncarceratedDeaths,
+    );
 
     incarceratedCasesDelta = getDelta(
       mostRecentIncarceratedActiveCases,


### PR DESCRIPTION
## Add Facility Summary Stats to Weekly Snapshot

Created a table and populated with relevant data for the facility summary. Also did a tiny bit of styling on the facility page to get it closer to the new designs, but the bulk of that work will probably need to happen in a separate PR. Open to suggestions for further condensing the logic between incarcerated/staff data!

 Notes on expected behavior:
1. We don't have a notion of "weekly" data for each facility, so we calculate the delta between the current data for the facility and the most recent backwards-looking date we have for it (i.e. if a facility has data for July 1, 2, and 15, we calculate the delta between July 15 and July 2)
2. A gray arrow is expected when there is no change for any given metric

Testing: 
<img width="955" alt="facility summary 2" src="https://user-images.githubusercontent.com/29155017/87715940-b16b7f00-c773-11ea-8020-12181d6e16c1.png">

(decreasing cases):
<img width="206" alt="decrease" src="https://user-images.githubusercontent.com/29155017/87716125-027b7300-c774-11ea-96bd-f48c33cd04d8.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #578

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
