### PR TITLE
Split up incarcerated/staff data on system-wide projection chart

### DIFF
--- a/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
+++ b/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
@@ -1,5 +1,6 @@
 import { curveCatmullRom, scaleTime } from "d3";
 import * as dateFns from "date-fns";
+import { flatten } from "lodash";
 import React from "react";
 import { ResponsiveXYFrame } from "semiotic";
 import styled from "styled-components";
@@ -56,8 +57,9 @@ const CurveChartWrapper = styled.div`
   }
 `;
 
-const legendColors = {
-  projected: Colors.black,
+const legendColors: { [key in string]: string } = {
+  incarcerated: Colors.black,
+  staff: Colors.forest50,
   today: Colors.tamarillo,
 };
 
@@ -81,15 +83,36 @@ const SystemWideProjectionChart: React.FC = () => {
     modelVersions,
     localeDataSource,
   );
-  const maxValue = Math.max(...activeCases);
-  const chartData = activeCases.map((cases, index) => {
-    return {
+
+  const maxValue = Math.max(...activeCases.incarcerated, ...activeCases.staff);
+
+  const chartData = Object.entries(activeCases).map(([bucket, values]) => ({
+    title: bucket,
+    key: bucket,
+    coordinates: values.map((cases: number, index) => ({
       cases,
       date: dateFns.addDays(chartUtils.today(), index),
-      color: index === 0 ? legendColors.today : legendColors.projected,
-    };
-  });
+      color: index === 0 ? legendColors.today : legendColors[bucket],
+    })),
+  }));
 
+  const annotations = flatten(
+    chartData.map(({ coordinates }) => {
+      return coordinates.map((data) => {
+        return {
+          type: "react-annotation",
+          disable: ["connector"],
+          note: {
+            label: `${data.cases}`,
+            orientation: "topBottom",
+            align: "top",
+            padding: 10,
+          },
+          ...data,
+        };
+      });
+    }),
+  );
   const frameProps = {
     showLinePoints: true,
     lines: chartData,
@@ -101,12 +124,12 @@ const SystemWideProjectionChart: React.FC = () => {
     responsiveWidth: true,
     yExtent: [0, maxValue + 50],
     margin: CHART_MARGINS,
-    lineStyle: {
-      stroke: legendColors.projected,
+    lineStyle: ({ key }: { key: string }) => ({
+      stroke: legendColors[key],
       strokeWidth: 2,
-      fill: legendColors.projected,
+      fill: legendColors[key],
       fillOpacity: 1,
-    },
+    }),
     pointStyle: (d: any) => {
       return {
         fill: d.color,
@@ -119,7 +142,7 @@ const SystemWideProjectionChart: React.FC = () => {
         orient: "bottom",
         baseline: "under",
         label: "Date",
-        tickValues: chartData.map((d) => d.date),
+        tickValues: chartData[0].coordinates.map((d) => d.date),
         tickFormat: (d: any) => d.getMonth() + 1 + "/" + d.getDate(),
       },
       {
@@ -134,20 +157,7 @@ const SystemWideProjectionChart: React.FC = () => {
         padding: -5,
       },
     },
-    annotations: [
-      ...chartData.map((data) => {
-        return {
-          type: "react-annotation",
-          disable: ["connector"],
-          note: {
-            label: `${data.cases}`,
-            orientation: "topBottom",
-            align: "top",
-          },
-          ...data,
-        };
-      }),
-    ],
+    annotations,
   };
 
   return (
@@ -160,8 +170,11 @@ const SystemWideProjectionChart: React.FC = () => {
             System-Wide Projection for Facilities with Active Cases
           </ChartHeader>
           <LegendContainer>
-            <LegendText legendColor={legendColors.projected}>
-              Projected Cases
+            <LegendText legendColor={legendColors.incarcerated}>
+              Projected Incarcerated Cases
+            </LegendText>
+            <LegendText legendColor={legendColors.staff}>
+              Projected Staff Cases
             </LegendText>
             <LegendText legendColor={legendColors.today}>
               Cases Today

--- a/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
+++ b/src/page-weekly-snapshot/SystemWideProjectionChart.tsx
@@ -142,7 +142,9 @@ const SystemWideProjectionChart: React.FC = () => {
         orient: "bottom",
         baseline: "under",
         label: "Date",
-        tickValues: chartData[0].coordinates.map((d) => d.date),
+        tickValues: chartData[0]
+          ? chartData[0].coordinates.map((d) => d.date)
+          : [],
         tickFormat: (d: any) => d.getMonth() + 1 + "/" + d.getDate(),
       },
       {

--- a/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
@@ -480,13 +480,14 @@ function get7DayProjection(
  *
  * @param modelVersions - An array of modelVersions for multiple facilities
  * @param localeDataSource - LocaleData from the LocaleDataContext
- * @returns totalActiveCases - Array of 7 values for active cases
+ * @returns { incarcerated, staff } - Object with incarcerated/staff array of
+ * 7 values for active cases for each bucket
  *
  */
 export function get7DayProjectionChartData(
   modelVersions: ModelInputs[][],
   localeDataSource: LocaleData,
-) {
+): { [key: string]: number[] } {
   const facilitiesProjections: ProjectedCases[] = getFacilitiesProjectionData(
     modelVersions,
     localeDataSource,
@@ -494,15 +495,19 @@ export function get7DayProjectionChartData(
     get7DayProjection,
   );
 
-  let totalActiveCases = Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0);
+  let totalActiveIncarceratedCases = Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0);
+  let totalActiveStaffCases = Array(NEXT_SEVEN_DAYS_PROJECTION).fill(0);
 
   for (let index = 0; index < NEXT_SEVEN_DAYS_PROJECTION; index++) {
     facilitiesProjections.forEach((facility) => {
-      totalActiveCases[index] +=
-        facility.projectedIncarceratedCases[index] +
-        facility.projectedStaffCases[index];
+      totalActiveIncarceratedCases[index] +=
+        facility.projectedIncarceratedCases[index];
+      totalActiveStaffCases[index] += facility.projectedStaffCases[index];
     });
   }
 
-  return totalActiveCases;
+  return {
+    incarcerated: totalActiveIncarceratedCases,
+    staff: totalActiveStaffCases,
+  };
 }


### PR DESCRIPTION
## Description of the change

This splits up the data for the 7 day system-wide projection chart on page 2 so that it shows incarcerated and staff data points as two lines. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #667

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
