### PR TITLE
Update case data ingest for BQ export

### DIFF
--- a/backend/python-functions/data_ingest.py
+++ b/backend/python-functions/data_ingest.py
@@ -20,6 +20,7 @@ fs_client = firestore.Client()
 facilities_collection = fs_client.collection(
     REFERENCE_FACILITIES_COLLECTION_ID)
 
+
 class FirestoreBatch():
     """
         Utility for managing Firestore batch writes to keep them under the
@@ -57,8 +58,8 @@ class FirestoreBatch():
     # NOTE: can also mirror other server transform operations as needed
     @property
     def SERVER_TIMESTAMP(self):
-       self.pending_ops_count += 1
-       return firestore.SERVER_TIMESTAMP
+        self.pending_ops_count += 1
+        return firestore.SERVER_TIMESTAMP
 
     def commit(self):
         return self.batch.commit()
@@ -226,7 +227,7 @@ def save_case_data(facilities):
 
         facility_ref = facilities_collection.document(facility_id)
         if not facility_ref.get().exists:
-            facility_metadata = { 'createdAt': batch.SERVER_TIMESTAMP }
+            facility_metadata = {'createdAt': batch.SERVER_TIMESTAMP}
             batch.set(facility_ref, facility_metadata)
 
         for date, cases in covid_cases.items():


### PR DESCRIPTION
## Description of the change

Because our new datasource maps facilities to unique IDs, we no longer need to include so much redundant metadata in the cases export file, and we can look up facilities directly by ID. This changes the ingest function to reflect that (and also includes the batch management logic from #681, which I factored out for reuse).

In Firestore, you can see the results of these two new ingest functions in the `reference_facilities_dev` collection.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #682 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
