### PR TITLE
Handle duplicate users without throwing an error

### DIFF
--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -59,6 +59,7 @@ service cloud.firestore {
       allow read: if userIsAuthenticated() && resource.data.auth0Id == resource.data.auth0Id;
 
       allow update: if userIsSelf(resource) && userIsSelf(request.resource);
+      allow delete: if userIsSelf(resource);
       allow create: if userIsSelf(request.resource);
     }
 

--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -485,7 +485,7 @@ export const getFacilities = async (
 
 const getUserDocument = async (
   params: { email: string } | { auth0Id: string },
-): Promise<firebase.firestore.DocumentData> => {
+): Promise<firebase.firestore.DocumentData | undefined> => {
   const db = await getDb();
 
   const [key, value] = Object.entries(params)[0];
@@ -605,6 +605,10 @@ export const addScenarioUser = async (
     }
 
     const userDocument = await getUserDocument({ email });
+    if (!userDocument) {
+      throw new Error(`No user found matching email address ${email}`);
+    }
+
     const auth0Id = userDocument.data().auth0Id;
     const scenario = await getScenario(scenarioId);
 


### PR DESCRIPTION
## Description of the change

I didn't have a ton of luck nailing down a root cause for this issue, nor was I able to prevent it (if it is in fact caused by a network error, as we suspect, Firestore does not seem to throw a relevant error when we try to query it). But I was able to determine that we don't really need to throw an error from `getUserDocument` when this happens: 
- because we look up users by email/auth0Id rather than firestore ID, the application doesn't really care which of the duplicates it uses
- if we sort the query by `createdAt`, we can ensure that we always use the original (oldest) user document, and the presence of duplicates no longer has any effect
- now that we know which one is the original, we can just delete the rest (only if they are for our own user account) to stop them from piling up and potentially causing other weirdness

I had to create a composite index on the `users` collection and update the Firestore security rules to accomplish this. The rules update is here, the composite index was just done via the Firebase console.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #624 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
