### PR TITLE
Don't create facilities from reference data with empty model inputs

### DIFF
--- a/src/facilities-context/__fixtures__/mergedFacilities.tsx
+++ b/src/facilities-context/__fixtures__/mergedFacilities.tsx
@@ -103,6 +103,7 @@ export const compositeFacility: Facility = {
     {
       observedAt: new Date(2020, 4, 28),
       ageUnknownCases: 5,
+      ageUnknownDeaths: 0,
       ageUnknownPopulation: referenceFacility.population[0].value,
       isReference: true,
       stateName,
@@ -112,6 +113,7 @@ export const compositeFacility: Facility = {
     {
       observedAt: new Date(2020, 4, 29),
       ageUnknownCases: 6,
+      ageUnknownDeaths: 0,
       ageUnknownPopulation: referenceFacility.population[0].value,
       isReference: true,
       stateName,
@@ -122,6 +124,7 @@ export const compositeFacility: Facility = {
     {
       observedAt: new Date(2020, 5, 3),
       ageUnknownCases: 14,
+      ageUnknownDeaths: 0,
       ageUnknownPopulation: userHistory[0].ageUnknownPopulation,
       isReference: true,
       stateName,
@@ -131,6 +134,7 @@ export const compositeFacility: Facility = {
     {
       observedAt: new Date(2020, 5, 4),
       ageUnknownCases: 19,
+      ageUnknownDeaths: 0,
       ageUnknownPopulation: userHistory[0].ageUnknownPopulation,
       isReference: true,
       stateName,
@@ -141,6 +145,7 @@ export const compositeFacility: Facility = {
     {
       observedAt: new Date(2020, 5, 7),
       ageUnknownCases: 28,
+      ageUnknownDeaths: 1,
       ageUnknownPopulation: userHistory[1].ageUnknownPopulation,
       isReference: true,
       stateName,
@@ -151,6 +156,7 @@ export const compositeFacility: Facility = {
   modelInputs: {
     observedAt: new Date(2020, 5, 7),
     ageUnknownCases: 28,
+    ageUnknownDeaths: 1,
     ageUnknownPopulation: userHistory[1].ageUnknownPopulation,
     isReference: true,
     stateName,

--- a/src/facilities-context/__tests__/transforms.test.tsx
+++ b/src/facilities-context/__tests__/transforms.test.tsx
@@ -61,6 +61,7 @@ describe("merged facility", () => {
       expect(mergedCase).toEqual({
         observedAt: referenceCase?.observedAt,
         ageUnknownCases: referenceCase?.popTestedPositive,
+        ageUnknownDeaths: referenceCase?.popDeaths,
         ageUnknownPopulation: referencePop,
         facilityCapacity: referenceCapacity,
         isReference: true,

--- a/src/facilities-context/__tests__/transforms.test.tsx
+++ b/src/facilities-context/__tests__/transforms.test.tsx
@@ -1,4 +1,4 @@
-import { isSameDay } from "date-fns";
+import { addDays, isSameDay } from "date-fns";
 import { cloneDeep, last, pick } from "lodash";
 
 import {
@@ -8,7 +8,11 @@ import {
   stateName,
   userFacility as userFacilityFixture,
 } from "../__fixtures__";
-import { Facility, ReferenceFacility } from "../../page-multi-facility/types";
+import {
+  Facility,
+  ReferenceFacility,
+  ReferenceFacilityCovidCase,
+} from "../../page-multi-facility/types";
 import { mergeFacilityObjects } from "../transforms";
 
 function getFindByDay(targetDate: Date) {
@@ -34,9 +38,21 @@ describe("merged facility", () => {
     // a minimal facility (created from reference data) won't have any real model history,
     // but at least one model version will be created.
     // in this case we expect it to not actually have any case or population data
-    userFacility.modelVersions = [
-      pick(userFacility.modelInputs, ["observedAt", "updatedAt"]),
-    ];
+
+    userFacility.modelInputs = pick(userFacility.modelInputs, [
+      "observedAt",
+      "updatedAt",
+      "stateName",
+      "countyName",
+    ]);
+    // the minimal user data may not coincide with a day of reference data;
+    // make sure it doesn't stick around and cause problems
+    const lastReferenceDate = (last(
+      referenceFacility.covidCases,
+    ) as ReferenceFacilityCovidCase).observedAt;
+
+    userFacility.modelInputs.observedAt = addDays(lastReferenceDate, 10);
+    userFacility.modelVersions = [{ ...userFacility.modelInputs }];
 
     const merged = mergeFacilityObjects({ userFacility, referenceFacility });
 
@@ -46,6 +62,9 @@ describe("merged facility", () => {
       // the contents of this array are tested below
       modelVersions: expect.any(Array),
     });
+
+    // the minimal inputs are junk and should be thrown away
+    expect(merged.modelInputs.observedAt).toEqual(lastReferenceDate);
 
     const referencePop = referenceFacility.population[0].value;
     const referenceCapacity = referenceFacility.capacity[0].value;

--- a/src/facilities-context/transforms.tsx
+++ b/src/facilities-context/transforms.tsx
@@ -106,7 +106,7 @@ function mergeModelVersions({
   userVersions,
   referenceFacility,
 }: Optional<MergedHistoryInputs, "referenceFacility">): ModelInputs[] {
-  const combinedVersions: ModelInputs[] = [...userVersions];
+  const combinedVersions: ModelInputs[] = [...userVersions.filter(hasCases)];
   let { stateName, countyName } = combinedVersions.length
     ? (last(combinedVersions) as ModelInputs)
     : ({} as ModelInputs);


### PR DESCRIPTION
## Description of the change

This fixes some broken tests against `FacilitiesContext` and also resolves the issue where a facility's `modelInputs` could be blank after creating it from reference data via the `SyncNoUserFacilities` modal.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #651 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
