### PR TITLE
Prevent repeat Rt requests while first one is loading

### DIFF
--- a/src/facilities-context/actions/index.tsx
+++ b/src/facilities-context/actions/index.tsx
@@ -47,10 +47,15 @@ export type RECEIVE_FACILITIES_ACTION = {
   payload: FacilityMapping;
 };
 
-export type RT_DATA_ACTION = {
-  type: typeof UPDATE_FACILITY_RT_DATA;
-  payload: RtDataMapping;
-};
+export type RT_DATA_ACTION =
+  | {
+      type: typeof UPDATE_FACILITY_RT_DATA;
+      payload: RtDataMapping;
+    }
+  | {
+      type: typeof REQUEST_RT_DATA;
+      payload: Facility["id"];
+    };
 
 export type FACILITY_ID_ACTION = {
   type: typeof SELECT_FACILITY | typeof REMOVE_FACILITY;
@@ -62,7 +67,7 @@ export type ERROR_ACTIONS = {
 };
 
 export type REQUEST_ACTIONS = {
-  type: typeof REQUEST_FACILITIES | typeof REQUEST_RT_DATA;
+  type: typeof REQUEST_FACILITIES;
 };
 
 export type DESELECT_FACILITY_ACTION = {

--- a/src/facilities-context/actions/rtData.tsx
+++ b/src/facilities-context/actions/rtData.tsx
@@ -8,7 +8,7 @@ export const UPDATE_FACILITY_RT_DATA = "UPDATE_FACILITY_RT_DATA";
 
 export function fetchFacilityRtData(dispatch: FacilitiesDispatch) {
   return async (facility: Facility) => {
-    dispatch({ type: REQUEST_RT_DATA });
+    dispatch({ type: REQUEST_RT_DATA, payload: facility.id });
     try {
       const facilityRtData = await getRtDataForFacility(facility);
       dispatch({

--- a/src/facilities-context/reducer.tsx
+++ b/src/facilities-context/reducer.tsx
@@ -47,6 +47,13 @@ export function facilitiesReducer(
       });
     }
 
+    case actions.REQUEST_RT_DATA:
+      const requestedFacility = action.payload;
+      return {
+        ...state,
+        rtData: { ...state.rtData, [requestedFacility]: undefined },
+      };
+
     case actions.UPDATE_FACILITY_RT_DATA:
       return Object.assign({}, state, {
         rtData: { ...state.rtData, ...action.payload },

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -66,7 +66,7 @@ export type PromoStatuses = {
   newModelInputs: boolean;
 };
 
-export type RtValue = RtData | RtError;
+export type RtValue = RtData | RtError | undefined;
 
 export type RtDataMapping = {
   [key in Facility["id"]]: RtValue;


### PR DESCRIPTION
## Description of the change

This fixes another of the performance issues that was exacerbated by shadow data, by setting a loading state for pending Rt requests. 

We had this (admittedly obscure) convention in the initial Rt implementation of explicitly mapping a facility ID to `undefined` while a request to the `calculate_rt` cloud function was pending, which let us only issue requests for facility IDs that were completely unmapped when initializing a facility. All the code that supported and built on that assumption was still in place but at some point the actual mapping step must have gotten lost in translation when we moved over to the `FacilitiesContext`, which was causing large numbers of duplicate requests in [the useEffect function that initializes Rt](https://github.com/Recidiviz/covid19-dashboard/blob/ian/688-rt-requests/src/facilities-context/FacilitiesContext.tsx#L320) (scaling in multiples of facility count, because each time one facility returned, an additional request would be issued for each pending facility). This PR restores that convention.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #688 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
