### PR TITLE
Shadow data QA bugs

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -957,22 +957,14 @@ export const deleteFacility = async (
       .collection(modelVersionCollectionId)
       .get();
 
-    const scenarioDoc = await scenarioRef.get();
-    const scenario = buildScenario(scenarioDoc);
-    const referenceFacilities = Object.assign(
-      {},
-      scenario[referenceFacilitiesProp],
-    );
-
     const db = await getDb();
     const batch = db.batch();
 
     // Remove the facility from the scenario referenceFacilities mapping
-    delete referenceFacilities[facilityId];
     const payload = buildUpdatePayload({
-      ...scenario,
-      [referenceFacilitiesProp]: referenceFacilities,
+      [`${referenceFacilitiesProp}.${facilityId}`]: firebase.firestore.FieldValue.delete(),
     });
+
     batch.update(scenarioRef, payload);
 
     modelVersions.docs.forEach((doc) => {

--- a/src/page-multi-facility/ReferenceDataModal/SyncNewReferenceData.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/SyncNewReferenceData.tsx
@@ -21,7 +21,7 @@ interface Props {
   stateName: ModelInputs["stateName"];
   systemType: Facility["systemType"];
   onClose: () => void;
-  useExistingFacilities?: boolean;
+  useExistingFacilities: boolean;
   closeModal?: () => void;
 }
 
@@ -30,7 +30,7 @@ const SyncNewReferenceData: React.FC<Props> = ({
   stateName,
   systemType,
   onClose,
-  useExistingFacilities = false,
+  useExistingFacilities,
   closeModal,
 }) => {
   const [selections, setSelections] = useState<ReferenceFacilitySelections>({});
@@ -79,7 +79,7 @@ const SyncNewReferenceData: React.FC<Props> = ({
     setUseReferenceData(useReferenceDataToggle);
   };
 
-  const disableSelections = !useReferenceData;
+  const disableSelections = useReferenceData !== undefined && !useReferenceData;
 
   return (
     <ReferenceDataModal

--- a/src/page-multi-facility/ReferenceDataModal/SyncNewReferenceData.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/SyncNewReferenceData.tsx
@@ -40,7 +40,9 @@ const SyncNewReferenceData: React.FC<Props> = ({
   } = useFacilities();
   const scenario = scenarioState.data;
   const [useReferenceData, setUseReferenceData] = useState(
-    scenario?.useReferenceData,
+    // undefined equals true because it means the user hasn't configured it yet,
+    // it's probably their first visit since the feature was activated
+    scenario?.useReferenceData === undefined || scenario.useReferenceData,
   );
 
   const mappedReferenceFacilities = scenario?.[referenceFacilitiesProp] || {};
@@ -79,7 +81,7 @@ const SyncNewReferenceData: React.FC<Props> = ({
     setUseReferenceData(useReferenceDataToggle);
   };
 
-  const disableSelections = useReferenceData !== undefined && !useReferenceData;
+  const disableSelections = !useReferenceData;
 
   return (
     <ReferenceDataModal

--- a/src/page-multi-facility/ReferenceDataModal/SyncNoUserFacilities.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/SyncNoUserFacilities.tsx
@@ -320,20 +320,6 @@ const SyncNoUserFacilities: React.FC = () => {
   const [scenarioState, dispatchScenarioUpdate] = useScenario();
   const scenario = scenarioState.data;
 
-  // Immediately set the referenceDataObservedAt time so that
-  // this modal does not compete with the SyncNewReferenceData
-  // modal for attention.
-  useEffect(() => {
-    saveScenario({
-      ...scenario,
-      referenceDataObservedAt: new Date(),
-    }).then((savedScenario) => {
-      if (savedScenario) dispatchScenarioUpdate(savedScenario);
-    });
-    // only want to run this once, on initial mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <Modal
       modalTitle={modalTitle}

--- a/src/page-multi-facility/ReferenceDataModal/context/ReferenceDataModalContext.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/context/ReferenceDataModalContext.tsx
@@ -231,7 +231,7 @@ export const ReferenceDataModalProvider: React.FC<{ syncType: SyncType }> = ({
               },
             });
 
-            clearPromoStatus;
+            clearPromoStatus();
           }}
           useExistingFacilities={state.useExistingFacilities}
         />

--- a/src/page-multi-facility/ReferenceDataModal/index.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/index.tsx
@@ -76,14 +76,6 @@ const ReferenceDataModal: React.FC<Props> = ({
   } = useFacilities();
 
   async function handleClose() {
-    rejectionToast(
-      saveScenario({
-        ...scenario,
-        referenceDataObservedAt: new Date(),
-      }).then((savedScenario) => {
-        if (savedScenario) dispatchScenarioUpdate(savedScenario);
-      }),
-    );
     onClose();
   }
 

--- a/src/page-multi-facility/ReferenceDataModal/shared/ReferenceFacilitySelect.tsx
+++ b/src/page-multi-facility/ReferenceDataModal/shared/ReferenceFacilitySelect.tsx
@@ -99,7 +99,7 @@ interface ReferenceFacilitySelectProps {
     id: ReferenceFacility["id"],
   ) => (facilityId: Facility["id"] | undefined) => void;
   selections: ReferenceFacilitySelections;
-  useExistingFacilities?: boolean;
+  useExistingFacilities: boolean;
   disabled?: boolean;
 }
 
@@ -108,7 +108,7 @@ export const ReferenceFacilitySelect: React.FC<ReferenceFacilitySelectProps> = (
   facilities,
   selections,
   onChange,
-  useExistingFacilities = false,
+  useExistingFacilities,
   disabled,
 }) => {
   return (


### PR DESCRIPTION
## Description of the change

Some more thorough testing after the recent merges uncovered a few more bugs, addressed here: 

- the "promo version" of the sync dialog that appears on first visit for existing users was not rendering with the correct content
- the `referenceDataObservedAt` date was not getting consistently updated when closing the various sync dialogs, which could lead to duplicate dialogs being shown
- deleted facilities would sometimes reappear in the reference facility mapping, due to database and client getting out of sync (which could prevent you from re-mapping the reference facility in some cases)
- new users would get shown the "promo version" modal immediately after creating new facilities from reference data, which seemed redundant and potentially confusing

A test deployment with the Shadow Data feature active is accessible at https://covid19-dashboard-git-ian-shadow-qa.recidiviz.now.sh/ 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

none

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
