### PR TITLE
Report Polish - Part 3

### DIFF
--- a/src/impact-dashboard/CurveChart.tsx
+++ b/src/impact-dashboard/CurveChart.tsx
@@ -1,16 +1,16 @@
-// @ts-nocheck
 import { curveCatmullRom, format } from "d3";
-import { add } from "date-fns";
+import { add, format as formatDate } from "date-fns";
 import React from "react";
-import ResponsiveXYFrame from "semiotic/lib/ResponsiveXYFrame";
+import { ResponsiveXYFrame } from "semiotic";
 import styled from "styled-components";
 
 import ChartTooltip from "../design-system/ChartTooltip";
 import ChartWrapper from "../design-system/ChartWrapper";
+import { ProjectionColors } from "../design-system/Colors";
 import { DateMMMMdyyyy } from "../design-system/DateFormats";
-import { MarkColors } from "./ChartArea";
+import { SeirCompartmentKeys } from "../infection-model/seir";
 
-const CurveChartWrapper = styled(ChartWrapper)`
+const CurveChartWrapper = styled(ChartWrapper)<{ chartHeight: number }>`
   height: ${(props) => props.chartHeight}px;
 
   .threshold-annotation {
@@ -52,17 +52,15 @@ interface TooltipProps {
 
 const Tooltip: React.FC<TooltipProps> = ({
   count,
-  days,
+  date,
   parentLine: { title },
 }) => {
-  const displayDate = add(new Date(), { days });
-
   return (
     <ChartTooltip>
       <TooltipTitle>{title}</TooltipTitle>
       <TooltipDatalist>
         <TooltipDatum>
-          <DateMMMMdyyyy date={displayDate} />
+          <DateMMMMdyyyy date={date} />
         </TooltipDatum>
         <TooltipDatum>People: {formatThousands(count)}</TooltipDatum>
       </TooltipDatalist>
@@ -78,7 +76,7 @@ interface CurveChartProps {
   curveData: ChartData;
   chartHeight?: number;
   hospitalBeds: number;
-  markColors: MarkColors;
+  markColors: ProjectionColors;
   hideAxes?: boolean;
   yAxisExtent?: number[];
   addAnnotations?: boolean;
@@ -88,8 +86,9 @@ const xAxisOptions: any[] = [
   {
     orient: "bottom",
     tickLineGenerator: () => null,
-    label: "Days",
-    ticks: 5,
+    label: "Date",
+    ticks: 6,
+    tickFormat: (value: Date) => formatDate(new Date(value), "MM/dd"),
   },
   {
     tickLineGenerator: () => null,
@@ -121,14 +120,14 @@ const CurveChart: React.FC<CurveChartProps> = ({
     lines: Object.entries(curveData).map(([bucket, values]) => ({
       title: bucket,
       key: bucket,
-      coordinates: values.map((count, index) => ({
+      coordinates: values?.map((count, index) => ({
         count,
-        days: index,
+        date: add(new Date(), { days: index }),
       })),
     })),
-    renderKey: (d, i) => d.key || i,
+    renderKey: (d: any, i: number) => d.key || i,
     lineType: { type: "area", interpolator: curveCatmullRom },
-    xAccessor: "days",
+    xAccessor: "date",
     yAccessor: "count",
     responsiveHeight: true,
     responsiveWidth: true,
@@ -137,7 +136,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
     margin: hideAxes
       ? { top: 5 }
       : { left: 60, bottom: 60, right: 10, top: 10 },
-    lineStyle: ({ key }) => ({
+    lineStyle: ({ key }: { key: SeirCompartmentKeys }) => ({
       stroke: markColors[key],
       strokeWidth: 1,
       fill: markColors[key],
@@ -159,7 +158,7 @@ const CurveChart: React.FC<CurveChartProps> = ({
           }
         : {},
     ],
-    svgAnnotationRules: ({ d, yScale }) => {
+    svgAnnotationRules: ({ d, yScale }: { d: any; yScale: any }) => {
       if (d.type === "y") {
         // don't try to render hospital beds that won't fit in the chart;
         // otherwise they might be visible

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -19,30 +19,24 @@ import { initialPublicCurveToggles } from "../page-multi-facility/curveToggles";
 import { useProjectionData } from "../page-multi-facility/projectionCurveHooks";
 import { Facility } from "../page-multi-facility/types";
 import FacilitySummaryTable from "./FacilitySummaryTable";
-import { Heading, LeftHeading } from "./shared/index";
+import {
+  BorderDiv,
+  CellHeaderContainer,
+  COLUMN_SPACING,
+  Header,
+  HorizontalRule,
+  LeftHeading,
+  SectionHeader,
+  Table,
+  TableCell,
+  TableCellContainer,
+  TableHeading,
+  TextContainer,
+  Value,
+} from "./shared";
 import SnapshotPage from "./SnapshotPage";
 
 const DURATION = 21;
-
-export const Table = styled.table`
-  color: ${Colors.black};
-  text-align: left;
-  width: 100%;
-  margin-top: 10px;
-`;
-
-const TableHeadingCell = styled.td`
-  font-family: "Poppins", sans serif;
-  line-height: 24px;
-  margin-right: 5px;
-  vertical-align: middle;
-`;
-
-export const BorderDiv = styled.div<{ marginRight?: string }>`
-  border-top: 1px solid ${Colors.black};
-  margin-right: ${(props) => props.marginRight || "5px"};
-  margin-bottom: 10px;
-`;
 
 const ProjectionSection = styled.div`
   margin-top: 10px;
@@ -55,22 +49,6 @@ const ProjectionContainer = styled.div`
     fill: ${Colors.black};
     font-family: "Libre Franklin";
   }
-`;
-
-export const HorizontalRule = styled.hr<{ marginRight?: string }>`
-  border-color: ${Colors.opacityGray};
-  margin-top: 10px;
-  margin-right: ${(props) => props.marginRight || "0px"};
-`;
-
-const TableCell = styled.td<{ labelCell?: boolean }>`
-  font-size: 13px;
-  line-height: 200%;
-  text-align: left;
-  opacity: 0.7;
-  border-top: 1px solid ${Colors.darkGray};
-  vertical-align: middle;
-  width: ${(props) => (props.labelCell ? "200px" : "auto")};
 `;
 
 interface Props {
@@ -86,11 +64,17 @@ function makeTableRow(row: TableRow) {
   const { label, week1, week2, week3, overall } = row;
   return (
     <tr key={label}>
-      <TableCell labelCell>{label}</TableCell>
-      <TableCell>{formatThousands(week1)}</TableCell>
-      <TableCell>{formatThousands(week2)}</TableCell>
-      <TableCell>{formatThousands(week3)}</TableCell>
-      <TableCell>{formatThousands(overall)}</TableCell>
+      <TableCell>{label}</TableCell>
+      {[week1, week2, week3, overall].map((data, idx) => (
+        <TableCell key={`FacilityTable-${label}-${idx}`}>
+          <TableCellContainer marginRight={COLUMN_SPACING}>
+            <HorizontalRule />
+            <TextContainer>
+              <Value>{formatThousands(data)}</Value>
+            </TextContainer>
+          </TableCellContainer>
+        </TableCell>
+      ))}
     </tr>
   );
 }
@@ -99,10 +83,26 @@ function makeHeadingRow() {
   return (
     <tr>
       <td />
-      <TableHeadingCell>Week 1</TableHeadingCell>
-      <TableHeadingCell>Week 2</TableHeadingCell>
-      <TableHeadingCell>Week 3</TableHeadingCell>
-      <TableHeadingCell>Overall</TableHeadingCell>
+      <TableCell>
+        <CellHeaderContainer>
+          <Header>Week 1</Header>
+        </CellHeaderContainer>
+      </TableCell>
+      <TableCell>
+        <CellHeaderContainer>
+          <Header>Week 2</Header>
+        </CellHeaderContainer>
+      </TableCell>
+      <TableCell>
+        <CellHeaderContainer>
+          <Header>Week 3</Header>
+        </CellHeaderContainer>
+      </TableCell>
+      <TableCell>
+        <CellHeaderContainer>
+          <Header>Overall</Header>
+        </CellHeaderContainer>
+      </TableCell>
     </tr>
   );
 }
@@ -145,9 +145,22 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
           <FacilityProjection projectionData={projectionData} />
         </ProjectionContainer>
 
-        <Heading>Incarcerated Population Projection</Heading>
-        <BorderDiv />
+        <HorizontalRule marginRight={COLUMN_SPACING} />
         <Table>
+          <thead>
+            <tr>
+              <TableHeading colSpan={5}>
+                <TableCellContainer marginRight={COLUMN_SPACING}>
+                  <TextContainer>
+                    <SectionHeader>
+                      Incarcerated Population Projection
+                    </SectionHeader>
+                  </TextContainer>
+                  <BorderDiv />
+                </TableCellContainer>
+              </TableHeading>
+            </tr>
+          </thead>
           <tbody>
             {makeHeadingRow()}
             {incarceratedData.map((row) => makeTableRow(row))}
@@ -155,9 +168,20 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
         </Table>
       </ProjectionSection>
       <ProjectionSection>
-        <Heading>Staff Projection</Heading>
-        <BorderDiv />
+        <HorizontalRule marginRight={COLUMN_SPACING} />
         <Table>
+          <thead>
+            <tr>
+              <TableHeading colSpan={5}>
+                <TableCellContainer marginRight={COLUMN_SPACING}>
+                  <TextContainer>
+                    <SectionHeader>Staff Projection</SectionHeader>
+                  </TextContainer>
+                  <BorderDiv />
+                </TableCellContainer>
+              </TableHeading>
+            </tr>
+          </thead>
           <tbody>
             {makeHeadingRow()}
             {staffData.map((row) => makeTableRow(row))}

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import Colors, { MarkColors as markColors } from "../design-system/Colors";
+import Colors from "../design-system/Colors";
 import Loading from "../design-system/Loading";
-import ChartArea from "../impact-dashboard/ChartArea";
 import { useEpidemicModelState } from "../impact-dashboard/EpidemicModelContext";
 import {
   formatThousands,
@@ -13,11 +12,10 @@ import {
   buildIncarceratedData,
   buildStaffData,
 } from "../impact-dashboard/ImpactProjectionTableContainer";
-import { CurveData } from "../infection-model";
 import { RtData, RtError } from "../infection-model/rt";
-import { initialPublicCurveToggles } from "../page-multi-facility/curveToggles";
 import { useProjectionData } from "../page-multi-facility/projectionCurveHooks";
 import { Facility } from "../page-multi-facility/types";
+import FacilityProjectionChart from "./FacilityProjectionChart";
 import FacilitySummaryTable from "./FacilitySummaryTable";
 import {
   BorderDiv,
@@ -54,10 +52,6 @@ const ProjectionContainer = styled.div`
 interface Props {
   facility: Facility;
   rtData: RtData | RtError | undefined;
-}
-
-interface ProjectionProps {
-  projectionData: CurveData | undefined;
 }
 
 function makeTableRow(row: TableRow) {
@@ -107,26 +101,15 @@ function makeHeadingRow() {
   );
 }
 
-const FacilityProjection: React.FC<ProjectionProps> = ({ projectionData }) => {
-  return (
-    <ChartArea
-      projectionData={projectionData}
-      initialCurveToggles={initialPublicCurveToggles}
-      markColors={markColors}
-      title={"Estimated Impact"}
-    />
-  );
-};
-
 const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
-  const projectionData = useProjectionData(
+  const curveData = useProjectionData(
     useEpidemicModelState(),
     true,
     rtData,
     DURATION,
   );
-  if (!projectionData) return <Loading />;
-  const { incarcerated, staff } = projectionData;
+  if (!curveData) return <Loading />;
+  const { incarcerated, staff } = curveData;
   const incarceratedData = buildIncarceratedData(incarcerated);
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
 
@@ -136,13 +119,12 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
       <ProjectionSection>
         <ProjectionContainer>
           <FacilitySummaryTable facility={facility} />
-          <HorizontalRule />
         </ProjectionContainer>
       </ProjectionSection>
 
       <ProjectionSection>
         <ProjectionContainer>
-          <FacilityProjection projectionData={projectionData} />
+          <FacilityProjectionChart curveData={curveData} />
         </ProjectionContainer>
 
         <HorizontalRule marginRight={COLUMN_SPACING} />

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -1,0 +1,129 @@
+import { curveCatmullRom, format } from "d3";
+import { add, format as formatDate } from "date-fns";
+import { flatten, pick } from "lodash";
+import React from "react";
+import { ResponsiveXYFrame } from "semiotic";
+import styled from "styled-components";
+
+import Colors from "../design-system/Colors";
+import { CurveData } from "../infection-model";
+import { SeirCompartmentKeys } from "../infection-model/seir";
+import { useChartDataFromProjectionData } from "../page-multi-facility/projectionCurveHooks";
+import {
+  CHART_MARGINS,
+  ChartHeader,
+  ChartHeaderContainer,
+  HorizontalRule,
+  LegendContainer,
+  LegendText,
+} from "./shared";
+
+const CurveChartWrapper = styled.div`
+  height: 500px;
+
+  .axis.x {
+    stroke-width: 0.25px;
+  }
+`;
+
+const ChartContainer = styled.div`
+  font-size: 12px;
+  font-weight: 400;
+  margin-bottom: 50px;
+`;
+
+interface ProjectionProps {
+  curveData: CurveData | undefined;
+}
+
+export interface ChartData {
+  [key: string]: number[];
+}
+
+const formatThousands = format(",~g");
+
+const legendColors: { [key in string]: string } = {
+  exposed: Colors.green,
+  infectious: Colors.lightBlue,
+  hospitalized: Colors.darkRed,
+  fatalities: Colors.black,
+};
+
+const FacilityProjectionChart: React.FC<ProjectionProps> = ({ curveData }) => {
+  const chartData = pick(
+    useChartDataFromProjectionData(curveData),
+    Object.keys(legendColors),
+  ) as ChartData;
+
+  const allValues: number[] = flatten(Object.values(chartData));
+  const maxValue = allValues && Math.max(...allValues);
+
+  if (!chartData) return null;
+
+  const frameProps = {
+    lines: Object.entries(chartData).map(([bucket, values]) => ({
+      title: bucket,
+      key: bucket,
+      coordinates: values?.map((count, index) => ({
+        count,
+        date: add(new Date(), { days: index }),
+      })),
+    })),
+    renderKey: (d: any, i: number) => d.key || i,
+    lineType: { type: "line", interpolator: curveCatmullRom },
+    xAccessor: "date",
+    yAccessor: "count",
+    responsiveHeight: true,
+    responsiveWidth: true,
+    yExtent: [0, maxValue + 100],
+    margin: CHART_MARGINS,
+    lineStyle: ({ key }: { key: SeirCompartmentKeys }) => ({
+      stroke: legendColors[key],
+      strokeWidth: 2,
+      fill: legendColors[key],
+      fillOpacity: 1,
+    }),
+    axes: [
+      {
+        orient: "bottom",
+        ticks: 5,
+        tickFormat: (value: Date) => formatDate(new Date(value), "MM/dd"),
+      },
+      {
+        orient: "left",
+        label: "Number of people",
+        baseline: false,
+        tickLineGenerator: () => null,
+        tickFormat: formatThousands,
+      },
+    ],
+    showLinePoints: false,
+    pointStyle: { display: "none" },
+  };
+  return (
+    <ChartContainer>
+      <HorizontalRule />
+      <ChartHeaderContainer>
+        <ChartHeader>Estimated Impact</ChartHeader>
+        <LegendContainer>
+          <LegendText legendColor={legendColors.exposed}>Exposed</LegendText>
+          <LegendText legendColor={legendColors.infectious}>
+            Infectious
+          </LegendText>
+          <LegendText legendColor={legendColors.hospitalized}>
+            Hospitalized
+          </LegendText>
+          <LegendText legendColor={legendColors.fatalities}>
+            Fatalities
+          </LegendText>
+        </LegendContainer>
+      </ChartHeaderContainer>
+      <HorizontalRule />
+      <CurveChartWrapper>
+        <ResponsiveXYFrame {...frameProps} />
+      </CurveChartWrapper>
+    </ChartContainer>
+  );
+};
+
+export default FacilityProjectionChart;

--- a/src/page-weekly-snapshot/FacilitySummaryTable.tsx
+++ b/src/page-weekly-snapshot/FacilitySummaryTable.tsx
@@ -6,7 +6,7 @@ import {
 } from "../hooks/useAddCasesInputs";
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { Facility } from "../page-multi-facility/types";
-import { COLUMN_SPACING } from "./shared";
+import { COLUMN_SPACING, HorizontalRule } from "./shared";
 import StatsTable, {
   StatsTableRow,
   ValueDescriptionWithDelta,
@@ -86,9 +86,12 @@ const FacilitySummaryTable: React.FC<{
   ];
 
   return (
-    <StatsTable header="Facility Summary">
-      <StatsTableRow columns={tableData} columnMarginRight={COLUMN_SPACING} />
-    </StatsTable>
+    <>
+      <HorizontalRule />
+      <StatsTable header="Facility Summary">
+        <StatsTableRow columns={tableData} columnMarginRight={COLUMN_SPACING} />
+      </StatsTable>
+    </>
   );
 };
 

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -60,8 +60,8 @@ const formatThousands = format(",~g");
 const lineColors: { [key in string]: string } = {
   projectedCases: Colors.forest50,
   projectedFatalities: Colors.black50,
-  actualCases: Colors.black,
-  actualFatalities: Colors.tamarillo,
+  cases: Colors.black,
+  fatalities: Colors.tamarillo,
 };
 
 const ImpactProjectionChart: React.FC = () => {
@@ -164,7 +164,6 @@ const ImpactProjectionChart: React.FC = () => {
       {
         type: "react-annotation",
         color: Colors.black,
-        disable: ["connector"],
         date: chartUtils.ninetyDaysAgo(),
         count: actualCasesDay90,
         note: {
@@ -205,13 +204,11 @@ const ImpactProjectionChart: React.FC = () => {
             <LegendText legendColor={lineColors.projectedCases}>
               Projected cases w/o intervention
             </LegendText>
-            <LegendText legendColor={lineColors.actualCases}>
-              Actual cases
-            </LegendText>
+            <LegendText legendColor={lineColors.cases}>Actual cases</LegendText>
             <LegendText legendColor={lineColors.projectedFatalities}>
               Projected fatalities w/o intervention
             </LegendText>
-            <LegendText legendColor={lineColors.actualFatalities}>
+            <LegendText legendColor={lineColors.fatalities}>
               Actual fatalities
             </LegendText>
           </LegendContainer>

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -10,9 +10,9 @@ import Loading from "../design-system/Loading";
 import { useFacilities } from "../facilities-context";
 import { useLocaleDataState } from "../locale-data-context";
 import ImpactToDateTable from "./ImpactToDateTable";
-import * as chartUtils from "./projectionChartUtils";
 import { LegendContainer, LegendText } from "./shared";
 import { HorizontalRule } from "./shared/index";
+import * as chartUtils from "./shared/projectionChartUtils";
 import { useWeeklyReport } from "./weekly-report-context";
 
 const ImpactProjectionContainer = styled.div`

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -126,7 +126,11 @@ const ImpactProjectionChart: React.FC = () => {
       {
         orient: "bottom",
         label: "Date",
-        tickValues: [chartUtils.ninetyDaysAgo(), chartUtils.today()],
+        baseline: "under",
+        tickLineGenerator: function HideTickLines() {
+          return <path style={{ fill: "none" }} />;
+        },
+        tickValues: chartUtils.xAxisTickValues(),
         tickFormat: (value: Date) => dateFns.format(value, "MM/dd"),
       },
       {

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -127,18 +127,14 @@ const ImpactProjectionChart: React.FC = () => {
         orient: "bottom",
         label: "Date",
         baseline: "under",
-        tickLineGenerator: function HideTickLines() {
-          return <path style={{ fill: "none" }} />;
-        },
+        tickLineGenerator: () => null,
         tickValues: chartUtils.xAxisTickValues(),
         tickFormat: (value: Date) => dateFns.format(value, "MM/dd"),
       },
       {
         orient: "left",
         baseline: "under",
-        tickLineGenerator: function HideTickLines() {
-          return <path style={{ fill: "none" }} />;
-        },
+        tickLineGenerator: () => null,
         tickFormat: formatThousands,
       },
     ],

--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -4,14 +4,13 @@ import React from "react";
 import { ResponsiveXYFrame } from "semiotic";
 import styled from "styled-components";
 
-import ChartWrapper from "../design-system/ChartWrapper";
 import Colors from "../design-system/Colors";
 import Loading from "../design-system/Loading";
 import { useFacilities } from "../facilities-context";
 import { useLocaleDataState } from "../locale-data-context";
 import ImpactToDateTable from "./ImpactToDateTable";
 import { LegendContainer, LegendText } from "./shared";
-import { HorizontalRule } from "./shared/index";
+import { CHART_MARGINS, ChartHeader, HorizontalRule } from "./shared";
 import * as chartUtils from "./shared/projectionChartUtils";
 import { useWeeklyReport } from "./weekly-report-context";
 
@@ -20,15 +19,12 @@ const ImpactProjectionContainer = styled.div`
   margin-bottom: 5vw;
 `;
 
-const ChartTitle = styled.h3`
-  font-size: 11px;
-  font-weight: bold;
-  line-height: 13px;
-  margin: 0 5vw;
+const CurveChartContainer = styled.div`
+  margin-bottom: 50px;
 `;
 
-const CurveChartWrapper = styled(ChartWrapper)<{ chartHeight: number }>`
-  height: ${(props) => props.chartHeight}px;
+const CurveChartWrapper = styled.div`
+  height: 700px;
   display: flex;
   flex-flow: column;
 
@@ -108,8 +104,11 @@ const ImpactProjectionChart: React.FC = () => {
     responsiveHeight: true,
     responsiveWidth: true,
     size: [450, 450],
-    yExtent: { extent: [0], includeAnnotations: false },
-    margin: { left: 100, bottom: 60, right: 100, top: 10 },
+    yExtent: {
+      extent: [0, projectedCasesToday + 1000],
+      includeAnnotations: false,
+    },
+    margin: CHART_MARGINS,
     lineStyle: ({ key }: { key: string }) => {
       const baseStyle = {
         stroke: lineColors[key],
@@ -193,12 +192,15 @@ const ImpactProjectionChart: React.FC = () => {
       ) : (
         <>
           <ImpactToDateTable {...tableData} />
-          <ChartTitle>
+          <ChartHeader>
             Projection Assuming No Intervention vs. Actual Cumulative Cases
-          </ChartTitle>
-          <CurveChartWrapper chartHeight={700}>
-            <ResponsiveXYFrame {...frameProps} />
-          </CurveChartWrapper>
+          </ChartHeader>
+          <HorizontalRule />
+          <CurveChartContainer>
+            <CurveChartWrapper>
+              <ResponsiveXYFrame {...frameProps} />
+            </CurveChartWrapper>
+          </CurveChartContainer>
           <HorizontalRule />
           <LegendContainer>
             <LegendText legendColor={lineColors.projectedCases}>

--- a/src/page-weekly-snapshot/ImpactToDateTable.tsx
+++ b/src/page-weekly-snapshot/ImpactToDateTable.tsx
@@ -49,6 +49,7 @@ const ImpactToDateTable: React.FC<TableData> = ({
   ];
   return (
     <ImpactToDateTableContainer>
+      <HorizontalRule />
       <StatsTable header="Intervention Impact To-Date">
         <StatsTableRow columns={columnData} columnMarginRight={"3vw"} />
       </StatsTable>

--- a/src/page-weekly-snapshot/ImpactToDateTable.tsx
+++ b/src/page-weekly-snapshot/ImpactToDateTable.tsx
@@ -7,7 +7,7 @@ import { TableData } from "./shared/projectionChartUtils";
 import StatsTable, { StatsTableRow } from "./shared/StatsTable";
 
 const ImpactToDateTableContainer = styled.div`
-  margin: 0 3vw 3vw;
+  margin: 10px 0;
 `;
 
 const formatValue = (n: number) => numeral(n).format("0,0");

--- a/src/page-weekly-snapshot/ImpactToDateTable.tsx
+++ b/src/page-weekly-snapshot/ImpactToDateTable.tsx
@@ -2,8 +2,8 @@ import numeral from "numeral";
 import React from "react";
 import styled from "styled-components";
 
-import { TableData } from "./projectionChartUtils";
 import { HorizontalRule } from "./shared";
+import { TableData } from "./shared/projectionChartUtils";
 import StatsTable, { StatsTableRow } from "./shared/StatsTable";
 
 const ImpactToDateTableContainer = styled.div`

--- a/src/page-weekly-snapshot/LocaleStatsTable.tsx
+++ b/src/page-weekly-snapshot/LocaleStatsTable.tsx
@@ -1,6 +1,7 @@
 import { maxBy, minBy, orderBy } from "lodash";
 import numeral from "numeral";
 import React from "react";
+import styled from "styled-components";
 
 import { Column, PageContainer } from "../design-system/PageColumn";
 import { useFacilities } from "../facilities-context";
@@ -19,20 +20,27 @@ import {
 import { NYTCountyRecord, NYTStateRecord, useNYTData } from "./NYTDataProvider";
 import {
   BorderDiv,
+  CellHeaderContainer,
   COLUMN_SPACING,
+  Header,
   Heading,
   HorizontalRule,
   Left,
-  LeftHeading,
   RankContainer,
   RankText,
   Right,
+  SubHeader,
   Table,
   TableHeading,
   TextContainer,
   TextContainerHeading,
+  Value,
+  ValueDescription,
 } from "./shared";
+import StatsTable, { StatsTableRow } from "./shared/StatsTable";
 import { useWeeklyReport } from "./weekly-report-context";
+
+const LocaleStatsContainer = styled.div``;
 
 type PerCapitaCountyCase = {
   name: string;
@@ -157,7 +165,7 @@ function makeCountyRow(
           {direction} {num}
         </Right>
       </TextContainerHeading>
-      <HorizontalRule />
+      {index !== 3 && <HorizontalRule />}
     </tr>
   );
 }
@@ -165,34 +173,10 @@ function makeCountyRow(
 function makeFacilitiesToWatchRow(highestCountiesFacilities: string) {
   return (
     <tr>
-      <TextContainerHeading>
-        <Left>{highestCountiesFacilities}</Left>
-      </TextContainerHeading>
+      <TextContainer>
+        <Value>{highestCountiesFacilities}</Value>
+      </TextContainer>
     </tr>
-  );
-}
-
-function makeTableHeading(heading: string) {
-  return (
-    <TableHeading>
-      <BorderDiv marginRight={COLUMN_SPACING} />
-      <TextContainer>{heading}</TextContainer>
-      <HorizontalRule marginRight={COLUMN_SPACING} />
-    </TableHeading>
-  );
-}
-
-function makeTableSubheading(leftHeading: string, rightHeading: string) {
-  return (
-    <TableHeading>
-      <BorderDiv>
-        <TextContainer>
-          <LeftHeading marginTop={"0px"}>{leftHeading}</LeftHeading>
-          <Right>{rightHeading}</Right>
-        </TextContainer>
-      </BorderDiv>
-      <HorizontalRule />
-    </TableHeading>
   );
 }
 
@@ -263,54 +247,70 @@ const LocaleStatsTable: React.FC<{}> = () => {
   }
 
   return (
-    <>
+    <LocaleStatsContainer>
+      <HorizontalRule />
       <Heading>Locale Summary</Heading>
       <PageContainer>
-        <BorderDiv marginRight={"-20px"} />
-        <Column>
-          <Table>
-            <BorderDiv />
-          </Table>
+        <Column margin={`0 ${COLUMN_SPACING} 0 0`}>
+          <BorderDiv />
         </Column>
-        <Column>
+        <Column borderTop={false} margin={`0 0 0 ${COLUMN_SPACING}`}>
+          <StatsTable>
+            <StatsTableRow
+              columnMarginRight={COLUMN_SPACING}
+              columns={[
+                {
+                  header: "State rate of spread",
+                  value: " ",
+                  valueDescription: (
+                    <ValueDescription>since last week</ValueDescription>
+                  ),
+                },
+                {
+                  header: "Facilities with rate of spread > 1.00",
+                  value: `${numFacilitiesThisWeek} of ${totalNumFacilities}`,
+                  marginRight: "0px",
+                  valueDescription: (
+                    <ValueDescription>
+                      {getDirection(
+                        numFacilitiesLastWeek,
+                        numFacilitiesThisWeek,
+                      )}
+                      {numFacilitiesLastWeek} since last week
+                    </ValueDescription>
+                  ),
+                },
+              ]}
+            />
+          </StatsTable>
+          <BorderDiv />
           <Table>
-            <tr>
-              {makeTableHeading("State rate of spread")}
-              {makeTableHeading("Facilities with rate of spread > 1")}
-            </tr>
-            <td>
-              <TextContainer>
-                <Left />
-                <Right marginRight={COLUMN_SPACING}>since last week</Right>
-              </TextContainer>
-            </td>
-            <td>
-              <TextContainer>
-                <Left>
-                  {numFacilitiesThisWeek} of {totalNumFacilities}{" "}
-                </Left>
-                <Right marginRight={COLUMN_SPACING}>
-                  {getDirection(numFacilitiesLastWeek, numFacilitiesThisWeek)}
-                  {numFacilitiesLastWeek} since last week
-                </Right>
-              </TextContainer>
-            </td>
+            <tbody>
+              <tr>
+                <CellHeaderContainer>
+                  <Header>Counties to watch</Header>
+                  <SubHeader>
+                    Change in cases per 100k since last week
+                  </SubHeader>
+                </CellHeaderContainer>
+                <HorizontalRule />
+              </tr>
+              {highestFourCounties.map((row, index) =>
+                makeCountyRow(row, facilitiesCounties, index),
+              )}
+              <tr>
+                <TableHeading>
+                  <BorderDiv />
+                  <Header>Facilities in counties to watch</Header>
+                  <HorizontalRule />
+                </TableHeading>
+              </tr>
+              {makeFacilitiesToWatchRow(highestCountiesFacilities)}
+            </tbody>
           </Table>
-          <tr>
-            {makeTableSubheading(
-              "Counties to watch",
-              "Change in cases per 100k since last week",
-            )}
-          </tr>
-          {highestFourCounties.map((row, index) =>
-            makeCountyRow(row, facilitiesCounties, index),
-          )}
-          <br />
-          <tr>{makeTableSubheading("Facilities in counties to watch", "")}</tr>
-          {makeFacilitiesToWatchRow(highestCountiesFacilities)}
         </Column>
       </PageContainer>
-    </>
+    </LocaleStatsContainer>
   );
 };
 

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -12,7 +12,7 @@ import {
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { LocaleData, useLocaleDataState } from "../locale-data-context";
 import { Facility } from "../page-multi-facility/types";
-import { ValueDescription } from "./shared";
+import { HorizontalRule, ValueDescription } from "./shared";
 import StatsTable, { StatsTableRow } from "./shared/StatsTable";
 
 type StateMetrics = {
@@ -258,6 +258,7 @@ const LocaleSummaryTable: React.FC<{
           </StatsTable>
         </Column>
         <Column>
+          <HorizontalRule />
           <StatsTable header="Fatalities">
             {fatalitiesTableData.map((tableData, index) => (
               <StatsTableRow

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -248,6 +248,7 @@ const LocaleSummaryTable: React.FC<{
     <>
       <PageContainer>
         <Column>
+          <HorizontalRule />
           <StatsTable header="Cases">
             {casesTableData.map((tableData, index) => (
               <StatsTableRow

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -206,11 +206,13 @@ const LocaleSummaryTable: React.FC<{
     hasDeathData = totalIncarceratedDeaths.hasData;
   }
 
+  const NO_DATA = "No data";
+
   const casesTableData = [
     {
       header: "Incarcerated Cases",
       subheader: "(per 100k)",
-      value: hasCaseData ? formatThousands(incarceratedCasesRate) : "???",
+      value: hasCaseData ? formatThousands(incarceratedCasesRate) : NO_DATA,
     },
     {
       header: "Overall State Cases",
@@ -228,7 +230,7 @@ const LocaleSummaryTable: React.FC<{
     {
       header: "Incarcerated Fatalities",
       subheader: "(per 100k)",
-      value: hasDeathData ? formatThousands(incarceratedDeathsRate) : "???",
+      value: hasDeathData ? formatThousands(incarceratedDeathsRate) : NO_DATA,
     },
     {
       header: "Overall State Fatalities",

--- a/src/page-weekly-snapshot/SnapshotPage.tsx
+++ b/src/page-weekly-snapshot/SnapshotPage.tsx
@@ -3,17 +3,16 @@ import React from "react";
 import {
   Body,
   Emphasize,
+  FooterContainer,
+  FooterText,
   HorizontalRule,
   Image,
   ImageContainer,
   ImageLeft,
-  LeftHeading,
   PageHeader,
   PageSubheader,
   PageWidthContainer,
-  Right,
   SnapshotPageContainer,
-  TOP_BOTTOM_MARGIN,
 } from "./shared/index";
 
 interface Props {
@@ -23,12 +22,7 @@ interface Props {
   image?: string;
 }
 
-const SnapshotPage: React.FC<Props> = ({
-  header,
-  subheader,
-  children,
-  image,
-}) => {
+const SnapshotPage: React.FC<Props> = ({ header, children, image }) => {
   return (
     <SnapshotPageContainer>
       <PageWidthContainer>
@@ -40,19 +34,17 @@ const SnapshotPage: React.FC<Props> = ({
           )}
           <PageHeader>{header}</PageHeader>
         </ImageContainer>
-        {subheader && (
-          <PageSubheader>
-            Weekly snapshot provided by <Emphasize>recidiviz</Emphasize>
-          </PageSubheader>
-        )}
+        <PageSubheader>
+          Weekly snapshot provided by <Emphasize>recidiviz</Emphasize>
+        </PageSubheader>
       </PageWidthContainer>
       <Body>{children}</Body>
       <HorizontalRule />
       <PageWidthContainer>
-        <LeftHeading>Log in to update data: model.recividiz.org</LeftHeading>
-        <Right marginTop={TOP_BOTTOM_MARGIN}>
-          Questions and feedback: covid@recidiviz.org
-        </Right>
+        <FooterContainer>
+          <FooterText>Log in to update data: model.recividiz.org</FooterText>
+          <FooterText>Questions and feedback: covid@recidiviz.org</FooterText>
+        </FooterContainer>
       </PageWidthContainer>
       <HorizontalRule />
     </SnapshotPageContainer>

--- a/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
+++ b/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
@@ -7,8 +7,8 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import { useFacilities } from "../facilities-context";
 import { useLocaleDataState } from "../locale-data-context";
-import * as chartUtils from "./projectionChartUtils";
 import { HorizontalRule, LegendContainer, LegendText } from "./shared";
+import * as chartUtils from "./shared/projectionChartUtils";
 import SystemWideSummaryTable from "./SystemWideSummaryTable";
 import { useWeeklyReport } from "./weekly-report-context";
 

--- a/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
+++ b/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
@@ -7,7 +7,13 @@ import styled from "styled-components";
 import Colors from "../design-system/Colors";
 import { useFacilities } from "../facilities-context";
 import { useLocaleDataState } from "../locale-data-context";
-import { HorizontalRule, LegendContainer, LegendText } from "./shared";
+import {
+  CHART_MARGINS,
+  ChartHeader,
+  HorizontalRule,
+  LegendContainer,
+  LegendText,
+} from "./shared";
 import * as chartUtils from "./shared/projectionChartUtils";
 import SystemWideSummaryTable from "./SystemWideSummaryTable";
 import { useWeeklyReport } from "./weekly-report-context";
@@ -48,15 +54,6 @@ const CurveChartWrapper = styled.div`
     line-height: 17px;
     text-align: right;
   }
-`;
-
-export const ChartHeader = styled.h3`
-  color: ${Colors.black};
-  font-family: "Libre Franklin";
-  font-style: normal;
-  font-weight: 700;
-  font-size: 11px;
-  line-height: 13px;
 `;
 
 const legendColors = {
@@ -103,7 +100,7 @@ const SystemWideProjectionChart: React.FC = () => {
     responsiveHeight: true,
     responsiveWidth: true,
     yExtent: [0, maxValue + 50],
-    margin: { left: 100, bottom: 60, right: 100, top: 10 },
+    margin: CHART_MARGINS,
     lineStyle: {
       stroke: legendColors.projected,
       strokeWidth: 2,

--- a/src/page-weekly-snapshot/SystemWideSummaryTable.tsx
+++ b/src/page-weekly-snapshot/SystemWideSummaryTable.tsx
@@ -7,7 +7,7 @@ import {
 } from "../hooks/useAddCasesInputs";
 import { formatThousands } from "../impact-dashboard/ImpactProjectionTable";
 import { Facility } from "../page-multi-facility/types";
-import { COLUMN_SPACING } from "./shared";
+import { COLUMN_SPACING, HorizontalRule } from "./shared";
 import StatsTable, {
   StatsTableRow,
   ValueDescriptionWithDelta,
@@ -224,6 +224,7 @@ const SystemWideSummaryTable: React.FC<{}> = () => {
 
   return (
     <>
+      <HorizontalRule />
       <StatsTable header="Current System Summary">
         <StatsTableRow columns={tableData} columnMarginRight={COLUMN_SPACING} />
       </StatsTable>

--- a/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
+++ b/src/page-weekly-snapshot/WeeklySnapshotPage.tsx
@@ -140,7 +140,7 @@ const WeeklySnapshotPage: React.FC = () => {
                 <LocaleSummary />
                 <ImpactProjectionChart />
               </SnapshotPage>
-              <SnapshotPage header="System Snapshot" subheader>
+              <SnapshotPage header="System Snapshot">
                 <SystemWideProjectionChart />
                 <LocaleStatsTable />
               </SnapshotPage>

--- a/src/page-weekly-snapshot/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/projectionChartUtils.tsx
@@ -1,4 +1,5 @@
 import * as dateFns from "date-fns";
+import { chunk } from "lodash";
 import ndarray from "ndarray";
 
 import {
@@ -24,6 +25,27 @@ import { ModelInputs } from "../page-multi-facility/types";
 
 export const today = () => dateFns.endOfToday();
 export const ninetyDaysAgo = () => dateFns.subDays(today(), NUM_DAYS);
+
+export const ninetyDayInterval = () =>
+  dateFns.eachDayOfInterval({
+    start: ninetyDaysAgo(),
+    end: today(),
+  });
+
+/**
+ * Returns an array of 6 tick values to use on the projection chart
+ * Using this function instead of the XYFrame option `ticks` because it does not
+ * consistently start with the first value on the x axis
+ *
+ * @returns tickValues - [1/1/2020, 1/12/2020, ...]
+ */
+export const xAxisTickValues = () => {
+  const dates = ninetyDayInterval();
+  const chunkSize = NUM_DAYS / 5;
+  const chunks = chunk(dates, chunkSize);
+  return chunks.map((c) => c[0]);
+};
+
 const SEVEN_DAY_PROJECTION = 7;
 
 type ProjectedCases = {
@@ -251,10 +273,7 @@ function findClosestVersionForDates(versions: ModelInputs[], date: Date) {
  * @returns actualData - An object of staff/incarcerated cases/fatalities 90 day arrays
  */
 export function getFacilitiesData(modelVersions: ModelInputs[]) {
-  const datesInterval = dateFns.eachDayOfInterval({
-    start: ninetyDaysAgo(),
-    end: today(),
-  });
+  const datesInterval = ninetyDayInterval();
 
   const actualData: FacilitiesData = {
     staffCases: [],

--- a/src/page-weekly-snapshot/shared/StatsTable.tsx
+++ b/src/page-weekly-snapshot/shared/StatsTable.tsx
@@ -1,10 +1,10 @@
 import { get } from "lodash";
 import React from "react";
-import styled from "styled-components";
 
 import { formatThousands } from "../../impact-dashboard/ImpactProjectionTable";
 import {
   BorderDiv,
+  CellHeaderContainer,
   COLUMN_SPACING,
   Delta,
   DELTA_DIRECTION_MAPPING,
@@ -21,12 +21,6 @@ import {
   Value,
   ValueDescription,
 } from ".";
-
-const HeaderContainer = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-between;
-`;
 
 export const ValueDescriptionWithDelta: React.FC<{
   deltaDirection: string;
@@ -66,12 +60,12 @@ export const StatsTableRow: React.FC<StatsTableRowProps> = ({
         <TableCell key={`${columnData.header}-${index}`}>
           <TableCellContainer marginRight={columnMarginRight}>
             <BorderDiv />
-            <HeaderContainer>
+            <CellHeaderContainer>
               <Header>{columnData.header}</Header>
               {columnData.subheader && (
                 <SubHeader>{columnData.subheader}</SubHeader>
               )}
-            </HeaderContainer>
+            </CellHeaderContainer>
             <HorizontalRule />
             <TextContainer>
               <Value>{columnData.value}</Value>

--- a/src/page-weekly-snapshot/shared/StatsTable.tsx
+++ b/src/page-weekly-snapshot/shared/StatsTable.tsx
@@ -41,6 +41,7 @@ export const ValueDescriptionWithDelta: React.FC<{
 type ColumnData = {
   header: string;
   subheader?: string;
+  marginRight?: string;
   value: string;
   valueDescription?: React.ReactElement | undefined;
 };
@@ -58,7 +59,9 @@ export const StatsTableRow: React.FC<StatsTableRowProps> = ({
     <tr>
       {columns.map((columnData: ColumnData, index) => (
         <TableCell key={`${columnData.header}-${index}`}>
-          <TableCellContainer marginRight={columnMarginRight}>
+          <TableCellContainer
+            marginRight={columnData.marginRight || columnMarginRight}
+          >
             <BorderDiv />
             <CellHeaderContainer>
               <Header>{columnData.header}</Header>
@@ -79,15 +82,14 @@ export const StatsTableRow: React.FC<StatsTableRowProps> = ({
 };
 
 interface StatesTableProps {
-  header: string;
+  header?: string;
   children: React.ReactNode;
 }
 
 const StatsTable: React.FC<StatesTableProps> = ({ header, children }) => {
   return (
-    <>
-      <HorizontalRule />
-      <Table>
+    <Table>
+      {header && (
         <thead>
           <tr>
             <TableHeading>
@@ -97,9 +99,9 @@ const StatsTable: React.FC<StatesTableProps> = ({ header, children }) => {
             </TableHeading>
           </tr>
         </thead>
-        <tbody>{children}</tbody>
-      </Table>
-    </>
+      )}
+      <tbody>{children}</tbody>
+    </Table>
   );
 };
 

--- a/src/page-weekly-snapshot/shared/index.tsx
+++ b/src/page-weekly-snapshot/shared/index.tsx
@@ -99,7 +99,6 @@ export const BorderDiv = styled.div<{ marginRight?: string }>`
 
 export const HorizontalRule = styled.hr<{ marginRight?: string }>`
   border-color: ${Colors.opacityGray};
-  margin-top: 10px;
   margin-right: ${(props) => props.marginRight || "0px"};
 `;
 
@@ -148,7 +147,7 @@ export const TextContainerHeading = styled.div<{
 
 export const TextContainer = styled.div`
   width: 100%;
-  margin: 10px 0;
+  margin: 12px 0;
   display: flex;
   justify-content: space-between;
   align-items: baseline;
@@ -180,7 +179,6 @@ export const Left = styled.div<{
 export const TableCell = styled.td<{ label?: boolean }>`
   font-size: 13px;
   line-height: 200%;
-  text-align: "left";
   width: ${(props) => (props.label ? "200px" : "auto")};
 `;
 
@@ -194,6 +192,7 @@ export const Heading = styled.div`
 export const DeltaContainer = styled.div`
   display: flex;
   justify-content: flex-end;
+  font-size: 14px;
 `;
 
 export const SnapshotPageContainer = styled.div`
@@ -328,7 +327,7 @@ export const ValueDescription = styled.div<{
   marginRight?: string;
   marginTop?: string;
 }>`
-  font-size: 12px;
+  font-size: 14px;
   letter-spacing: -0.01em;
   margin-top: ${(props) => props.marginTop || "0px"};
   margin-right: ${(props) => props.marginRight || "0px"};
@@ -337,4 +336,10 @@ export const ValueDescription = styled.div<{
 
 export const TableCellContainer = styled.div<{ marginRight?: string }>`
   margin-right: ${(props) => props.marginRight || "0px"};
+`;
+
+export const CellHeaderContainer = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
 `;

--- a/src/page-weekly-snapshot/shared/index.tsx
+++ b/src/page-weekly-snapshot/shared/index.tsx
@@ -66,6 +66,22 @@ export const STATE_CODE_MAPPING = {
   "Wyoming": "WY",
 };
 
+export const FooterContainer = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  padding: ${TOP_BOTTOM_MARGIN} 0;
+  width: 100%;
+`;
+
+export const FooterText = styled.div`
+  color: ${Colors.black};
+  font-size: 12px;
+  font-family: "Libre Franklin";
+  font-weight: 500;
+  letter-spacing: -0.01em;
+`;
+
 export const Delta = styled.div<{ deltaDirection?: string }>`
   color: ${(props) =>
     props.deltaDirection == "positive"
@@ -103,14 +119,6 @@ export const HorizontalRule = styled.hr<{ marginRight?: string }>`
   margin-right: ${(props) => props.marginRight || "0px"};
 `;
 
-export const TableHeadingCell = styled.th`
-  font-family: "Libre Franklin";
-  font-weight: bold;
-  font-size: 11px;
-  line-height: 13px;
-  vertical-align: middle;
-`;
-
 export const RankContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -122,7 +130,7 @@ export const RankContainer = styled.div`
 
 export const RankText = styled.td`
   font-family: "Libre Franklin";
-  font-size: 11px;
+  font-size: 13px;
   margin-right: 10px;
   align-items: baseline;
 `;
@@ -184,10 +192,12 @@ export const TableCell = styled.td<{ label?: boolean }>`
 `;
 
 export const Heading = styled.div`
-  font-weight: 700;
+  color: ${Colors.black};
+  font-family: "Libre Franklin";
+  font-size: 13px;
+  font-weight: bold;
   line-height: 13px;
-  border-top: 1px solid ${Colors.darkGray};
-  padding: 10px 0;
+  padding: ${TOP_BOTTOM_MARGIN} 0;
 `;
 
 export const DeltaContainer = styled.div`
@@ -229,7 +239,7 @@ export const PageHeader = styled.div`
   margin-bottom: 3px;
   font-family: "Libre Baskerville";
   text-align: left;
-  padding-top: 10px;
+  padding-top: ${TOP_BOTTOM_MARGIN};
 `;
 
 export const PageSubheader = styled.div`
@@ -256,7 +266,7 @@ export const Image = styled.img`
   -webkit-border-radius: 40px;
   border: 1px solid black;
   padding-top: 5px;
-  margin-top: 10px;
+  margin-top: ${TOP_BOTTOM_MARGIN};
   margin-bottom: -10px;
 `;
 

--- a/src/page-weekly-snapshot/shared/index.tsx
+++ b/src/page-weekly-snapshot/shared/index.tsx
@@ -4,6 +4,7 @@ import Colors from "../../design-system/Colors";
 
 export const COLUMN_SPACING = "20px";
 export const TOP_BOTTOM_MARGIN = "10px";
+export const CHART_MARGINS = { left: 100, bottom: 60, right: 100, top: 10 };
 
 export const DELTA_DIRECTION_MAPPING = {
   positive: "↑ ",
@@ -275,7 +276,7 @@ export const LegendContainer = styled.div`
   color: ${Colors.black};
   display: flex;
   flex-flow: row nowrap;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 500;
   margin: 10px 0;
 `;
@@ -342,4 +343,21 @@ export const CellHeaderContainer = styled.div`
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
+`;
+
+export const ChartHeader = styled.h3`
+  color: ${Colors.black};
+  font-family: "Libre Franklin";
+  font-style: normal;
+  font-weight: bold;
+  font-size: 13px;
+  line-height: 13px;
+  margin-bottom: 1vw;
+`;
+
+export const ChartHeaderContainer = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  align-items: baseline;
 `;

--- a/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
@@ -11,17 +11,20 @@ import {
   totalIncarceratedConfirmedDeaths,
   totalStaffConfirmedCases,
   totalStaffConfirmedDeaths,
-} from "../impact-dashboard/EpidemicModelContext";
+} from "../../impact-dashboard/EpidemicModelContext";
 import {
   countActiveCasesForDay,
   countCasesForDay,
-} from "../impact-dashboard/ImpactProjectionTableContainer";
-import { NUM_DAYS } from "../infection-model";
-import { calculateCurves, curveInputsFromUserInputs } from "../infection-model";
-import { getAllValues, getColView } from "../infection-model/matrixUtils";
-import { seirIndex } from "../infection-model/seir";
-import { LocaleData } from "../locale-data-context";
-import { ModelInputs } from "../page-multi-facility/types";
+} from "../../impact-dashboard/ImpactProjectionTableContainer";
+import { NUM_DAYS } from "../../infection-model";
+import {
+  calculateCurves,
+  curveInputsFromUserInputs,
+} from "../../infection-model";
+import { getAllValues, getColView } from "../../infection-model/matrixUtils";
+import { seirIndex } from "../../infection-model/seir";
+import { LocaleData } from "../../locale-data-context";
+import { ModelInputs } from "../../page-multi-facility/types";
 
 export const today = () => dateFns.endOfToday();
 export const ninetyDaysAgo = () => dateFns.subDays(today(), NUM_DAYS);

--- a/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
@@ -49,7 +49,8 @@ export const xAxisTickValues = () => {
   return chunks.map((c) => c[0]);
 };
 
-const SEVEN_DAY_PROJECTION = 7;
+// Projection should show 8 data points, the current day + 7 days
+const NEXT_SEVEN_DAYS_PROJECTION = 8;
 
 type ProjectedCases = {
   projectedStaffCases: number[];
@@ -457,12 +458,12 @@ function get7DayProjection(
 ): ProjectedCases {
   const curveData = calculateCurveData(
     epidemicModelInputs,
-    SEVEN_DAY_PROJECTION,
+    NEXT_SEVEN_DAYS_PROJECTION,
   );
 
   const zeroProjection = {
-    projectedStaffCases: Array(SEVEN_DAY_PROJECTION).fill(0),
-    projectedIncarceratedCases: Array(SEVEN_DAY_PROJECTION).fill(0),
+    projectedStaffCases: Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0),
+    projectedIncarceratedCases: Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0),
   };
 
   if (!curveData) return zeroProjection;
@@ -493,9 +494,9 @@ export function get7DayProjectionChartData(
     get7DayProjection,
   );
 
-  let totalActiveCases = Array(SEVEN_DAY_PROJECTION).fill(0);
+  let totalActiveCases = Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0);
 
-  for (let index = 0; index < SEVEN_DAY_PROJECTION; index++) {
+  for (let index = 0; index < NEXT_SEVEN_DAYS_PROJECTION; index++) {
     facilitiesProjections.forEach((facility) => {
       totalActiveCases[index] +=
         facility.projectedIncarceratedCases[index] +


### PR DESCRIPTION
## Description of the change

[example_AL-2.pdf](https://github.com/Recidiviz/covid19-dashboard/files/5009402/example_AL-2.pdf)

Includes the following updates:
- P1: Update “???” to “No data” when we have no data
- P1: Add an arrow pointing toward the date of first case
- P1: Add more date labels on the x-axis, at least 5 total based on what’s straightforward to do with the graphing library. Actual number not important
- For # of facilities with rate of spread > 1, add 2 decimal points to make it “1.00”
- P1: Change x-axis labels from “day 0” to actual date (otherwise, there is no easy way to timestamp these pages in case they get separated from the rest of the report)
- P1: Update table font sizes and styles to match mocks. The numbers should be same style as in the summary stats. Aim to make it 2x as tall to take up some more space on the page
- P1: “Estimated impact” and legend font to match mocks / the rest of the report
- P2: Remove shading for lines (or somehow make the shading transparent?). If that’s too annoying, ignore.
- P2: Based on how much whitespace is left after making the table vertically longer, increase the chart y-axis height to take up some more space on page


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #660

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
