### PR TITLE
Handle current population less than historical cases in projections

### DIFF
--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -315,18 +315,33 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
   ).forEach(([pop, cases, recovered, deaths], index) => {
     // distribute cases across compartments proportionally
 
+    let uninfectedPopulation = pop - cases;
+    if (uninfectedPopulation < 0) {
+      // there are legitimate cases for population to be less than cases,
+      // such as deaths or post-recovery releases; when this happens,
+      // we need to prevent negative numbers from entering the model
+      // and also adjust the total population accordingly
+      totalPopulationByDay[0] -= uninfectedPopulation;
+      uninfectedPopulation = 0;
+    }
+
     if (typeof recovered !== "undefined" && typeof deaths !== "undefined") {
       const activeCases = Math.max(cases - recovered - deaths, 0);
 
       const infectious = activeCases * pInitiallyInfectious;
+
       // exposed is related to the number of infectious
       // but it can't be more than the total uninfected population
       const exposed = Math.min(
         infectious * ratioExposedToInfected,
-        pop - cases,
+        uninfectedPopulation,
       );
 
-      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+      singleDayState.set(
+        index,
+        seirIndex.susceptible,
+        uninfectedPopulation - exposed,
+      );
       singleDayState.set(index, seirIndex.exposed, exposed);
       singleDayState.set(index, seirIndex.infectious, infectious);
       singleDayState.set(index, seirIndex.mild, activeCases * pInitiallyMild);
@@ -357,10 +372,14 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
       // but it can't be more than the total uninfected population
       const exposed = Math.min(
         infectious * ratioExposedToInfected,
-        pop - cases,
+        uninfectedPopulation,
       );
 
-      singleDayState.set(index, seirIndex.susceptible, pop - cases - exposed);
+      singleDayState.set(
+        index,
+        seirIndex.susceptible,
+        uninfectedPopulation - exposed,
+      );
       singleDayState.set(index, seirIndex.exposed, exposed);
       singleDayState.set(index, seirIndex.infectious, infectious);
       singleDayState.set(
@@ -446,7 +465,8 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     // update total population for today to account for any adjustments made;
     // the next day will depend on this
     totalPopulationByDay[day] =
-      totalPopulation + expectedPopulationChanges[day];
+      // make sure we don't set the population below zero
+      Math.max(totalPopulation + expectedPopulationChanges[day], 0);
 
     day++;
   }

--- a/src/infection-model/seir.tsx
+++ b/src/infection-model/seir.tsx
@@ -465,8 +465,7 @@ export function getAllBracketCurves(inputs: CurveProjectionInputs) {
     // update total population for today to account for any adjustments made;
     // the next day will depend on this
     totalPopulationByDay[day] =
-      // make sure we don't set the population below zero
-      Math.max(totalPopulation + expectedPopulationChanges[day], 0);
+      totalPopulation + expectedPopulationChanges[day];
 
     day++;
   }


### PR DESCRIPTION
## Description of the change

Addresses an issue where the projection would predict negative populations in some compartments if the current population for a bracket is less than its cumulative number of cases. This is not necessarily a user error, since people can exit a facility after being infected. It was observed in the wild in facilities with very small numbers (single digits) in individual age brackets.

Clamping negative numbers to zero in the initial distribution of current cases and population across departments prevents any subsequent projections from dipping below zero. However, we also have a competing assumption that the sum of all compartments will always equal the total population. Both conditions can't be true in this case; they will be off by the difference between cumulative cases and current population. My solution to this was to adjust the model's total population figure by this same amount. There is some precedent for this, since the model's total population already includes some people who are presumably not physically in the facility anymore (e.g., fatalities, people moved to hospitals), but I definitely need confirmation that @justkunz has no objections to this!

The test data replicates (with falsified values) the conditions observed in the wild that led to this bug. I also used the `/inspect-model` UI to both reproduce the bug and verify the fix. I also don't see any obvious regressions in any of my available test data.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (adjusts configuration to achieve some end related to functionality, development, performance, or security)

## Related issues

Closes #706 

## Checklists

### Development

These boxes should be checked by the submitter prior to merging:

- [x] Manual testing has been performed locally

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
