### PR TITLE
Performance Improvements - Part One

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -82,6 +82,7 @@ interface CurveChartProps {
   hideAxes?: boolean;
   yAxisExtent?: number[];
   addAnnotations?: boolean;
+  useHoverAnnotations?: boolean;
 }
 
 const xAxisOptions: any[] = [
@@ -116,6 +117,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
   hideAxes,
   yAxisExtent = [0],
   addAnnotations = true,
+  useHoverAnnotations = true,
 }) => {
   const frameProps = {
     lines: Object.entries(curveData).map(([bucket, values]) => ({
@@ -169,7 +171,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
       }
       return null;
     },
-    hoverAnnotation: true,
+    hoverAnnotation: useHoverAnnotations,
     tooltipContent: Tooltip,
     // these two options place the hover targets along the line
     // (rather in the center of the area) but keep them invisible

--- a/src/impact-dashboard/CurveChartContainer.tsx
+++ b/src/impact-dashboard/CurveChartContainer.tsx
@@ -14,6 +14,7 @@ interface Props {
   markColors: ProjectionColors;
   curveData?: ChartData;
   addAnnotations?: boolean;
+  useHoverAnnotations?: boolean;
 }
 
 const CurveChartContainer: React.FC<Props> = ({
@@ -23,6 +24,7 @@ const CurveChartContainer: React.FC<Props> = ({
   hideAxes,
   curveData,
   addAnnotations = true,
+  useHoverAnnotations = true,
 }) => {
   const { hospitalBeds } = useEpidemicModelState();
   const [curveDataFiltered, setCurveDataFiltered] = useState(curveData);
@@ -62,6 +64,7 @@ const CurveChartContainer: React.FC<Props> = ({
       markColors={markColors}
       hideAxes={hideAxes}
       addAnnotations={addAnnotations}
+      useHoverAnnotations={useHoverAnnotations}
     />
   );
 };

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -86,6 +86,7 @@ interface Props {
 }
 
 const FacilityRow: React.FC<Props> = ({ facility, facilityRtData, onSave }) => {
+  console.log(facility.name);
   const {
     actions: { selectFacility },
   } = useFacilities();
@@ -203,6 +204,7 @@ const FacilityRow: React.FC<Props> = ({ facility, facilityRtData, onSave }) => {
             groupStatus={initialPublicCurveToggles}
             markColors={markColors}
             addAnnotations={false}
+            useHoverAnnotations={false}
           />
         </div>
       </DataContainer>

--- a/src/page-multi-facility/FacilityRow.tsx
+++ b/src/page-multi-facility/FacilityRow.tsx
@@ -86,7 +86,6 @@ interface Props {
 }
 
 const FacilityRow: React.FC<Props> = ({ facility, facilityRtData, onSave }) => {
-  console.log(facility.name);
   const {
     actions: { selectFacility },
   } = useFacilities();

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -7,14 +7,14 @@ import Colors from "../design-system/Colors";
 import iconAddSrc from "../design-system/icons/ic_add.svg";
 import Loading from "../design-system/Loading";
 import TextLabel from "../design-system/TextLabel";
-import { useFacilities } from "../facilities-context";
+import { FacilitiesState, useFacilities } from "../facilities-context";
 import { useFlag } from "../feature-flags";
 import useReadOnlyMode from "../hooks/useReadOnlyMode";
 import useReferenceFacilitiesEligible from "../hooks/useReferenceFacilitiesEligible";
 import useRejectionToast from "../hooks/useRejectionToast";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { getFacilitiesRtDataById } from "../infection-model/rt";
-import { useLocaleDataState } from "../locale-data-context";
+import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import useScenario from "../scenario-context/useScenario";
 import FacilityRow from "./FacilityRow";
 import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
@@ -24,7 +24,7 @@ import SyncNewReferenceData from "./ReferenceDataModal/SyncNewReferenceData";
 import SyncNoUserFacilities from "./ReferenceDataModal/SyncNoUserFacilities";
 import ScenarioSidebar from "./ScenarioSidebar";
 import SystemSummary from "./SystemSummary";
-import { Facility } from "./types";
+import { Facility, RtDataMapping } from "./types";
 
 const MultiFacilityImpactDashboardContainer = styled.main.attrs({
   className: `
@@ -77,6 +77,40 @@ const ScenarioTab = styled.li<{ active?: boolean }>`
   `
       : null}
 `;
+
+interface ProjectionsPanelProps {
+  facilitiesState: FacilitiesState;
+  facilities: Facility[];
+  localeDataSource: LocaleData;
+  rtData: Pick<RtDataMapping, string> | undefined;
+  handleFacilitySave: (facility: Facility) => void;
+}
+
+const ProjectionsPanel = (props: ProjectionsPanelProps) => {
+  return (
+    <>
+      <ProjectionsHeader />
+      {props.facilitiesState.loading ? (
+        <Loading />
+      ) : (
+        props.facilities.map((facility) => (
+          <FacilityRowPlaceholder key={facility.id}>
+            <EpidemicModelProvider
+              facilityModel={facility.modelInputs}
+              localeDataSource={props.localeDataSource}
+            >
+              <FacilityRow
+                facility={facility}
+                facilityRtData={props.rtData && props.rtData[facility.id]}
+                onSave={props.handleFacilitySave}
+              />
+            </EpidemicModelProvider>
+          </FacilityRowPlaceholder>
+        ))
+      )}
+    </>
+  );
+};
 
 const MultiFacilityImpactDashboard: React.FC = () => {
   const rejectionToast = useRejectionToast();
@@ -135,30 +169,6 @@ const MultiFacilityImpactDashboard: React.FC = () => {
 
   const [selectedTab, setSelectedTab] = useState(0);
 
-  const projectionsPanel = (
-    <>
-      <ProjectionsHeader />
-      {facilitiesState.loading ? (
-        <Loading />
-      ) : (
-        facilities.map((facility) => (
-          <FacilityRowPlaceholder key={facility.id}>
-            <EpidemicModelProvider
-              facilityModel={facility.modelInputs}
-              localeDataSource={localeDataSource}
-            >
-              <FacilityRow
-                facility={facility}
-                facilityRtData={rtData && rtData[facility.id]}
-                onSave={handleFacilitySave}
-              />
-            </EpidemicModelProvider>
-          </FacilityRowPlaceholder>
-        ))
-      )}
-    </>
-  );
-
   return (
     <MultiFacilityImpactDashboardContainer>
       {scenarioState.loading ? (
@@ -198,7 +208,15 @@ const MultiFacilityImpactDashboard: React.FC = () => {
             </ScenarioTabList>
           </ScenarioTabs>
         </div>
-        {selectedTab === 0 && projectionsPanel}
+        {selectedTab == 0 && (
+          <ProjectionsPanel
+            facilitiesState={facilitiesState}
+            facilities={facilities}
+            localeDataSource={localeDataSource}
+            rtData={rtData}
+            handleFacilitySave={handleFacilitySave}
+          />
+        )}
         {selectedTab === 1 && (
           <RateOfSpreadPanel
             facilities={facilities}

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -86,7 +86,9 @@ interface ProjectionsPanelProps {
   handleFacilitySave: (facility: Facility) => void;
 }
 
-const ProjectionsPanel = (props: ProjectionsPanelProps) => {
+const ProjectionsPanel = React.memo(function ProjectionsPanel(
+  props: ProjectionsPanelProps,
+) {
   return (
     <>
       <ProjectionsHeader />
@@ -110,7 +112,7 @@ const ProjectionsPanel = (props: ProjectionsPanelProps) => {
       )}
     </>
   );
-};
+});
 
 const MultiFacilityImpactDashboard: React.FC = () => {
   const rejectionToast = useRejectionToast();

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -1,6 +1,6 @@
 import { isAfter } from "date-fns";
 import { navigate } from "gatsby";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 
 import Colors from "../design-system/Colors";
@@ -15,6 +15,7 @@ import useRejectionToast from "../hooks/useRejectionToast";
 import { EpidemicModelProvider } from "../impact-dashboard/EpidemicModelContext";
 import { getFacilitiesRtDataById } from "../infection-model/rt";
 import { LocaleData, useLocaleDataState } from "../locale-data-context";
+import facility from "../pages/facility";
 import useScenario from "../scenario-context/useScenario";
 import FacilityRow from "./FacilityRow";
 import FacilityRowPlaceholder from "./FacilityRowPlaceholder";
@@ -154,11 +155,14 @@ const MultiFacilityImpactDashboard: React.FC = () => {
         );
       }));
 
-  const handleFacilitySave = async (facility: Facility) => {
-    if (scenarioId) {
-      await rejectionToast(createOrUpdateFacility(facility));
-    }
-  };
+  const handleFacilitySave = useCallback(
+    async (facility: Facility) => {
+      if (scenarioId) {
+        await rejectionToast(createOrUpdateFacility(facility));
+      }
+    },
+    [facility],
+  );
 
   useEffect(() => {
     setReferenceDataModalOpen(showSyncNewReferenceData);

--- a/src/page-multi-facility/projectionCurveHooks.tsx
+++ b/src/page-multi-facility/projectionCurveHooks.tsx
@@ -1,5 +1,5 @@
 import { zip } from "d3-array";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 import { EpidemicModelInputs } from "../impact-dashboard/EpidemicModelContext";
 import {
@@ -47,13 +47,12 @@ export const useProjectionData = (
     }
   }
 
-  const [curves, updateCurves] = useState(
-    getCurves(input, useRt, latestRt, numDays),
-  );
-
-  useEffect(() => {
-    updateCurves(getCurves(input, useRt, latestRt, numDays));
-  }, [input, latestRt, useRt, numDays]);
+  const curves = useMemo(() => getCurves(input, useRt, latestRt, numDays), [
+    input,
+    latestRt,
+    useRt,
+    numDays,
+  ]);
 
   return curves;
 };
@@ -87,10 +86,9 @@ function buildCurves(projectionData?: CurveData): CurveDataMapping | undefined {
 }
 
 export const useChartDataFromProjectionData = (projectionData?: CurveData) => {
-  const [curveData, updateCurveData] = useState(buildCurves(projectionData));
-  useEffect(() => {
-    updateCurveData(buildCurves(projectionData));
-  }, [projectionData]);
+  const curveData = useMemo(() => buildCurves(projectionData), [
+    projectionData,
+  ]);
 
   return curveData;
 };


### PR DESCRIPTION
## Performance Improvements - Part One

> "Hey kids, ~~spelling~~ memoizing is fun!" --Taylor Swift at some point, probably

Changes in this PR:
1. Switch `useState` + `useEffect` patterns to `useMemo`: The expensive function `buildCurves` has been called every time the main page re-rendered, and the result has been thrown away. Switching to `useMemo` caches the results of the last call and prevents the function from being called again if the dependencies haven't changed.

2. Make tooltips optional for projection graphs on the main page: I was noticing a spike in browser memory usage when hovering over projection graphs and decided to make adding tooltips an optional parameter. This seems to have reduced memory consumption and I synced with @sychang that they are not necessary to have on the main page. This parameter can also be used in other places (i.e. report automation) where tooltips are not needed. 

3. Moving `ProjectionsPanel` into a separate function and memoize: I'm actually not sure if this memoization here helps, but in the worst case it still is recalculated on every re-render (as it currently is) and this makes the code more readable. 

None of these changes appear to have impacted functionality from my testing, but please let me know if you notice any strangeness!

Next Steps:
While these changes seem to get larger scenarios loaded without the browser freezing or crashing, navigation to facilities/back to the main page is still very slow. Looking into that next!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Related to #657 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
