### PR TITLE
Duplication fails for large scenarios

### DIFF
--- a/src/database/index.tsx
+++ b/src/database/index.tsx
@@ -251,6 +251,9 @@ export const getScenarios = async (): Promise<Scenario[]> => {
   try {
     const db = await getDb();
 
+    // if we just made a change let's make sure it's reflected here
+    await db.waitForPendingWrites();
+
     const scenarioResults = await db
       .collection(scenariosCollectionId)
       .where(`roles.${currentUserId()}`, "in", ["owner", "viewer"])

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -15,8 +15,16 @@ import {
 import { referenceFacilitiesProp } from ".";
 import { FacilityDocUpdate } from "./types";
 
-const timestampToDate = (timestamp: firebase.firestore.Timestamp): Date => {
-  return timestamp.toDate();
+const timestampToDate = (
+  timestamp: firebase.firestore.Timestamp | null,
+): Date => {
+  if (timestamp) {
+    return timestamp.toDate();
+  } else {
+    // when Firestore writes are pending, server timestamps may be null;
+    // we can substitute the local now in the meantime
+    return new Date();
+  }
 };
 
 const buildPlannedRelease = (plannedReleaseData: any): PlannedRelease => {
@@ -98,11 +106,7 @@ export const buildScenario = (
   let scenario: Scenario = documentData;
   scenario.id = document.id;
   scenario.createdAt = timestampToDate(documentData.createdAt);
-  scenario.updatedAt = timestampToDate(
-    // when Firestore writes are pending, updatedAt may be null since it's a server timestamp;
-    // we can substitute the local now in the meantime
-    documentData.updatedAt || firebase.firestore.Timestamp.now(),
-  );
+  scenario.updatedAt = timestampToDate(documentData.updatedAt);
   scenario.referenceDataObservedAt = documentData.referenceDataObservedAt
     ? timestampToDate(documentData.referenceDataObservedAt)
     : undefined;

--- a/src/database/type-transforms.tsx
+++ b/src/database/type-transforms.tsx
@@ -15,16 +15,8 @@ import {
 import { referenceFacilitiesProp } from ".";
 import { FacilityDocUpdate } from "./types";
 
-const timestampToDate = (
-  timestamp: firebase.firestore.Timestamp | null,
-): Date => {
-  if (timestamp) {
-    return timestamp.toDate();
-  } else {
-    // when Firestore writes are pending, server timestamps may be null;
-    // we can substitute the local now in the meantime
-    return new Date();
-  }
+const timestampToDate = (timestamp: firebase.firestore.Timestamp): Date => {
+  return timestamp.toDate();
 };
 
 const buildPlannedRelease = (plannedReleaseData: any): PlannedRelease => {
@@ -106,7 +98,11 @@ export const buildScenario = (
   let scenario: Scenario = documentData;
   scenario.id = document.id;
   scenario.createdAt = timestampToDate(documentData.createdAt);
-  scenario.updatedAt = timestampToDate(documentData.updatedAt);
+  scenario.updatedAt = timestampToDate(
+    // when Firestore writes are pending, updatedAt may be null since it's a server timestamp;
+    // we can substitute the local now in the meantime
+    documentData.updatedAt || firebase.firestore.Timestamp.now(),
+  );
   scenario.referenceDataObservedAt = documentData.referenceDataObservedAt
     ? timestampToDate(documentData.referenceDataObservedAt)
     : undefined;

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -157,6 +157,16 @@ export class BatchWriter {
             case "UPDATE":
               writeBatch.update(operation.params.ref, operation.params.data);
               break;
+            default:
+              console.error(
+                // type assertion here because operation is technically a never
+                // in the present implementation; this is mainly intended as a guardrail
+                // for future implementations of additional write methods (e.g. CREATE)
+                `Operation type ${
+                  (operation as any).type
+                } is unsupported; change will not be committed.`,
+              );
+              break;
           }
         });
         return writeBatch.commit();

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -53,6 +53,13 @@ type BatchOperation = BatchDelete | BatchSet | BatchUpdate;
  * Wrapper around firebase.firestore.WriteBatch that abstracts away the batch size limit.
  * Exposes methods and properties that would result in batch operations.
  * Automatically chunks the batch when it's full to prevent overflows.
+ *
+ * NOTE: Successful use of this class requires that the write method is called
+ * immediately after provisioning its pending ops (the server transformations), so
+ * that the write and additional ops are guaranteed to be applied to the same batch.
+ * If you don't follow this order (e.g. you prepare a number of documents that trigger
+ * pending ops, then call all their write methods), the commit may fail because it will
+ * apply all the pending ops to the first batch.
  */
 export class BatchWriter {
   private client: firebase.firestore.Firestore;

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -89,7 +89,12 @@ export class BatchWriter {
   }
 
   // NOTE: can also mirror other server transform operations as needed
-  get serverTimestamp() {
+  serverDelete() {
+    this.pendingOpsCount += 1;
+    return firebase.firestore.FieldValue.delete();
+  }
+
+  serverTimestamp() {
     this.pendingOpsCount += 1;
     return firebase.firestore.FieldValue.serverTimestamp();
   }

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -1,3 +1,4 @@
+import firebase from "firebase";
 import mapObject from "map-obj";
 
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";
@@ -25,3 +26,94 @@ export const prepareFromStorage = (state: object): EpidemicModelPersistent => {
     { deep: true },
   );
 };
+
+type BatchOperationType = "CREATE" | "DELETE" | "SET" | "UPDATE";
+type BatchOperationParams = [
+  firebase.firestore.DocumentReference<firebase.firestore.DocumentData>,
+  firebase.firestore.DocumentData,
+  // add other option types when implemented
+  firebase.firestore.SetOptions | undefined,
+];
+type BatchOperation = {
+  type: BatchOperationType;
+  params: BatchOperationParams;
+};
+
+/**
+ * Wrapper around firebase.firestore.WriteBatch that abstracts away the batch size limit.
+ * Exposes methods and properties that would result in batch operations.
+ * Automatically chunks the batch when it's full to prevent overflows.
+ */
+export class BatchWriter {
+  private client: firebase.firestore.Firestore;
+  private currentBatch!: BatchOperation[];
+  // a single "write" can trigger additional operations (in effect,
+  // incrementing the batch size by >1); track them here to anticipate
+  // and prevent overflows
+  private currentBatchSize = 0;
+  // this limit is imposed by Firestore
+  readonly MAX_BATCH_SIZE = 500;
+  private operationBatches: BatchOperation[][] = [];
+  private pendingOpsCount = 0;
+
+  constructor(client: firebase.firestore.Firestore) {
+    this.client = client;
+    this.startBatch();
+  }
+
+  private startBatch() {
+    const newBatch: BatchOperation[] = [];
+    this.currentBatch = newBatch;
+    this.operationBatches.push(newBatch);
+  }
+
+  private trackWrite() {
+    this.currentBatchSize += 1 + this.pendingOpsCount;
+    this.pendingOpsCount = 0;
+  }
+
+  private preventOverflow() {
+    if (this.currentBatchSize + this.pendingOpsCount >= this.MAX_BATCH_SIZE) {
+      this.startBatch();
+    }
+  }
+
+  // NOTE: can also mirror other server transform operations as needed
+  get serverTimestamp() {
+    this.pendingOpsCount += 1;
+    return firebase.firestore.FieldValue.serverTimestamp();
+  }
+
+  // NOTE: can also mirror create, delete, update methods on batch as needed
+  set(
+    ref: BatchOperationParams[0],
+    data: BatchOperationParams[1],
+    options?: firebase.firestore.SetOptions,
+  ) {
+    this.preventOverflow();
+    this.currentBatch.push({
+      type: "SET",
+      params: [ref, data, options],
+    });
+    this.trackWrite();
+    // mimic Firestore interface, allows for chained method calls
+    return this;
+  }
+
+  async commit() {
+    await Promise.all(
+      this.operationBatches.map((operationBatch) => {
+        const writeBatch = this.client.batch();
+        operationBatch.forEach(({ type, params: [ref, data, options] }) => {
+          switch (type) {
+            case "SET":
+              writeBatch.set(ref, data, options);
+              break;
+            // add other methods here as they are implemented
+          }
+        });
+        return writeBatch.commit();
+      }),
+    );
+  }
+}

--- a/src/database/utils.tsx
+++ b/src/database/utils.tsx
@@ -1,4 +1,4 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
 import mapObject from "map-obj";
 
 import { EpidemicModelPersistent } from "../impact-dashboard/EpidemicModelContext";

--- a/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
+++ b/src/page-multi-facility/ReadOnlyScenarioBanner.tsx
@@ -9,6 +9,7 @@ import iconRecidivizSrc from "../design-system/icons/ic_recidiviz_color.svg";
 import Loading from "../design-system/Loading";
 import ModalDialog from "../design-system/ModalDialog";
 import useReadOnlyMode from "../hooks/useReadOnlyMode";
+import useRejectionToast from "../hooks/useRejectionToast";
 import { Scenario } from "./types";
 
 interface BannerProps {
@@ -64,15 +65,18 @@ const ReadOnlyScenarioBanner: React.FC<Props> = (props) => {
   const { scenario, dispatchScenarioUpdate } = props;
   const readOnlyMode = useReadOnlyMode(scenario);
   const [modalOpen, setModalOpen] = useState(false);
+  const rejectionToast = useRejectionToast();
 
   const duplicate = (scenarioId: string) => {
     setModalOpen(true);
-    duplicateScenario(scenarioId)
-      .then((scenario) => {
-        setModalOpen(false);
-        dispatchScenarioUpdate(scenario);
-      })
-      .then(() => navigate("/"));
+    rejectionToast(
+      duplicateScenario(scenarioId)
+        .then((scenario) => {
+          setModalOpen(false);
+          dispatchScenarioUpdate(scenario);
+        })
+        .then(() => navigate("/")),
+    );
   };
 
   return (

--- a/src/page-multi-facility/ScenarioLibraryModal.tsx
+++ b/src/page-multi-facility/ScenarioLibraryModal.tsx
@@ -314,9 +314,11 @@ const ScenarioLibraryModal: React.FC<Props> = ({ trigger }) => {
       loading: true,
     });
 
-    duplicateScenario(scenarioId).then(() => {
-      fetchScenarios();
-    });
+    rejectionToast(
+      duplicateScenario(scenarioId).then(() => {
+        fetchScenarios();
+      }),
+    );
   };
 
   const changeScenario = (scenario: Scenario) => {


### PR DESCRIPTION
## Description of the change

Adds a wrapper around Firestore batched writes to manage the batch size limit. This is similar to but more extensive than the Python version implemented in #686 ... there were some existing libraries on npm that partially implemented this but none of them had a solution for the server-side transformations contributing to the batch size, so they did not prevent the errors we were seeing. All of our unbounded client-side batch writes (duplication and deletion of scenarios and facilities) use this new wrapper and I verified that all still work (and where applicable, now succeed where they used to fail). 

Also added some additional error handling for duplication to prevent the additional baseline scenario creation that accompanied batch write failures.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #701 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
