### PR TITLE
Format the ranking text based on rank > 25

### DIFF
--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -46,6 +46,21 @@ function formatOrdinal(value: number) {
   return value + (suffix[(rem - 20) % 10] || suffix[rem] || suffix[0]);
 }
 
+function formatRankText(rank: number) {
+  if (rank === 0) return null;
+  // Based on whether rank > 25 or rank <= 25. Example: 42nd lowest = 8th highest
+  const rankOver25 = rank > 25;
+  const leveledRank = rankOver25 ? 50 - rank : rank;
+  const rankLevel = rankOver25 ? "highest" : "lowest";
+  if (rank === 50) {
+    return `Highest of ${NUM_STATES} states`;
+  } else if (rank === 1) {
+    return `Lowest of ${NUM_STATES} states`;
+  } else {
+    return `${formatOrdinal(leveledRank)} ${rankLevel} of ${NUM_STATES}`;
+  }
+}
+
 function getRate(
   numerator: number | undefined,
   denominator: number | undefined,
@@ -217,11 +232,9 @@ const LocaleSummaryTable: React.FC<{
     {
       header: "Overall State Cases",
       subheader: "(per 100k)",
-      value: formatThousands(casesRate),
+      value: casesRate ? formatThousands(casesRate) : NO_DATA,
       valueDescription: (
-        <ValueDescription>
-          {formatOrdinal(casesRateRank)} lowest of {NUM_STATES}
-        </ValueDescription>
+        <ValueDescription>{formatRankText(casesRateRank)}</ValueDescription>
       ),
     },
   ];
@@ -235,11 +248,9 @@ const LocaleSummaryTable: React.FC<{
     {
       header: "Overall State Fatalities",
       subheader: "(per 100k)",
-      value: formatThousands(deathsRate),
+      value: deathsRate ? formatThousands(deathsRate) : NO_DATA,
       valueDescription: (
-        <ValueDescription>
-          {formatOrdinal(deathsRateRank)} lowest of {NUM_STATES}
-        </ValueDescription>
+        <ValueDescription>{formatRankText(deathsRateRank)}</ValueDescription>
       ),
     },
   ];

--- a/src/page-weekly-snapshot/LocaleSummaryTable.tsx
+++ b/src/page-weekly-snapshot/LocaleSummaryTable.tsx
@@ -50,9 +50,9 @@ function formatRankText(rank: number) {
   if (rank === 0) return null;
   // Based on whether rank > 25 or rank <= 25. Example: 42nd lowest = 8th highest
   const rankOver25 = rank > 25;
-  const leveledRank = rankOver25 ? 50 - rank : rank;
+  const leveledRank = rankOver25 ? 51 - rank : rank;
   const rankLevel = rankOver25 ? "highest" : "lowest";
-  if (rank === 50) {
+  if (rank === NUM_STATES) {
     return `Highest of ${NUM_STATES} states`;
   } else if (rank === 1) {
     return `Lowest of ${NUM_STATES} states`;


### PR DESCRIPTION
## Description of the change

This adds logic for the ranking text on the locale summary table:
 
P2: Add logic to show “XXth lowest/highest” based on whether XX>25 or XX<=25. Example, 42nd lowest = 8th highest.

@sychang I added some additional logic so that:

- when rank = 50 it reads: "Highest of 50 states"
- when rank = 1 it reads: "Lowest of 50 states"
- when rank = 0: it doesn't show this text, and it replaces the 0 overall cases with "No data"

Let me know if there should be any changes to that!

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #170 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
