### PR TITLE
Display est. rate of spread on facility chart when available

### DIFF
--- a/src/infection-model/rt.tsx
+++ b/src/infection-model/rt.tsx
@@ -63,6 +63,10 @@ export function isRtError(data: any): data is RtError {
   return has(data, "error");
 }
 
+export function getLatestRtValue(data: RtData | RtError | undefined) {
+  return isRtData(data) ? data.Rt[data.Rt.length - 1].value : null;
+}
+
 const getFetchUrl = () => {
   let url = "https://us-central1-c19-backend.cloudfunctions.net/calculate_rt";
   if (process.env.NODE_ENV !== "production") {

--- a/src/page-weekly-snapshot/FacilityPage.tsx
+++ b/src/page-weekly-snapshot/FacilityPage.tsx
@@ -12,7 +12,7 @@ import {
   buildIncarceratedData,
   buildStaffData,
 } from "../impact-dashboard/ImpactProjectionTableContainer";
-import { RtData, RtError } from "../infection-model/rt";
+import { getLatestRtValue, RtData, RtError } from "../infection-model/rt";
 import { useProjectionData } from "../page-multi-facility/projectionCurveHooks";
 import { Facility } from "../page-multi-facility/types";
 import FacilityProjectionChart from "./FacilityProjectionChart";
@@ -105,6 +105,7 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
   const { incarcerated, staff } = curveData;
   const incarceratedData = buildIncarceratedData(incarcerated);
   const staffData = buildStaffData({ staff, showHospitalizedRow: false });
+  const latestRtValue = getLatestRtValue(rtData);
 
   return (
     <SnapshotPage header={facility.name}>
@@ -117,7 +118,10 @@ const FacilityPage: React.FC<Props> = ({ facility, rtData }) => {
 
       <ProjectionSection>
         <ProjectionContainer>
-          <FacilityProjectionChart curveData={curveData} />
+          <FacilityProjectionChart
+            curveData={curveData}
+            latestRtValue={latestRtValue}
+          />
         </ProjectionContainer>
 
         <HorizontalRule marginRight={COLUMN_SPACING} />

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -34,6 +34,7 @@ const ChartContainer = styled.div`
 
 interface ProjectionProps {
   curveData: CurveData | undefined;
+  latestRtValue: number | null;
 }
 
 export interface ChartData {
@@ -41,6 +42,7 @@ export interface ChartData {
 }
 
 const formatThousands = format(",~g");
+const formatRtValue = format(".2f");
 
 const legendColors: { [key in string]: string } = {
   exposed: Colors.green,
@@ -49,7 +51,10 @@ const legendColors: { [key in string]: string } = {
   fatalities: Colors.black,
 };
 
-const FacilityProjectionChart: React.FC<ProjectionProps> = ({ curveData }) => {
+const FacilityProjectionChart: React.FC<ProjectionProps> = ({
+  curveData,
+  latestRtValue,
+}) => {
   const chartData = pick(
     useChartDataFromProjectionData(curveData),
     Object.keys(legendColors),
@@ -104,7 +109,11 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({ curveData }) => {
     <ChartContainer>
       <HorizontalRule />
       <ChartHeaderContainer>
-        <ChartHeader>Estimated Impact</ChartHeader>
+        <ChartHeader>
+          Estimated Impact{" "}
+          {latestRtValue &&
+            `(Estimated rate of spread: ${formatRtValue(latestRtValue)})`}
+        </ChartHeader>
         <LegendContainer>
           <LegendText legendColor={legendColors.exposed}>Exposed</LegendText>
           <LegendText legendColor={legendColors.infectious}>


### PR DESCRIPTION
## Description of the change

This adds a facility's Rt value used to calculate the charts in the Estimated Impact heading if it's available. For now, if it's not available we're are not displaying anything, and @sychang mentioned adding something to the appendix about it. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Part of #667 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
