### PR TITLE
[Report automation] Add Impact to-date table stats

### DIFF
--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -85,7 +85,9 @@ export const recoveredBracketKeys: Array<
   "staffRecovered",
 ];
 
-export const deathBracketKeys: Array<keyof ModelInputsPopulationBrackets> = [
+export const incarceratedDeathsKeys: Array<
+  keyof ModelInputsPopulationBrackets
+> = [
   "age0Deaths",
   "age20Deaths",
   "age45Deaths",
@@ -94,7 +96,13 @@ export const deathBracketKeys: Array<keyof ModelInputsPopulationBrackets> = [
   "age75Deaths",
   "age85Deaths",
   "ageUnknownDeaths",
-  "staffDeaths",
+];
+
+export const staffDeathsKey = "staffDeaths";
+
+export const deathBracketKeys: Array<keyof ModelInputsPopulationBrackets> = [
+  ...incarceratedDeathsKeys,
+  staffDeathsKey,
 ];
 
 interface ModelInputsPersistent extends ModelInputsPopulationBrackets {
@@ -345,9 +353,12 @@ const incarceratedCasesKeys: (keyof ModelInputsPopulationBrackets)[] = [
   "age85Cases",
   "ageUnknownCases",
 ];
+
+const staffCasesKey = "staffCases";
+
 const casesKeys: (keyof ModelInputsPopulationBrackets)[] = [
   ...incarceratedCasesKeys,
-  "staffCases",
+  staffCasesKey,
 ];
 
 export const incarceratedPopulationKeys: (keyof ModelInputsPopulationBrackets)[] = [
@@ -384,10 +395,28 @@ export function totalConfirmedDeaths(
   return sum(Object.values(pick(brackets, deathBracketKeys)));
 }
 
+export function totalStaffConfirmedDeaths(
+  brackets: ModelInputsPopulationBrackets,
+): number {
+  return sum(Object.values(pick(brackets, staffDeathsKey)));
+}
+
+export function totalIncarceratedConfirmedDeaths(
+  brackets: ModelInputsPopulationBrackets,
+): number {
+  return sum(Object.values(pick(brackets, incarceratedDeathsKeys)));
+}
+
 export function totalIncarceratedConfirmedCases(
   brackets: ModelInputsPopulationBrackets,
 ): number {
   return sum(Object.values(pick(brackets, incarceratedCasesKeys)));
+}
+
+export function totalStaffConfirmedCases(
+  brackets: ModelInputsPopulationBrackets,
+): number {
+  return sum(Object.values(pick(brackets, staffCasesKey)));
 }
 
 export function totalIncarceratedPopulation(

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -104,12 +104,15 @@ const ImpactProjectionChart: React.FC = () => {
   if (!scenarioLoading && !facilitiesState.loading && !facilities.length) {
     return <div>Missing scenario data for state: {stateName}</div>;
   }
-  const chartData = chartUtils.getChartData(modelVersions, localeDataSource);
+  const { chartData, tableData } = chartUtils.getChartAndTableData(
+    modelVersions,
+    localeDataSource,
+  );
+
   const projectedCasesToday =
     chartData.projectedCases[chartData.projectedCases.length - 1];
-  const actualCasesToday =
-    chartData.actualCases[chartData.actualCases.length - 1];
-  const actualCasesDay90 = chartData.actualCases[0];
+  const actualCasesToday = chartData.cases[chartData.cases.length - 1];
+  const actualCasesDay90 = chartData.cases[0];
 
   const frameProps = {
     showLinePoints: false,
@@ -212,7 +215,7 @@ const ImpactProjectionChart: React.FC = () => {
         <Loading />
       ) : (
         <>
-          <ImpactToDateTable />
+          <ImpactToDateTable {...tableData} />
           <ChartTitle>
             Projection Assuming No Intervention vs. Actual Cumulative Cases
           </ChartTitle>

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -9,7 +9,8 @@ import Colors from "../design-system/Colors";
 import Loading from "../design-system/Loading";
 import { useFacilities } from "../facilities-context";
 import { useLocaleDataState } from "../locale-data-context";
-import { getChartData, ninetyDaysAgo, today } from "./projectionChartUtils";
+import ImpactToDateTable from "./ImpactToDateTable";
+import * as chartUtils from "./projectionChartUtils";
 import { HorizontalRule } from "./SnapshotPage";
 import { useWeeklyReport } from "./weekly-report-context";
 
@@ -103,8 +104,7 @@ const ImpactProjectionChart: React.FC = () => {
   if (!scenarioLoading && !facilitiesState.loading && !facilities.length) {
     return <div>Missing scenario data for state: {stateName}</div>;
   }
-
-  const chartData = getChartData(modelVersions, localeDataSource);
+  const chartData = chartUtils.getChartData(modelVersions, localeDataSource);
   const projectedCasesToday =
     chartData.projectedCases[chartData.projectedCases.length - 1];
   const actualCasesToday =
@@ -120,7 +120,7 @@ const ImpactProjectionChart: React.FC = () => {
         return {
           index,
           count,
-          date: dateFns.addDays(ninetyDaysAgo(), index),
+          date: dateFns.addDays(chartUtils.ninetyDaysAgo(), index),
         };
       }),
     })),
@@ -148,7 +148,7 @@ const ImpactProjectionChart: React.FC = () => {
       {
         orient: "bottom",
         label: "Date",
-        tickValues: [ninetyDaysAgo(), today()],
+        tickValues: [chartUtils.ninetyDaysAgo(), chartUtils.today()],
         tickFormat: (value: Date) => dateFns.format(value, "MM/dd"),
       },
       {
@@ -170,7 +170,7 @@ const ImpactProjectionChart: React.FC = () => {
         type: "react-annotation",
         color: Colors.black,
         disable: ["connector"],
-        date: dateFns.subDays(today(), 20),
+        date: dateFns.subDays(chartUtils.today(), 20),
         count: actualCasesToday,
         note: {
           title: "Today",
@@ -184,7 +184,7 @@ const ImpactProjectionChart: React.FC = () => {
         type: "react-annotation",
         color: Colors.black,
         disable: ["connector"],
-        date: ninetyDaysAgo(),
+        date: chartUtils.ninetyDaysAgo(),
         count: actualCasesDay90,
         note: {
           label: "Date of first recorded case",
@@ -194,7 +194,7 @@ const ImpactProjectionChart: React.FC = () => {
         type: "react-annotation",
         color: Colors.black,
         disable: ["connector"],
-        date: dateFns.subDays(today(), 10),
+        date: dateFns.subDays(chartUtils.today(), 10),
         count: projectedCasesToday,
         note: {
           padding: -30,
@@ -212,6 +212,7 @@ const ImpactProjectionChart: React.FC = () => {
         <Loading />
       ) : (
         <>
+          <ImpactToDateTable />
           <ChartTitle>
             Projection Assuming No Intervention vs. Actual Cumulative Cases
           </ChartTitle>

--- a/src/page-weekly-snapshot/ImpactToDateTable.tsx
+++ b/src/page-weekly-snapshot/ImpactToDateTable.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import styled from "styled-components";
+
+import {
+  BorderDiv,
+  HorizontalRule,
+  Left,
+  Right,
+  Table,
+  TableCell,
+  TableHeadingCell,
+  TextContainer,
+  TextContainerHeading,
+} from "./shared";
+
+const ImpactToDateTableContainer = styled.div`
+  margin: 0 3vw 3vw;
+`;
+
+const ImpactStatContainer = styled.div`
+  margin-right: 3vw;
+`;
+
+export default function ImpactToDateTable({}) {
+  return (
+    <ImpactToDateTableContainer>
+      <HorizontalRule />
+      <Table>
+        <thead>
+          <tr>
+            <TableHeadingCell>
+              <TextContainerHeading>
+                <Right>Intervention Impact To-Date</Right>
+              </TextContainerHeading>
+            </TableHeadingCell>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <TableCell>
+              <ImpactStatContainer>
+                <BorderDiv />
+                Incarcerated lives saved
+                <HorizontalRule />
+                <TextContainer>
+                  <Left>4</Left>
+                </TextContainer>
+              </ImpactStatContainer>
+            </TableCell>
+            <TableCell>
+              <ImpactStatContainer>
+                <BorderDiv />
+                Staff lives saved
+                <HorizontalRule />
+                <TextContainer>
+                  <Left>4</Left>
+                </TextContainer>
+              </ImpactStatContainer>
+            </TableCell>
+            <TableCell>
+              <ImpactStatContainer>
+                <BorderDiv />
+                Incarcerated cases prevented
+                <HorizontalRule />
+                <TextContainer>
+                  <Left>4</Left>
+                </TextContainer>
+              </ImpactStatContainer>
+            </TableCell>
+            <TableCell>
+              <BorderDiv />
+              Staff cases prevented
+              <HorizontalRule />
+              <TextContainer>
+                <Left>4</Left>
+              </TextContainer>
+            </TableCell>
+          </tr>
+        </tbody>
+      </Table>
+      <HorizontalRule />
+    </ImpactToDateTableContainer>
+  );
+}

--- a/src/page-weekly-snapshot/ImpactToDateTable.tsx
+++ b/src/page-weekly-snapshot/ImpactToDateTable.tsx
@@ -1,6 +1,8 @@
+import numeral from "numeral";
 import React from "react";
 import styled from "styled-components";
 
+import { TableData } from "./projectionChartUtils";
 import {
   BorderDiv,
   HorizontalRule,
@@ -21,7 +23,25 @@ const ImpactStatContainer = styled.div`
   margin-right: 3vw;
 `;
 
-export default function ImpactToDateTable({}) {
+const formatValue = (n: number) => numeral(n).format("0,0");
+
+const ImpactToDateTable: React.FC<TableData> = ({
+  staffCasesToday,
+  staffFatalitiesToday,
+  incarceratedCasesToday,
+  incarceratedFatalitiesToday,
+  projectedStaffCasesToday,
+  projectedStaffFatalitiesToday,
+  projectedIncarceratedCasesToday,
+  projectedIncarceratedFatalitiesToday,
+}) => {
+  const incarceratedLivesSaved =
+    projectedIncarceratedFatalitiesToday - incarceratedFatalitiesToday;
+  const staffLivesSaved = projectedStaffFatalitiesToday - staffFatalitiesToday;
+  const incarceratedCasesPrevented =
+    projectedIncarceratedCasesToday - incarceratedCasesToday;
+  const staffCasesPrevented = projectedStaffCasesToday - staffCasesToday;
+
   return (
     <ImpactToDateTableContainer>
       <HorizontalRule />
@@ -43,7 +63,7 @@ export default function ImpactToDateTable({}) {
                 Incarcerated lives saved
                 <HorizontalRule />
                 <TextContainer>
-                  <Left>4</Left>
+                  <Left>{formatValue(incarceratedLivesSaved)}</Left>
                 </TextContainer>
               </ImpactStatContainer>
             </TableCell>
@@ -53,7 +73,7 @@ export default function ImpactToDateTable({}) {
                 Staff lives saved
                 <HorizontalRule />
                 <TextContainer>
-                  <Left>4</Left>
+                  <Left>{formatValue(staffLivesSaved)}</Left>
                 </TextContainer>
               </ImpactStatContainer>
             </TableCell>
@@ -63,7 +83,7 @@ export default function ImpactToDateTable({}) {
                 Incarcerated cases prevented
                 <HorizontalRule />
                 <TextContainer>
-                  <Left>4</Left>
+                  <Left>{formatValue(incarceratedCasesPrevented)}</Left>
                 </TextContainer>
               </ImpactStatContainer>
             </TableCell>
@@ -72,7 +92,7 @@ export default function ImpactToDateTable({}) {
               Staff cases prevented
               <HorizontalRule />
               <TextContainer>
-                <Left>4</Left>
+                <Left>{formatValue(staffCasesPrevented)}</Left>
               </TextContainer>
             </TableCell>
           </tr>
@@ -81,4 +101,6 @@ export default function ImpactToDateTable({}) {
       <HorizontalRule />
     </ImpactToDateTableContainer>
   );
-}
+};
+
+export default ImpactToDateTable;

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -1,9 +1,7 @@
 import { sum } from "d3-array";
 import { get, keys, omit, orderBy, pick, values } from "lodash";
 import React from "react";
-import styled from "styled-components";
 
-import Colors from "../design-system/Colors";
 import { Column, PageContainer } from "../design-system/PageColumn";
 import { useFacilities } from "../facilities-context";
 import {
@@ -14,67 +12,18 @@ import {
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import { Facility } from "../page-multi-facility/types";
-
-const Table = styled.table`
-  color: ${Colors.black};
-  text-align: left;
-  width: 100%;
-  margin-top: 10px;
-`;
-const HorizontalRule = styled.hr`
-  border-color: ${Colors.black};
-  width: 100%;
-  margin-bottom: 10px;
-`;
-
-const TableHeadingCell = styled.td`
-  font-family: "Libre Franklin";
-  font-weight: bold;
-  font-size: 11px;
-  line-height: 13px;
-  vertical-align: middle;
-`;
-
-const LeftHeading = styled.div`
-  text-align: left;
-`;
-
-const TextContainerHeading = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 10px;
-`;
-
-const TextContainer = styled.div`
-  width: 100%;
-  margin: 15px 0 15px;
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  color: ${Colors.black};
-`;
-
-const Right = styled.div`
-  text-align: right;
-`;
-
-const Left = styled.div`
-  text-align: left;
-  font-size: 24px;
-  font-family: "Libre Baskerville";
-`;
-
-const BorderDiv = styled.div`
-  border-top: 2px solid ${Colors.black};
-`;
-
-const TableCell = styled.td<{ label?: boolean }>`
-  font-size: 11px;
-  line-height: 200%;
-  text-align: "left";
-  width: ${(props) => (props.label ? "200px" : "auto")};
-`;
+import {
+  BorderDiv,
+  HorizontalRule,
+  Left,
+  LeftHeading,
+  Right,
+  Table,
+  TableCell,
+  TableHeadingCell,
+  TextContainer,
+  TextContainerHeading,
+} from "./shared";
 
 type StateMetrics = {
   stateName: string;

--- a/src/page-weekly-snapshot/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/projectionChartUtils.tsx
@@ -332,10 +332,15 @@ export function getChartAndTableData(
     projectedIncarceratedFatalitiesToday: 0,
   };
 
-  console.log({ chartData, tableData, facilitiesData, projectionData });
-
   for (let index = 0; index <= NUM_DAYS; index++) {
     facilitiesData.forEach((facilityData) => {
+      // Sum staff+incarcerated across all facilities
+      chartData.cases[index] +=
+        facilityData.staffCases[index] + facilityData.incarceratedCases[index];
+      chartData.fatalities[index] +=
+        facilityData.staffFatalities[index] +
+        facilityData.incarceratedFatalities[index];
+
       // Sum the values across all facilities for today's index
       if (index === NUM_DAYS) {
         tableData.staffCasesToday += facilityData.staffCases[index];
@@ -345,16 +350,17 @@ export function getChartAndTableData(
         tableData.incarceratedFatalitiesToday +=
           facilityData.incarceratedFatalities[index];
       }
-
-      // Sum staff+incarcerated across all facilities
-      chartData.cases[index] +=
-        facilityData.staffCases[index] + facilityData.incarceratedCases[index];
-      chartData.fatalities[index] +=
-        facilityData.staffFatalities[index] +
-        facilityData.incarceratedFatalities[index];
     });
 
     projectionData.forEach((projection) => {
+      // Sum staff+incarcerated across all facilities
+      chartData.projectedCases[index] +=
+        projection.projectedStaffCases[index] +
+        projection.projectedIncarceratedCases[index];
+      chartData.projectedFatalities[index] +=
+        projection.projectedStaffFatalities[index] +
+        projection.projectedIncarceratedFatalities[index];
+
       // Sum the values across all facilities for today's index
       if (index === NUM_DAYS) {
         tableData.projectedStaffCasesToday +=
@@ -366,14 +372,6 @@ export function getChartAndTableData(
         tableData.projectedIncarceratedFatalitiesToday +=
           projection.projectedIncarceratedFatalities[index];
       }
-
-      // Sum staff+incarcerated across all facilities
-      chartData.projectedCases[index] +=
-        projection.projectedStaffCases[index] +
-        projection.projectedIncarceratedCases[index];
-      chartData.projectedFatalities[index] +=
-        projection.projectedStaffFatalities[index] +
-        projection.projectedIncarceratedFatalities[index];
     });
   }
 

--- a/src/page-weekly-snapshot/shared/index.tsx
+++ b/src/page-weekly-snapshot/shared/index.tsx
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+
+import Colors from "../../design-system/Colors";
+
+export const Table = styled.table`
+  color: ${Colors.black};
+  text-align: left;
+  width: 100%;
+  margin-top: 10px;
+  table-layout: fixed;
+`;
+
+export const HorizontalRule = styled.hr`
+  border-color: ${Colors.opacityGray};
+  width: 100%;
+  margin-bottom: 10px;
+`;
+
+export const TableHeadingCell = styled.td`
+  font-family: "Libre Franklin";
+  font-weight: bold;
+  font-size: 11px;
+  line-height: 13px;
+  vertical-align: middle;
+`;
+
+export const LeftHeading = styled.div`
+  text-align: left;
+`;
+
+export const TextContainerHeading = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+`;
+
+export const TextContainer = styled.div`
+  width: 100%;
+  margin: 15px 0 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  color: ${Colors.black};
+`;
+
+export const Right = styled.div`
+  text-align: right;
+`;
+
+export const Left = styled.div`
+  text-align: left;
+  font-size: 24px;
+  font-family: "Libre Baskerville";
+`;
+
+export const BorderDiv = styled.div`
+  border-top: 2px solid ${Colors.black};
+`;
+
+export const TableCell = styled.td<{ label?: boolean }>`
+  font-size: 11px;
+  line-height: 200%;
+  text-align: "left";
+  width: ${(props) => (props.label ? "200px" : "auto")};
+`;


### PR DESCRIPTION
## Description of the change

Adds the table stats section above the impact to date chart

cc @neeharmb  

@sychang If a calculation for one of the table numbers is negative, do we want to show that negative number, or replace it with 0?

![image](https://user-images.githubusercontent.com/5402804/88126025-7c04ce00-cb85-11ea-9557-bbd57b4283c3.png)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #589

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
