### PR TITLE
641 Update charts & rtdata after adding reference facilities from SyncNoUserFacilities modal

### DIFF
--- a/src/facilities-context/FacilitiesContext.tsx
+++ b/src/facilities-context/FacilitiesContext.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 
 import { referenceFacilitiesProp } from "../database";
 import { useFlag } from "../feature-flags";
+import { hasCases } from "../impact-dashboard/EpidemicModelContext";
 import {
   Facility,
   RtDataMapping,
@@ -299,7 +300,10 @@ export const FacilitiesProvider: React.FC<{ children: React.ReactNode }> = ({
     const facilities = Object.values({ ...state.facilities });
     if (facilities.length) {
       facilities.forEach((facility) => {
-        if (!state.rtData.hasOwnProperty(facility.id)) {
+        if (
+          !state.rtData.hasOwnProperty(facility.id) &&
+          hasCases(facility.modelInputs)
+        ) {
           facilitiesActions.fetchFacilityRtData(dispatch)(facility);
         }
       });

--- a/src/facilities-context/FacilitiesContext.tsx
+++ b/src/facilities-context/FacilitiesContext.tsx
@@ -143,36 +143,6 @@ export const FacilitiesProvider: React.FC<{ children: React.ReactNode }> = ({
     },
   };
 
-  async function prepareReferenceFacilities(facilities: FacilityMapping) {
-    // fetch reference facilities based on user facilities
-    // first facility is the reference; assume they're all the same
-    const userFacility = Object.values(facilities)[0];
-    if (!userFacility) return facilities;
-    const {
-      modelInputs: { stateName },
-      systemType,
-    } = userFacility && userFacility;
-
-    if (stateName && systemType) {
-      const referenceFacilities = await facilitiesActions.fetchReferenceFacilities(
-        stateName,
-        systemType,
-      );
-
-      dispatch({
-        type: facilitiesActions.RECEIVE_REFERENCE_FACILITIES,
-        payload: referenceFacilities,
-      });
-
-      return facilitiesActions.buildCompositeFacilities(
-        facilities,
-        referenceFacilities,
-        facilityToReference,
-      );
-    }
-    return facilities;
-  }
-
   // when a new scenario is loaded, facility data must be initialized
   // in a specific order to avoid unwanted side effects:
   // we fetch user facility data, then fetch reference data (when applicable);
@@ -269,22 +239,35 @@ export const FacilitiesProvider: React.FC<{ children: React.ReactNode }> = ({
   // update facilities when reference mapping changes
   useEffect(
     () => {
-      if (state.loading || isEmpty(facilityToReference)) return;
+      if (
+        state.loading ||
+        isEmpty(facilityToReference) ||
+        isEmpty(state.facilities)
+      )
+        return;
+
       async function updateFacilities() {
-        let facilities = state.facilities;
+        let referenceFacilities = state.referenceFacilities;
         // If user just synced new reference facilities and is updating
         // facilityToReference for the first time after initialization, then
         // referenceFacilities will not be loaded yet.
-        if (isEmpty(state.referenceFacilities)) {
-          facilities = await prepareReferenceFacilities(facilities);
-        } else {
-          facilities = facilitiesActions.buildCompositeFacilities(
-            facilities,
-            state.referenceFacilities,
-            facilityToReference,
-          );
+        if (isEmpty(referenceFacilities)) {
+          const {
+            modelInputs: { stateName },
+            systemType,
+          } = Object.values(state.facilities)[0];
+          if (stateName && systemType) {
+            referenceFacilities = await facilitiesActions.fetchReferenceFacilities(
+              stateName,
+              systemType,
+            );
+          }
         }
-
+        const facilities = facilitiesActions.buildCompositeFacilities(
+          state.facilities,
+          referenceFacilities,
+          facilityToReference,
+        );
         facilitiesActions.receiveFacilities(dispatch, facilities);
       }
       updateFacilities();

--- a/src/facilities-context/reducer.tsx
+++ b/src/facilities-context/reducer.tsx
@@ -66,7 +66,7 @@ export function facilitiesReducer(
       return { ...state, referenceFacilities: {} };
 
     case actions.CLEAR_FACILITIES:
-      return { ...state, facilities: {}, loading: false };
+      return { ...state, facilities: {} };
 
     case actions.CAN_USE_REFERENCE_DATA:
       return { ...state, canUseReferenceData: action.payload };

--- a/src/facilities-context/validators.tsx
+++ b/src/facilities-context/validators.tsx
@@ -25,6 +25,14 @@ const removeNonsenseCases: SingleDayValidator = (modelInputs) => {
       )
         return null;
     }
+  } else if (
+    modelInputs?.ageUnknownCases === undefined &&
+    modelInputs?.staffCases === undefined
+  ) {
+    // If we create a facility from a reference facility, we will have a modelInput with
+    // no cases. We want to remove this so that it does not interfere with the
+    // reference facility's cases increasing monotonically.
+    return null;
   }
   return modelInputs;
 };

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -308,7 +308,7 @@ export function EpidemicModelProvider({
   );
 
   return (
-    <EpidemicModelStateContext.Provider value={state}>
+    <EpidemicModelStateContext.Provider value={{ ...facilityModel, ...state }}>
       <EpidemicModelDispatchContext.Provider value={dispatch}>
         {children}
       </EpidemicModelDispatchContext.Provider>

--- a/src/impact-dashboard/EpidemicModelContext.tsx
+++ b/src/impact-dashboard/EpidemicModelContext.tsx
@@ -1,6 +1,6 @@
 import { sum } from "d3";
 import { pick } from "lodash";
-import React from "react";
+import React, { useEffect } from "react";
 
 import { LocaleData } from "../locale-data-context";
 import { Facility, ModelInputs } from "../page-multi-facility/types";
@@ -281,9 +281,11 @@ function epidemicModelReducer(
         stateName = state.stateName;
       }
       if (stateName && countyName) {
-        return getLocaleDefaults(state.localeDataSource, stateName, countyName);
+        return {
+          ...getLocaleDefaults(state.localeDataSource, stateName, countyName),
+          ...updates,
+        };
       }
-
       return Object.assign({}, state, updates);
   }
 }
@@ -307,8 +309,14 @@ export function EpidemicModelProvider({
     initialState,
   );
 
+  useEffect(() => {
+    if (facilityModel) {
+      dispatch({ type: "update", payload: facilityModel });
+    }
+  }, [facilityModel]);
+
   return (
-    <EpidemicModelStateContext.Provider value={{ ...facilityModel, ...state }}>
+    <EpidemicModelStateContext.Provider value={state}>
       <EpidemicModelDispatchContext.Provider value={dispatch}>
         {children}
       </EpidemicModelDispatchContext.Provider>

--- a/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
+++ b/src/page-multi-facility/MultiFacilityImpactDashboard.tsx
@@ -132,7 +132,6 @@ const MultiFacilityImpactDashboard: React.FC = () => {
   const systemType = facilities[0]?.systemType;
   const stateName = facilities[0]?.modelInputs.stateName;
   const showSyncReferenceFacilitiesBaseConditions =
-    facilitiesState.canUseReferenceData &&
     !facilitiesState.loading &&
     !scenarioState.loading &&
     !readOnlyMode && // i.e. User must own of the Scenario
@@ -142,6 +141,7 @@ const MultiFacilityImpactDashboard: React.FC = () => {
     showSyncReferenceFacilitiesBaseConditions && facilities.length == 0;
 
   const showSyncNewReferenceData =
+    facilitiesState.canUseReferenceData &&
     showSyncReferenceFacilitiesBaseConditions &&
     !showSyncNoUserFacilities &&
     (!scenario?.referenceDataObservedAt ||

--- a/src/page-multi-facility/ReferenceDataModal/SyncNoUserFacilities.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/SyncNoUserFacilities.tsx
@@ -277,7 +277,7 @@ const SyncReferenceFacilitiesCard: React.FC<SyncReferenceFacilitiesCardProps> = 
       return;
     }
 
-    // Promise.all preserves insertion order so we can use this information to guarnatee User
+    // Promise.all preserves insertion order so we can use this information to guarantee User
     // Facilities in the savedFacilities array have a matching index with the Reference
     // Facilities in the selectedFacilities array.  Since the indexes match, it is acceptable
     // to generate the facilityIdToReferenceId mapping by iterating over the savedFacilities


### PR DESCRIPTION
## Description of the change

This fixes the issue where a user added reference facilities from the "SyncNoUserFacilities" modal and the chart and rt data were not populating. I think the issue came from the `EpidemicModelContext` not being updated with the new facility model for each row, and a timing issue with requesting rt data using the incorrect model inputs before the user facilities became merged with the reference model inputs. I used the `hasCases` validation to only request rt data for the facilities context when the model inputs has case data, this prevented the calculation requests with the incorrect inputs to fire. I'm not sure if this will cause any issues for other facilities that might have undefined case data in the inputs, but I assume having no rt data for those facilities would be expected behavior?

I also needed to remove the check for `canUseReferenceData` in the logic for showing the SyncNoUserFacilities modal, since this will be `false` for scenarios that have no facilities. I moved the check down to the next modal's conditions for `showSyncNewReferenceData`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #641 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
