### PR TITLE
Remove fatalities from the impact to date chart

### DIFF
--- a/src/page-weekly-snapshot/ImpactProjectionChart.tsx
+++ b/src/page-weekly-snapshot/ImpactProjectionChart.tsx
@@ -55,9 +55,7 @@ const formatThousands = format(",~g");
 
 const lineColors: { [key in string]: string } = {
   projectedCases: Colors.forest50,
-  projectedFatalities: Colors.black50,
   cases: Colors.black,
-  fatalities: Colors.tamarillo,
 };
 
 const ImpactProjectionChart: React.FC = () => {
@@ -116,7 +114,7 @@ const ImpactProjectionChart: React.FC = () => {
         fill: lineColors[key],
         fillOpacity: 1,
       };
-      if (key === "projectedCases" || key === "projectedFatalities") {
+      if (key === "projectedCases") {
         return { ...baseStyle, strokeDasharray: "5px" };
       }
       return baseStyle;
@@ -207,12 +205,6 @@ const ImpactProjectionChart: React.FC = () => {
               Projected cases w/o intervention
             </LegendText>
             <LegendText legendColor={lineColors.cases}>Actual cases</LegendText>
-            <LegendText legendColor={lineColors.projectedFatalities}>
-              Projected fatalities w/o intervention
-            </LegendText>
-            <LegendText legendColor={lineColors.fatalities}>
-              Actual fatalities
-            </LegendText>
           </LegendContainer>
           <HorizontalRule />
         </>

--- a/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
+++ b/src/page-weekly-snapshot/shared/projectionChartUtils.tsx
@@ -73,9 +73,7 @@ interface FacilitiesData {
 interface ChartData {
   [key: string]: number[];
   cases: number[];
-  fatalities: number[];
   projectedCases: number[];
-  projectedFatalities: number[];
 }
 
 export interface TableData {
@@ -363,8 +361,7 @@ export function getFacilitiesProjectionData(
  *
  * @param modelVersions - An array of modelVersions for multiple facilities
  * @param localeDataSource - LocaleData from the LocaleDataContext
- * @returns tableData, chartData - { projectedCases: [0..89], cases: [0..89],
- * fatalities: [0..89], projectedCases: [0..89] }
+ * @returns tableData, chartData - { projectedCases: [0..89], cases: [0..89], }
  */
 export function getImpactChartAndTableData(
   modelVersions: ModelInputs[][],
@@ -380,9 +377,7 @@ export function getImpactChartAndTableData(
 
   const chartData: ChartData = {
     projectedCases: addProjectionPadding([]),
-    projectedFatalities: addProjectionPadding([]),
     cases: addProjectionPadding([]),
-    fatalities: addProjectionPadding([]),
   };
 
   const tableData: TableData = {
@@ -401,9 +396,6 @@ export function getImpactChartAndTableData(
       // Sum staff+incarcerated across all facilities
       chartData.cases[index] +=
         facilityData.staffCases[index] + facilityData.incarceratedCases[index];
-      chartData.fatalities[index] +=
-        facilityData.staffFatalities[index] +
-        facilityData.incarceratedFatalities[index];
 
       // Sum the values across all facilities for today's index
       if (index === NUM_DAYS) {
@@ -421,9 +413,6 @@ export function getImpactChartAndTableData(
       chartData.projectedCases[index] +=
         projection.projectedStaffCases[index] +
         projection.projectedIncarceratedCases[index];
-      chartData.projectedFatalities[index] +=
-        projection.projectedStaffFatalities[index] +
-        projection.projectedIncarceratedFatalities[index];
 
       // Sum the values across all facilities for today's index
       if (index === NUM_DAYS) {


### PR DESCRIPTION
## Description of the change

This removes the projected and actual fatalities from the impact to date chart. Pending go ahead by @sychang 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #667 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
