### PR TITLE
Format page for printing to PDF

### DIFF
--- a/src/design-system/InputSelect.tsx
+++ b/src/design-system/InputSelect.tsx
@@ -20,6 +20,10 @@ const SelectContainer = styled.div`
   flex-grow: 1;
   flex-basis: 50%;
   margin-right: 8px;
+
+  @media print {
+    display: none;
+  }
 `;
 
 const caretSize = 5;

--- a/src/design-system/PageColumn.tsx
+++ b/src/design-system/PageColumn.tsx
@@ -9,6 +9,10 @@ export const PageContainer = styled.div`
   @media (max-width: 700px) {
     flex-direction: column;
   }
+
+  @media print {
+    flex-flow: row nowrap;
+  }
 `;
 
 const borderStyle = `1px solid ${Colors.paleGreen}`;
@@ -20,5 +24,9 @@ export const Column = styled.div<{ width?: string; borderTop?: boolean }>`
 
   @media (max-width: 700px) {
     width: inherit;
+  }
+
+  @media print {
+    width: 50%;
   }
 `;

--- a/src/page-weekly-snapshot/shared/index.tsx
+++ b/src/page-weekly-snapshot/shared/index.tsx
@@ -196,6 +196,12 @@ export const SnapshotPageContainer = styled.div`
   font-size: 11px;
   font-weight: 400;
   font-family: "Libre Franklin";
+  page-break-after: always;
+
+  @media print {
+    min-height: 1700px;
+    height: 100%;
+  }
 `;
 
 export const PageWidthContainer = styled.div`


### PR DESCRIPTION
## Description of the change

This is the first step in generating PDF reports from the weekly snapshot page. A user can select a state and then use the browser's File > Print option to print the page. I used these print settings--but could adjust the page to any other print settings if needed (@sychang)

![image](https://user-images.githubusercontent.com/5402804/88607610-823af480-d034-11ea-8dca-f1285a6cc1ff.png)

The next step would be to automate generating a PDF per state, @jessex and @sychang let me know if I should create a new issue for that, or keep referencing it with #644 !

Here's an example PDF:
[example_AL.pdf](https://github.com/Recidiviz/covid19-dashboard/files/4985431/example_AL.pdf)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #644

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
