### PR TITLE
[Report Automation] Projection Bugs

### DIFF
--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -108,7 +108,6 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({
     axes: [
       {
         orient: "bottom",
-        ticks: numXTicks,
         tickFormat: (value: Date) => formatDate(new Date(value), "M/d"),
         tickValues: xTickValues,
       },

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -46,8 +46,8 @@ const formatRtValue = format(".2f");
 
 const legendColors: { [key in string]: string } = {
   exposed: Colors.green,
-  infectious: Colors.lightBlue,
-  hospitalized: Colors.darkRed,
+  infectious: Colors.darkRed,
+  hospitalized: Colors.lightBlue,
   fatalities: Colors.black,
 };
 

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -55,12 +55,10 @@ function addDays(date: Date, days: number) {
   return result;
 }
 
-function calculateXTickValues() {
-  let increment = 0;
-  for (let i = 0; i < numXTicks; i++) {
-    increment += tickIntervals;
-    xTickValues.push(addDays(startOfToday(), increment));
-  }
+let increment = 0;
+for (let i = 0; i < numXTicks; i++) {
+  increment += tickIntervals;
+  xTickValues.push(addDays(startOfToday(), increment));
 }
 
 const legendColors: { [key in string]: string } = {
@@ -83,8 +81,6 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({
   const maxValue = allValues && Math.max(...allValues);
 
   if (!chartData) return null;
-
-  calculateXTickValues();
 
   const frameProps = {
     lines: Object.entries(chartData).map(([bucket, values]) => ({

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -80,7 +80,7 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({
     yAccessor: "count",
     responsiveHeight: true,
     responsiveWidth: true,
-    yExtent: [0, maxValue + 100],
+    yExtent: [0, maxValue],
     margin: CHART_MARGINS,
     lineStyle: ({ key }: { key: SeirCompartmentKeys }) => ({
       stroke: legendColors[key],

--- a/src/page-weekly-snapshot/FacilityProjectionChart.tsx
+++ b/src/page-weekly-snapshot/FacilityProjectionChart.tsx
@@ -1,5 +1,5 @@
 import { curveCatmullRom, format } from "d3";
-import { add, format as formatDate } from "date-fns";
+import { add, format as formatDate, startOfToday } from "date-fns";
 import { flatten, pick } from "lodash";
 import React from "react";
 import { ResponsiveXYFrame } from "semiotic";
@@ -44,6 +44,25 @@ export interface ChartData {
 const formatThousands = format(",~g");
 const formatRtValue = format(".2f");
 
+const PROJECTION_DURATION = 90;
+const numXTicks = 4;
+const tickIntervals = PROJECTION_DURATION / numXTicks;
+const xTickValues: Date[] = [];
+
+function addDays(date: Date, days: number) {
+  let result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+function calculateXTickValues() {
+  let increment = 0;
+  for (let i = 0; i < numXTicks; i++) {
+    increment += tickIntervals;
+    xTickValues.push(addDays(startOfToday(), increment));
+  }
+}
+
 const legendColors: { [key in string]: string } = {
   exposed: Colors.green,
   infectious: Colors.darkRed,
@@ -64,6 +83,8 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({
   const maxValue = allValues && Math.max(...allValues);
 
   if (!chartData) return null;
+
+  calculateXTickValues();
 
   const frameProps = {
     lines: Object.entries(chartData).map(([bucket, values]) => ({
@@ -91,8 +112,9 @@ const FacilityProjectionChart: React.FC<ProjectionProps> = ({
     axes: [
       {
         orient: "bottom",
-        ticks: 5,
-        tickFormat: (value: Date) => formatDate(new Date(value), "MM/dd"),
+        ticks: numXTicks,
+        tickFormat: (value: Date) => formatDate(new Date(value), "M/d"),
+        tickValues: xTickValues,
       },
       {
         orient: "left",


### PR DESCRIPTION
## Projection Bugs

- Change the y-axis maxExtent to the maxValue in a projection--this matches the behavior in the web app. I'm not entirely sure what the rationale was behind adding 100 to the maxValue, but all the projections I've tested look good to me.
- Switch the color of the infectious and hospitalized lines--this also matches the behavior in the web app
- Change x-axis tick values to be calculated based on the current day so they are more evenly spaced per the mocks

Testing:
![image](https://user-images.githubusercontent.com/29155017/89681063-cbebd080-d8b9-11ea-8a49-c9f81c2a6073.png)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #675 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
