### PR TITLE
Fix issue with SyncNewFacility modal navigating home too soon

### DIFF
--- a/src/page-multi-facility/ReferenceDataModal/SyncNewFacility.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/SyncNewFacility.tsx
@@ -44,7 +44,9 @@ const SyncNewFacility: React.FC<Props> = ({ facilityId, onClose }) => {
     referenceFacilities,
   );
 
-  if (!facilityId || isEmpty(unmappedReferenceFacilities)) {
+  if (!facilityId) {
+    return null;
+  } else if (facilityId && isEmpty(unmappedReferenceFacilities)) {
     navigate("/");
     return null;
   }


### PR DESCRIPTION
## Description of the change

Fixes a bug where the SyncNewFacility modal navigates back to the homepage too soon. Checks unmappedReferenceFacilities and facilityId in an `else if` branch before navigating home. If this is approved and I'm offline, please feel free to merge!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
