### PR TITLE
Use prod reference facilities data from Firestore

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -52,11 +52,9 @@ const scenariosCollectionId = "scenarios";
 const facilitiesCollectionId = "facilities";
 const modelVersionCollectionId = "modelVersions";
 const usersCollectionId = "users";
-// TODO (#521): when the datasource stabilizes, change this to the real collection
-const referenceFacilitiesCollectionId = "reference_facilities_test";
+const referenceFacilitiesCollectionId = "reference_facilities";
 const referenceFacilitiesCovidCasesCollectionId = "covidCases";
-// TODO (#521): when we switch to using the real data update this property for the scenario
-export const referenceFacilitiesProp = "testReferenceFacilities";
+export const referenceFacilitiesProp = "referenceFacilities";
 
 // Note: None of these are secrets.
 let firebaseConfig = {

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -204,20 +204,15 @@ export const buildReferenceFacility = (
   stateName = String(stateName);
   canonicalName = String(canonicalName);
   facilityType = String(facilityType);
-  countyName = String(countyName);
+  countyName = countyName ? String(countyName) : undefined;
   createdAt = timestampToDate(data.createdAt);
 
-  // if these are not arrays then unfortunately they are garbage;
-  // this probably means the documents have been mangled somehow,
-  // it is not an expected case
-  if (!Array.isArray(capacity)) {
-    capacity = [];
-  }
+  // population can be missing or mangled; if so provide an empty array here
+  // to preserve a consistent interface
   if (!Array.isArray(population)) {
     population = [];
   }
 
-  capacity = capacity.map(toSimpleTimeseries);
   population = population.map(toSimpleTimeseries);
 
   return {

--- a/src/facilities-context/__fixtures__/mergedFacilities.tsx
+++ b/src/facilities-context/__fixtures__/mergedFacilities.tsx
@@ -46,7 +46,7 @@ export const referenceFacility: ReferenceFacility = {
   canonicalName: "Florida State Test Facility",
   facilityType: "State Prison",
   createdAt: new Date(2020, 5, 5),
-  capacity: [{ date: new Date(2020, 0, 1), value: 275 }],
+  capacity: 275,
   population: [{ date: new Date(2020, 0, 1), value: 380 }],
   covidCases: [
     {
@@ -108,7 +108,7 @@ export const compositeFacility: Facility = {
       isReference: true,
       stateName,
       countyName,
-      facilityCapacity: referenceFacility.capacity[0].value,
+      facilityCapacity: referenceFacility.capacity,
     },
     {
       observedAt: new Date(2020, 4, 29),
@@ -118,7 +118,7 @@ export const compositeFacility: Facility = {
       isReference: true,
       stateName,
       countyName,
-      facilityCapacity: referenceFacility.capacity[0].value,
+      facilityCapacity: referenceFacility.capacity,
     },
     userHistory[0],
     {
@@ -129,7 +129,7 @@ export const compositeFacility: Facility = {
       isReference: true,
       stateName,
       countyName,
-      facilityCapacity: referenceFacility.capacity[0].value,
+      facilityCapacity: referenceFacility.capacity,
     },
     {
       observedAt: new Date(2020, 5, 4),
@@ -139,7 +139,7 @@ export const compositeFacility: Facility = {
       isReference: true,
       stateName,
       countyName,
-      facilityCapacity: referenceFacility.capacity[0].value,
+      facilityCapacity: referenceFacility.capacity,
     },
     userHistory[1],
     {
@@ -150,7 +150,7 @@ export const compositeFacility: Facility = {
       isReference: true,
       stateName,
       countyName,
-      facilityCapacity: referenceFacility.capacity[0].value,
+      facilityCapacity: referenceFacility.capacity,
     },
   ],
   modelInputs: {
@@ -161,6 +161,6 @@ export const compositeFacility: Facility = {
     isReference: true,
     stateName,
     countyName,
-    facilityCapacity: referenceFacility.capacity[0].value,
+    facilityCapacity: referenceFacility.capacity,
   },
 };

--- a/src/facilities-context/__tests__/transforms.test.tsx
+++ b/src/facilities-context/__tests__/transforms.test.tsx
@@ -67,7 +67,7 @@ describe("merged facility", () => {
     expect(merged.modelInputs.observedAt).toEqual(lastReferenceDate);
 
     const referencePop = referenceFacility.population[0].value;
-    const referenceCapacity = referenceFacility.capacity[0].value;
+    const referenceCapacity = referenceFacility.capacity;
 
     expect(merged.modelVersions.length).toBe(
       referenceFacility.covidCases.length,
@@ -158,7 +158,7 @@ describe("merged facility", () => {
   });
 
   it("should impute missing reference capacity from user data", () => {
-    referenceFacility.capacity = [];
+    referenceFacility.capacity = undefined;
     userFacility.modelVersions[0].facilityCapacity = 345;
     userFacility.modelVersions[1].facilityCapacity = 275;
 

--- a/src/facilities-context/transforms.tsx
+++ b/src/facilities-context/transforms.tsx
@@ -71,7 +71,6 @@ function getCapacityFunc({
   // (because they change less frequently and are not part of reference covid records)
   const capacityByDate: SimpleTimeseries[] = orderBy(
     [
-      ...referenceFacility.capacity,
       ...userVersions.filter(hasCapacity).map((version) => ({
         date: version.observedAt,
         // this is a safe assertion because we filtered out undefined values above,
@@ -81,7 +80,14 @@ function getCapacityFunc({
     ],
     ["date"],
   );
-
+  // if there is absolutely no user capacity data, the reference value
+  // (unversioned) can be used as a fallback
+  if (capacityByDate.length === 0 && referenceFacility.capacity) {
+    capacityByDate.push({
+      date: new Date(),
+      value: referenceFacility.capacity,
+    });
+  }
   return getDateThresholdFunc(capacityByDate);
 }
 

--- a/src/page-multi-facility/types.tsx
+++ b/src/page-multi-facility/types.tsx
@@ -112,7 +112,7 @@ export type ReferenceFacility = {
   countyName?: string;
   canonicalName: string;
   facilityType: string;
-  capacity: SimpleTimeseries[];
+  capacity?: number;
   population: SimpleTimeseries[];
   covidCases: ReferenceFacilityCovidCase[];
   createdAt: Date;


### PR DESCRIPTION
## Description of the change

Points the webapp at the real reference data collection in Firestore, and accounts for a small change in the final shape of those reference facility documents resulting from BigQuery exports (facility capacity, when present, is now a single unversioned number rather than a timeseries).

Note that if you have had shadow data enabled in your local environment, this change will break your configuration. But now that the "prepopulate data" modal has been built, you can use that to create a new mapping from your facilities to these new reference facility documents.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #521, closes #683 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
