### PR TITLE
Set the min cases per day to 1 so the likelihood/posterior calc works

### DIFF
--- a/backend/python-functions/realtime_rt.py
+++ b/backend/python-functions/realtime_rt.py
@@ -14,6 +14,10 @@ def prepare_cases(cases):
         min_periods=1,
         center=True).mean(std=2).round()
 
+    # the min accepted value for the Rt calc is 1
+    # bump any 0 values up to 1
+    smoothed.loc[smoothed == 0] = 1
+
     original = new_cases.loc[smoothed.index]
 
     return original, smoothed
@@ -115,7 +119,8 @@ def compute_r_t(historical_case_counts):
         if required_column not in historical_case_counts:
             raise ValueError(f'Input is missing required column {required_column}')
 
-    case_df = pd.Series(historical_case_counts['cases'], index=historical_case_counts['dates'])
+    case_df = pd.Series(historical_case_counts['cases'], index=historical_case_counts['dates'],
+                        dtype=int)
     case_df.index = pd.to_datetime(case_df.index)
     case_df.index.name = 'date'
     case_df.sort_index(inplace=True)


### PR DESCRIPTION
## Description of the change

The Rt calc is breaking on the prison/jail data because there are long stretches of time when the case count does not change. The underlying Rt alg uses the change in cases to compute the change in Rt day over day, and it does not handle the 0 case delta at all. This change bumps up any 0 delta days to 1 so that the calculation can proceed. 

I have applied this change to a handful of states and it does not have a significant impact on the Rt results since 1 new case per day is not enough to double the total case count (double case count over 7 days -> Rt = 1). The original ticket said that all the Connecticut facilities were failing on the shadow data, so I also made sure that all of those facilities passed when the non-monotonic values are removed.

For reference, here are two state level Rt plots using public data for states that Zak reaches out to often:
<img width="502" alt="download-22" src="https://user-images.githubusercontent.com/3298757/94084440-647ed700-fdba-11ea-8618-438c6e1c0832.png">
<img width="502" alt="download-24" src="https://user-images.githubusercontent.com/3298757/94086005-8712ef00-fdbe-11ea-9293-7be5ccdafc02.png">


The Rt peaks still line up with spikes in cases for both states.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Related issues

Closes #690 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [X] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
